### PR TITLE
Einar/pr/misc

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,17 @@
+Alan <alan@neptune.cash> <alan@neptune.cash>
+Alan <alan@neptune.cash> <alan.szepieniec+github@gmail.com>
+Alan <alan@neptune.cash> <alan.szepieniec@gmail.com>
+Einar <einar@neptune.cash> <einar@di.ku.dk>
+Einar <einar@neptune.cash> <einar@neptune.cash>
+Einar <einar@neptune.cash> <einar@noreply.neptune.builders>
+Ferdinand <ferdinand@neptune.cash> <ferdinand@neptune.cash>
+Philip <philip@munksgaard.me> <philip@munksgaard.me>
+Simon <simon@neptune.cash> <shreddedglory@gmail.com>
+Simon <simon@neptune.cash> <simon@neptune.cash>
+Simon <simon@neptune.cash> <simon@simonshine.dk>
+Simon <simon@neptune.cash> <sshine@noreply.neptune.builders>
+sword-smith <thor@neptune.cash> <sword-smith@noreply.neptune.builders>
+sword-smith <thor@neptune.cash> <thorkilk@gmail.com>
+sword-smith <thor@neptune.cash> <thor@neptune.cash>
+Ulrik <ulrikelmelund@gmail.com> <ulrik-dk@noreply.neptune.builders>
+Ulrik <ulrikelmelund@gmail.com> <ulrikelmelund@gmail.com>

--- a/twenty-first/src/amount/u32s.rs
+++ b/twenty-first/src/amount/u32s.rs
@@ -3,6 +3,7 @@ use serde_big_array;
 use serde_big_array::BigArray;
 use serde_derive::{Deserialize, Serialize};
 use std::{
+    fmt::Display,
     iter::Sum,
     ops::{Add, Div, Mul, Rem, Sub},
 };
@@ -298,6 +299,17 @@ impl<const N: usize> From<u32> for U32s<N> {
     }
 }
 
+impl<const N: usize> From<u64> for U32s<N> {
+    fn from(i: u64) -> Self {
+        U32s::<N>::from(BigUint::from(i))
+    }
+}
+
+impl<const N: usize> Display for U32s<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", BigUint::from(*self))
+    }
+}
 #[cfg(test)]
 mod u32s_tests {
     use rand::{thread_rng, RngCore};
@@ -467,6 +479,19 @@ mod u32s_tests {
         assert!(U32s::new([100, 0]) > U32s::new([99, 0]));
         assert!(U32s::new([0, 1]) > U32s::new([1 << 31, 0]));
         assert!(U32s::new([542, 12]) > U32s::new([1 << 31, 11]));
+    }
+
+    #[test]
+    fn compare_simple_test_more() {
+        assert!(U32s::new([0]) < U32s::new([1]));
+        assert!(U32s::new([0]) <= U32s::new([100]));
+        assert!(U32s::new([99]) < U32s::new([100]));
+        assert!(U32s::new([99, 0]) <= U32s::new([100, 0]));
+        assert!(U32s::new([100, 0]) <= U32s::new([100, 0]));
+        assert!(U32s::new([100, 0]) >= U32s::new([100, 0]));
+        assert!(U32s::new([1 << 31, 0]) < U32s::new([0, 1]));
+        assert!(U32s::new([1 << 31, 11]) <= U32s::new([542, 12]));
+        assert!(U32s::new([0]) >= U32s::new([0]));
     }
 
     #[test]
@@ -681,5 +706,16 @@ mod u32s_tests {
         let j = serde_json::to_string(&s).unwrap();
         let s_back = serde_json::from_str::<U32s<64>>(&j).unwrap();
         assert!(&s.values[..] == &s_back.values[..]);
+    }
+
+    #[test]
+    fn display_u32s() {
+        let v = u64::MAX;
+        let u32s = U32s::<4>::from(v);
+
+        let v_string = format!("{}", v);
+        let u32s_string = format!("{}", u32s);
+
+        assert_eq!(v_string, u32s_string)
     }
 }

--- a/twenty-first/src/amount/u32s.rs
+++ b/twenty-first/src/amount/u32s.rs
@@ -3,6 +3,7 @@ use serde_big_array;
 use serde_big_array::BigArray;
 use serde_derive::{Deserialize, Serialize};
 use std::{
+    convert::TryFrom,
     fmt::Display,
     iter::Sum,
     ops::{Add, Div, Mul, Rem, Sub},
@@ -299,9 +300,14 @@ impl<const N: usize> From<u32> for U32s<N> {
     }
 }
 
