### PR TITLE
Change signature of MMR function to mutate membership proofs

### DIFF
--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -85,7 +85,7 @@ where
 
     fn batch_mutate_leaf_and_update_mps(
         &mut self,
-        membership_proofs: &mut [MmrMembershipProof<H>],
+        membership_proofs: &mut [&mut MmrMembershipProof<H>],
         mutation_data: Vec<(MmrMembershipProof<H>, <H as Hasher>::Digest)>,
     ) -> Vec<usize> {
         assert!(
@@ -100,11 +100,11 @@ where
         let mut modified_mps: Vec<usize> = vec![];
         for (i, mp) in membership_proofs.iter_mut().enumerate() {
             let new_mp = self.prove_membership(mp.data_index).0;
-            if new_mp != *mp {
+            if new_mp != **mp {
                 modified_mps.push(i);
             }
 
-            *mp = new_mp
+            **mp = new_mp
         }
 
         modified_mps

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -228,7 +228,7 @@ where
 
     fn batch_mutate_leaf_and_update_mps(
         &mut self,
-        membership_proofs: &mut [MmrMembershipProof<H>],
+        membership_proofs: &mut [&mut MmrMembershipProof<H>],
         mut mutation_data: Vec<(MmrMembershipProof<H>, <H as Hasher>::Digest)>,
     ) -> Vec<usize> {
         // Calculate all derivable paths
@@ -565,10 +565,14 @@ mod accumulator_mmr_tests {
             // Do the update on both MMRs
             let mut mmra_mps = original_membership_proofs.clone();
             let mut ammr_mps = original_membership_proofs.clone();
-            let mutated_mps_mmra =
-                mmra.batch_mutate_leaf_and_update_mps(&mut mmra_mps, mutation_data.clone());
-            let mutated_mps_ammr =
-                ammr.batch_mutate_leaf_and_update_mps(&mut ammr_mps, mutation_data.clone());
+            let mutated_mps_mmra = mmra.batch_mutate_leaf_and_update_mps(
+                &mut mmra_mps.iter_mut().collect::<Vec<_>>(),
+                mutation_data.clone(),
+            );
+            let mutated_mps_ammr = ammr.batch_mutate_leaf_and_update_mps(
+                &mut ammr_mps.iter_mut().collect::<Vec<_>>(),
+                mutation_data.clone(),
+            );
             assert_eq!(mutated_mps_mmra, mutated_mps_ammr);
 
             // Verify that both MMRs end up with same peaks

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -865,8 +865,10 @@ mod mmr_membership_proof_test {
             // MmrAccumulator agrees
             let mut mmra: MmrAccumulator<Hasher> = (&mut archival_mmr).into();
             let mut mps_copy = original_mps;
-            let updated_mp_indices_1 =
-                mmra.batch_mutate_leaf_and_update_mps(&mut mps_copy, mutation_argument);
+            let updated_mp_indices_1 = mmra.batch_mutate_leaf_and_update_mps(
+                &mut mps_copy.iter_mut().collect::<Vec<_>>(),
+                mutation_argument,
+            );
             assert_eq!(own_membership_proofs, mps_copy);
             assert_eq!(mmra.get_peaks(), archival_mmr.get_peaks());
             assert_eq!(updated_mp_indices_0, updated_mp_indices_1);
@@ -935,7 +937,7 @@ mod mmr_membership_proof_test {
         // Let's test the exact same for the MMR accumulator scheme
         let mut mmra: MmrAccumulator<Hasher> = MmrAccumulator::new(leaf_hashes);
         let ret_from_acc = mmra.batch_mutate_leaf_and_update_mps(
-            &mut membership_proofs,
+            &mut membership_proofs.iter_mut().collect::<Vec<_>>(),
             membership_proofs_init_and_new_leafs,
         );
         assert!(ret_from_acc.is_empty());

--- a/twenty-first/src/util_types/mmr/mmr_trait.rs
+++ b/twenty-first/src/util_types/mmr/mmr_trait.rs
@@ -38,7 +38,7 @@ where
     /// membership proofs that have changed as a result of this operation.
     fn batch_mutate_leaf_and_update_mps(
         &mut self,
-        membership_proofs: &mut [MmrMembershipProof<H>],
+        membership_proofs: &mut [&mut MmrMembershipProof<H>],
         mutation_data: Vec<(MmrMembershipProof<H>, H::Digest)>,
     ) -> Vec<usize>;
 


### PR DESCRIPTION
I need this for manipulating MMR membership proofs through nested calls