### PR TITLE
README: Add release protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,20 @@ A collection of cryptography functions written in Rust.
 ## Notes
 
 The `Makefile` recipes set the flag `RUSTFLAGS=-Dwarnings` and this makes the recompilation **much** slower than without this flag, as `cargo` for some reason rebuilds the entire crate when this flag is set and a minor change is made in a test. So it is much faster to run the tests using cargo and then use the `make test` command before e.g. committing to ensure that the test build does not produce any warnings.
+
+## Release protocol
+
+While twenty-first's version is `0.x.y`, releasing a new version:
+
+1. Is the release backwards-compatible?
+   Then the new version is `0.x.y+1`. Otherwise the new version is `0.x+1.0`.
+2. Create a commit that increases `version = "0.x.y"` in twenty-first/Cargo.toml.
+   The commit message should give a one-line summary of each release change.
+3. Have a `v0.x.y` [git tag][tag] on this commit created. (`git tag v0.x.y [sha]`, `git push upstream --tags`)
+4. Have this commit `cargo publish`ed on [crates.io][crates] and in GitHub [tags][tags].
+
+[tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
+[tags]: https://github.com/Neptune-Crypto/twenty-first/tags
+[crates]: https://crates.io/crates/twenty-first/versions
+
+If you do not have the privilege to create git tags or run `cargo publish`, submit a PR and the merger will take care of these.


### PR DESCRIPTION
This set of steps describes how a new release is made.

This protocol ensures that backwards-breaking changes are not released with a "major-compatible" version number, causing projects that depend on this library to break unexpectedly.

It also ensures better ability to track what changes were made. This helps the discovery of regressions and gives a better overview of each release.

---

Note that I've applied this protocol for the releases 0.1.5 and 0.2.0. They appear here:

- https://github.com/Neptune-Crypto/twenty-first/tags
- https://crates.io/crates/twenty-first/versions

Note also that the releases 0.1.0, 0.1.1, 0.1.2 and 0.1.3 don't (yet) have git tags.