-impl<const N: usize> From<u64> for U32s<N> {
-    fn from(i: u64) -> Self {
-        U32s::<N>::from(BigUint::from(i))
+impl<const N: usize> TryFrom<u64> for U32s<N> {
+    type Error = &'static str;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        if N < 2 {
+            return Err("U32s<{N}>, N<=1 may not be big enough to hold a u64");
+        }
+        Ok(U32s::<N>::from(BigUint::from(value)))
     }
 }
 
@@ -711,11 +717,18 @@ mod u32s_tests {
     #[test]
     fn display_u32s() {
         let v = u64::MAX;
-        let u32s = U32s::<4>::from(v);
+        let u32s = U32s::<4>::try_from(v).unwrap();
 
         let v_string = format!("{}", v);
         let u32s_string = format!("{}", u32s);
 
         assert_eq!(v_string, u32s_string)
+    }
+
+    #[ignore]
+    #[test]
+    fn crash() {
+        let _u32s = U32s::<0>::from(0u32);
+        assert!(true)
     }
 }

--- a/twenty-first/src/util_types/blake3_wrapper.rs
+++ b/twenty-first/src/util_types/blake3_wrapper.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use rand::Rng;
 use serde::ser::SerializeTuple;
 use serde::{Deserialize, Serialize};
@@ -25,17 +23,6 @@ impl From<[u8; 32]> for Blake3Hash {
 impl From<u128> for Blake3Hash {
     fn from(n: u128) -> Self {
         Blake3Hash(blake3::Hash::from_hex(format!("{:064x}", n)).unwrap())
-    }
-}
-
-/// Automatically dereference our wapper type into the underlying hash.
-/// This allows us to pass a `&blake3_wrapper::Blake3Hash` everywhere we need a `&blake3::Hash`.
-/// [Deref]: https://doc.rust-lang.org/book/ch15-02-deref.html#implicit-deref-coercions-with-functions-and-methods
-impl Deref for Blake3Hash {
-    type Target = blake3::Hash;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 
@@ -119,16 +106,5 @@ mod blake3_wrapper_test {
         let digests = Blake3Hash::random_elements(n, &mut rng);
 
         assert_eq!(n, digests.len())
-    }
-
-    #[test]
-    fn deref_coercion() {
-        let boxed: Blake3Hash = blake3::hash(b"hello").into();
-
-        let exclicitly_derefed = &boxed.0;
-        // Coerce a reference to our wrapper to be a reference to the wrapped type.
-        let deref_coerced: &blake3::Hash = &boxed;
-
-        assert_eq!(exclicitly_derefed, deref_coerced);
     }
 }

--- a/twenty-first/src/util_types/simple_hasher.rs
+++ b/twenty-first/src/util_types/simple_hasher.rs
@@ -312,6 +312,8 @@ impl SamplableFrom<Vec<BFieldElement>> for XFieldElement {
 
 #[cfg(test)]
 pub mod test_simple_hasher {
+    use rand::RngCore;
+
     use crate::shared_math::rescue_prime_regular::RescuePrimeRegular;
 
     use super::*;
@@ -338,7 +340,8 @@ pub mod test_simple_hasher {
         type Digest = <RescuePrimeRegular as Hasher>::Digest;
         let rpr: RescuePrimeRegular = RescuePrimeRegular::new();
         let digest1: Digest = rpr.hash_sequence(&42usize.to_sequence());
-        let digest2: Digest = rpr.hash_sequence(&((1 << 4 + 42) as usize).to_sequence());
+        let mut prng = rand::thread_rng();
+        let digest2: Digest = rpr.hash_sequence(&((prng.next_u64() as usize).to_sequence()));
         let digests = vec![digest1.clone(), digest2.clone()].concat();
         let hash_sequence_digest = rpr.hash_sequence(&digests);
         let hash_pair_digest = rpr.hash_pair(&digest1, &digest2);


### PR DESCRIPTION
This PR fixes and adds miscellaneous things - some of them needed by the work on `neptune-core`.

* Fixes ` cargo build --all-targets`
* Implements `Display` instance for `U32s<N>`
* Implements `From<u64>` for `U32s<N>` 
* Implements `Deref` instance for our `Blake3Wrapper` as suggested by [_The Book_, ch. 15.2][The Book].
* Introduces `.mailmap` file for nicer git logs.  This is a copy from `neptune-core`.
* ` cargo build --all-targets  && cargo test --all && cargo clippy --all` succeeds except for a few slow tests.

[The Book]: https://doc.rust-lang.org/book/ch15-02-deref.html#treating-smart-pointers-like-regular-references-with-the-deref-trait