### PR TITLE
Replace simple_hasher::Hasher with AlgebraicHasher

### DIFF
--- a/stark-brainfuck/src/io_table.rs
+++ b/stark-brainfuck/src/io_table.rs
@@ -323,8 +323,8 @@ mod io_table_tests {
                 let matrix_len = io_table.0.matrix.len() as isize;
                 let base_steps = max(0, matrix_len - 1) as usize;
                 for step in 0..base_steps {
-                    let row: BFieldElement = io_matrix[step].clone();
-                    let next_row: BFieldElement = io_matrix[step + 1].clone();
+                    let row: BFieldElement = io_matrix[step];
+                    let next_row: BFieldElement = io_matrix[step + 1];
                     let point: Vec<BFieldElement> = vec![row, next_row];
 
                     // Since there are no base AIR constraints on either IOTables,
@@ -336,7 +336,7 @@ mod io_table_tests {
                 }
 
                 // Test base transition constraints after padding
-                io_table.0.matrix = io_matrix.into_iter().map(|x| vec![x.clone()]).collect();
+                io_table.0.matrix = io_matrix.iter().map(|&x| vec![x]).collect();
                 io_table.pad();
 
                 let padded_matrix_len = io_table.0.matrix.len() as isize;

--- a/stark-brainfuck/src/stark.rs
+++ b/stark-brainfuck/src/stark.rs
@@ -739,12 +739,9 @@ impl Stark {
 
         let combination_root: Digest = proof_stream.dequeue(32)?;
 
-        let indices_seed = proof_stream.verifier_fiat_shamir();
-        let indices = StarkHasher::sample_indices(
-            self.security_level,
-            &indices_seed.into(),
-            self.fri.domain.length,
-        );
+        let indices_seed: Digest = proof_stream.verifier_fiat_shamir();
+        let indices =
+            StarkHasher::sample_indices(self.security_level, &indices_seed, self.fri.domain.length);
         timer.elapsed("Got indices");
 
         // Verify low degree of combination polynomial

--- a/stark-brainfuck/src/stark_proof_stream.rs
+++ b/stark-brainfuck/src/stark_proof_stream.rs
@@ -67,7 +67,7 @@ impl ProofItem {
 
     pub fn as_merkle_root(&self) -> Result<Digest, Box<dyn std::error::Error>> {
         match self {
-            Self::MerkleRoot(bs) => Ok(bs.clone()),
+            Self::MerkleRoot(bs) => Ok(*bs),
             _ => Err(ProofStreamError::boxed(
                 "expected merkle root, but got something else",
             )),

--- a/stark-brainfuck/src/stark_proof_stream.rs
+++ b/stark-brainfuck/src/stark_proof_stream.rs
@@ -1,25 +1,26 @@
 use itertools::Itertools;
 
 use twenty_first::shared_math::b_field_element::BFieldElement;
+use twenty_first::shared_math::rescue_prime_digest::Digest;
 use twenty_first::shared_math::x_field_element::XFieldElement;
+use twenty_first::util_types::algebraic_hasher::Hashable;
 use twenty_first::util_types::merkle_tree::PartialAuthenticationPath;
 use twenty_first::util_types::proof_stream_typed::{ProofStream, ProofStreamError};
-use twenty_first::util_types::simple_hasher::{Hashable, Hasher, ToVec};
 
 use crate::stark::TERMINAL_COUNT;
 
-pub type StarkProofStream<H> = ProofStream<ProofItem<H>, H>;
+pub type StarkProofStream<H> = ProofStream<ProofItem, H>;
 
 #[allow(type_alias_bounds)]
-type FriProof<H: Hasher> = Vec<(PartialAuthenticationPath<H::Digest>, XFieldElement)>;
+type FriProof = Vec<(PartialAuthenticationPath<Digest>, XFieldElement)>;
 type CompressedAuthenticationPaths<Digest> = Vec<PartialAuthenticationPath<Vec<Digest>>>;
 
 #[derive(Debug, Clone)]
-pub enum ProofItem<H: Hasher> {
-    CompressedAuthenticationPaths(CompressedAuthenticationPaths<H::Digest>),
+pub enum ProofItem {
+    CompressedAuthenticationPaths(CompressedAuthenticationPaths<Digest>),
     TransposedBaseElementVectors(Vec<Vec<BFieldElement>>),
     TransposedExtensionElementVectors(Vec<Vec<XFieldElement>>),
-    MerkleRoot(H::Digest),
+    MerkleRoot(Digest),
     Terminals([XFieldElement; TERMINAL_COUNT]),
     TransposedBaseElements(Vec<BFieldElement>),
     TransposedExtensionElements(Vec<XFieldElement>),
@@ -27,13 +28,13 @@ pub enum ProofItem<H: Hasher> {
     RevealedCombinationElement(XFieldElement),
     RevealedCombinationElements(Vec<XFieldElement>),
     FriCodeword(Vec<XFieldElement>),
-    FriProof(FriProof<H>),
+    FriProof(FriProof),
 }
 
-impl<H: Hasher> ProofItem<H> {
+impl ProofItem {
     pub fn as_compressed_authentication_paths(
         &self,
-    ) -> Result<CompressedAuthenticationPaths<H::Digest>, Box<dyn std::error::Error>> {
+    ) -> Result<CompressedAuthenticationPaths<Digest>, Box<dyn std::error::Error>> {
         match self {
             Self::CompressedAuthenticationPaths(caps) => Ok(caps.to_owned()),
             _ => Err(ProofStreamError::boxed(
@@ -64,7 +65,7 @@ impl<H: Hasher> ProofItem<H> {
         }
     }
 
-    pub fn as_merkle_root(&self) -> Result<H::Digest, Box<dyn std::error::Error>> {
+    pub fn as_merkle_root(&self) -> Result<Digest, Box<dyn std::error::Error>> {
         match self {
             Self::MerkleRoot(bs) => Ok(bs.clone()),
             _ => Err(ProofStreamError::boxed(
@@ -148,7 +149,7 @@ impl<H: Hasher> ProofItem<H> {
         }
     }
 
-    pub fn as_fri_proof(&self) -> Result<FriProof<H>, Box<dyn std::error::Error>> {
+    pub fn as_fri_proof(&self) -> Result<FriProof, Box<dyn std::error::Error>> {
         match self {
             Self::FriProof(fri_proof) => Ok(fri_proof.to_owned()),
             _ => Err(ProofStreamError::boxed(
@@ -158,52 +159,42 @@ impl<H: Hasher> ProofItem<H> {
     }
 }
 
-impl<H: Hasher> Default for ProofItem<H> {
-    fn default() -> Self {
-        panic!("Do not have a default method ProofItem")
-    }
-}
+impl IntoIterator for ProofItem {
+    type Item = BFieldElement;
 
-impl<H: Hasher> IntoIterator for ProofItem<H>
-where
-    BFieldElement: Hashable<H::T>,
-    ProofItem<H>: Default,
-{
-    type Item = H::T;
-
-    type IntoIter = std::vec::IntoIter<H::T>;
+    type IntoIter = std::vec::IntoIter<BFieldElement>;
 
     // simulates serialization
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            ProofItem::MerkleRoot(digest) => digest.to_vec().into_iter(),
-            ProofItem::Terminals(xs) => bs_to_ts::<H::T>(&xs_to_bs(&xs)).into_iter(),
-            ProofItem::TransposedBaseElements(bs) => bs_to_ts(&bs).into_iter(),
-            ProofItem::TransposedExtensionElements(xs) => bs_to_ts(&xs_to_bs(&xs)).into_iter(),
-            ProofItem::AuthenticationPath(bss) => bs_to_ts(&bss.concat()).into_iter(),
-            ProofItem::RevealedCombinationElement(x) => bs_to_ts(&xs_to_bs(&[x])).into_iter(),
-            ProofItem::FriCodeword(xs) => bs_to_ts(&xs_to_bs(&xs)).into_iter(),
-            ProofItem::RevealedCombinationElements(xs) => bs_to_ts(&xs_to_bs(&xs)).into_iter(),
+            ProofItem::MerkleRoot(digest) => digest.to_sequence().into_iter(),
+            ProofItem::Terminals(xs) => xs_to_bs(&xs).into_iter(),
+            ProofItem::TransposedBaseElements(bs) => bs.into_iter(),
+            ProofItem::TransposedExtensionElements(xs) => xs_to_bs(&xs).into_iter(),
+            ProofItem::AuthenticationPath(bss) => bss.concat().into_iter(),
+            ProofItem::RevealedCombinationElement(x) => xs_to_bs(&[x]).into_iter(),
+            ProofItem::FriCodeword(xs) => xs_to_bs(&xs).into_iter(),
+            ProofItem::RevealedCombinationElements(xs) => xs_to_bs(&xs).into_iter(),
             ProofItem::FriProof(fri_proof) => {
-                let mut element_sequence: Vec<H::T> = vec![];
+                let mut element_sequence: Vec<BFieldElement> = vec![];
 
                 for (partial_auth_path, xfield_element) in fri_proof.iter() {
                     for bs_in_partial_auth_path in partial_auth_path.0.iter().flatten() {
-                        element_sequence.append(&mut bs_in_partial_auth_path.clone().to_vec());
+                        element_sequence.append(&mut bs_in_partial_auth_path.clone().to_sequence());
                     }
-                    element_sequence.append(&mut bs_to_ts(&xs_to_bs(&[xfield_element.to_owned()])));
+                    element_sequence.append(&mut xs_to_bs(&[xfield_element.to_owned()]));
                 }
 
                 element_sequence.into_iter()
             }
             ProofItem::CompressedAuthenticationPaths(partial_auth_paths) => {
-                let mut bs: Vec<H::T> = vec![];
+                let mut bs: Vec<BFieldElement> = vec![];
 
                 for partial_auth_path in partial_auth_paths.iter() {
                     for bs_in_partial_auth_path in partial_auth_path.0.iter().flatten() {
                         let flattened = bs_in_partial_auth_path
                             .iter()
-                            .flat_map(|d| d.to_vec())
+                            .flat_map(|digest| digest.to_sequence())
                             .collect_vec();
                         bs.append(&mut flattened.clone());
                     }
@@ -211,35 +202,19 @@ where
 
                 bs.into_iter()
             }
-            ProofItem::TransposedBaseElementVectors(bss) => {
-                bs_to_ts::<H::T>(&bss.concat()).into_iter()
+            ProofItem::TransposedBaseElementVectors(bss) => bss.concat().into_iter(),
+            ProofItem::TransposedExtensionElementVectors(xss) => {
+                let bs: Vec<BFieldElement> = xss
+                    .into_iter()
+                    .flatten()
+                    .flat_map(|xfe| xfe.coefficients)
+                    .collect_vec();
+                bs.into_iter()
             }
-            ProofItem::TransposedExtensionElementVectors(xss) => xss
-                .into_iter()
-                .map(|xs| bs_to_ts::<H::T>(&xs_to_bs(&xs)))
-                .concat()
-                .into_iter(),
         }
     }
 }
 
-// impl<H: Hasher> IntoIterator for ProofItem<H>
-// where
-//     Vec<BFieldElement>: From<Vec<H::T>> + Hashable<H::T>,
-//     BFieldElement: Hashable<H::T>,
-// {
-//     type Item = H::T;
-
-//     type IntoIter = std::vec::IntoIter<H::T>;
-// }
-
 fn xs_to_bs(xs: &[XFieldElement]) -> Vec<BFieldElement> {
     xs.iter().map(|x| x.coefficients.to_vec()).concat()
-}
-
-fn bs_to_ts<T>(bs: &[BFieldElement]) -> Vec<T>
-where
-    BFieldElement: Hashable<T>,
-{
-    bs.iter().flat_map(|b| b.to_sequence()).collect_vec()
 }

--- a/stark-brainfuck/src/table_collection.rs
+++ b/stark-brainfuck/src/table_collection.rs
@@ -265,8 +265,8 @@ mod brainfuck_table_collection_tests {
 
     #[test]
     fn degree_bounds_test() {
-        let mut expected_bounds: HashMap<&str, (Vec<Degree>, Vec<Degree>, Vec<Degree>)> =
-            HashMap::new();
+        type DegreeBounds = (Vec<Degree>, Vec<Degree>, Vec<Degree>);
+        let mut expected_bounds: HashMap<&str, DegreeBounds> = HashMap::new();
 
         // The expected values have been found from the Python STARK BF tutorial
         expected_bounds.insert(

--- a/stark-brainfuck/src/xfri.rs
+++ b/stark-brainfuck/src/xfri.rs
@@ -802,13 +802,13 @@ mod xfri_tests {
         expansion_factor: usize,
         colinearity_checks: usize,
     ) -> Fri<H> {
-        let maybe_omega: Option<XFieldElement> =
-            XFieldElement::primitive_root_of_unity(subgroup_order);
+        let maybe_omega: Option<BFieldElement> =
+            BFieldElement::primitive_root_of_unity(subgroup_order);
 
         // The element 7 generates all of Zp\{0}
         let offset: Option<BFieldElement> = Some(BFieldElement::new(7));
 
-        let fri: Fri<H> = Fri::<H>::new(
+        let fri: Fri<H> = Fri::new(
             offset.unwrap(),
             maybe_omega.unwrap(),
             subgroup_order as usize,

--- a/stark-brainfuck/src/xfri.rs
+++ b/stark-brainfuck/src/xfri.rs
@@ -389,10 +389,7 @@ impl<H: AlgebraicHasher> Fri<H> {
         let last_codeword: Vec<XFieldElement> = proof_stream.dequeue()?.as_fri_codeword()?;
 
         // Check if last codeword matches the given root
-        let codeword_digests = last_codeword
-            .iter()
-            .map(|elm| Hasher::hash(elm))
-            .collect_vec();
+        let codeword_digests = last_codeword.iter().map(Hasher::hash).collect_vec();
         let last_codeword_mt = MerkleTree::<H>::from_digests(&codeword_digests);
         let last_root = roots.last().unwrap();
         if *last_root != last_codeword_mt.get_root() {
@@ -423,8 +420,7 @@ impl<H: AlgebraicHasher> Fri<H> {
         let hm = proof_stream.verifier_fiat_shamir();
         let mut a_indices: Vec<usize> = self.sample_indices(&hm.to_sequence());
         timer.elapsed("Sample indices");
-        let mut a_values =
-            Self::dequeue_and_authenticate(&a_indices, roots[0].clone(), proof_stream)?;
+        let mut a_values = Self::dequeue_and_authenticate(&a_indices, roots[0], proof_stream)?;
 
         // set up "B" for offsetting inside loop.  Note that "B" and "A" indices
         // can be calcuated from each other.
@@ -442,8 +438,7 @@ impl<H: AlgebraicHasher> Fri<H> {
                 .map(|x| (x + current_domain_len / 2) % current_domain_len)
                 .collect();
             timer.elapsed(&format!("Get b-indices for current round ({})", r));
-            let b_values =
-                Self::dequeue_and_authenticate(&b_indices, roots[r].clone(), proof_stream)?;
+            let b_values = Self::dequeue_and_authenticate(&b_indices, roots[r], proof_stream)?;
             timer.elapsed(&format!("Read & verify b-auth paths round {}", r));
             debug_assert_eq!(
                 self.colinearity_checks_count,

--- a/stark-rescue-prime/src/stark_rp.rs
+++ b/stark-rescue-prime/src/stark_rp.rs
@@ -1283,9 +1283,9 @@ pub mod test_stark {
 
         let mut npo2 = trace.len() + num_randomizers;
         if npo2 & (npo2 - 1) != 0 {
-            npo2 = npo2 << 1;
+            npo2 <<= 1;
             while npo2 & (npo2 - 1) != 0 {
-                npo2 = npo2 & (npo2 - 1);
+                npo2 &= npo2 - 1;
             }
         }
 
@@ -1408,9 +1408,9 @@ pub mod test_stark {
 
         let mut npo2 = trace.len() + num_randomizers as usize;
         if npo2 & (npo2 - 1) != 0 {
-            npo2 = npo2 << 1;
+            npo2 <<= 1;
             while npo2 & (npo2 - 1) != 0 {
-                npo2 = npo2 & (npo2 - 1);
+                npo2 &= npo2 - 1;
             }
         }
 

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -56,6 +56,7 @@ serde_json = "1.0"
 serde_with = "1"
 structopt = { version = "0.3", features = ["paw"] }
 emojihash-rs = "0.2"
+get-size = { version = "^0.1", features = ["derive"] }
 
 [[bench]]
 name = "polynomial_square"

--- a/twenty-first/src/amount/u32s.rs
+++ b/twenty-first/src/amount/u32s.rs
@@ -548,10 +548,11 @@ mod u32s_tests {
             Some([0xFFFFFFFF, 0x0, 0x0, 0x0]),
         ];
         let mut rhs: U32s<4>;
-        for i in 0..4 {
+        for (i, mask) in masks.into_iter().enumerate() {
+            // for i in 0..4 {
             rhs = U32s::new([0; 4]);
             rhs.values[i] = 1u32;
-            let vals = get_u32s::<4>(100, masks[i]);
+            let vals = get_u32s::<4>(100, mask);
             for val in vals {
                 let mut expected = val;
                 expected.values.rotate_right(i);
@@ -695,9 +696,9 @@ mod u32s_tests {
             a = match and_mask {
                 None => a,
                 Some(mask) => {
-                    for i in 0..N {
+                    (0..N).for_each(|i| {
                         a.values[i] &= mask[i];
-                    }
+                    });
                     a
                 }
             };
@@ -718,7 +719,7 @@ mod u32s_tests {
         };
         let j = serde_json::to_string(&s).unwrap();
         let s_back = serde_json::from_str::<U32s<64>>(&j).unwrap();
-        assert!(&s.values[..] == &s_back.values[..]);
+        assert!(s.values[..] == s_back.values[..]);
     }
 
     #[test]
@@ -736,6 +737,5 @@ mod u32s_tests {
     #[test]
     fn crash() {
         let _u32s = U32s::<0>::from(0u32);
-        assert!(true)
     }
 }

--- a/twenty-first/src/amount/u32s.rs
+++ b/twenty-first/src/amount/u32s.rs
@@ -1,4 +1,5 @@
 use num_bigint::BigUint;
+use num_traits::{One, Zero};
 use serde_big_array;
 use serde_big_array::BigArray;
 use serde_derive::{Deserialize, Serialize};
@@ -9,9 +10,8 @@ use std::{
     ops::{Add, Div, Mul, Rem, Sub},
 };
 
-use num_traits::{One, Zero};
-
-use crate::{shared_math::b_field_element::BFieldElement, util_types::simple_hasher::Hashable};
+use crate::shared_math::b_field_element::BFieldElement;
+use crate::util_types::algebraic_hasher::Hashable;
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct U32s<const N: usize> {
@@ -317,7 +317,7 @@ impl<const N: usize> Display for U32s<N> {
     }
 }
 
-impl<const N: usize> Hashable<BFieldElement> for U32s<N> {
+impl<const N: usize> Hashable for U32s<N> {
     fn to_sequence(&self) -> Vec<BFieldElement> {
         self.values.into_iter().map(BFieldElement::from).collect()
     }

--- a/twenty-first/src/shared_math.rs
+++ b/twenty-first/src/shared_math.rs
@@ -4,6 +4,7 @@ pub mod mpolynomial;
 pub mod ntt;
 pub mod other;
 pub mod polynomial;
+pub mod rescue_prime_digest;
 pub mod rescue_prime_regular;
 pub mod stark;
 pub mod traits;

--- a/twenty-first/src/shared_math/fri.rs
+++ b/twenty-first/src/shared_math/fri.rs
@@ -391,8 +391,7 @@ where
 
         // for every round, check consistency of subsequent layers
         let mut codeword_evaluations: Vec<CodewordEvaluation<XFieldElement>> = vec![];
-        let mut a_values =
-            Self::dequeue_and_authenticate(&a_indices, roots[0].clone(), proof_stream)?;
+        let mut a_values = Self::dequeue_and_authenticate(&a_indices, roots[0], proof_stream)?;
 
         // set up "B" for offsetting inside loop.  Note that "B" and "A" indices
         // can be calcuated from each other.
@@ -406,8 +405,7 @@ where
                 .map(|x| (x + current_domain_len / 2) % current_domain_len)
                 .collect();
 
-            let b_values =
-                Self::dequeue_and_authenticate(&b_indices, roots[r].clone(), proof_stream)?;
+            let b_values = Self::dequeue_and_authenticate(&b_indices, roots[r], proof_stream)?;
 
             debug_assert_eq!(
                 self.colinearity_checks_count,

--- a/twenty-first/src/shared_math/fri.rs
+++ b/twenty-first/src/shared_math/fri.rs
@@ -578,12 +578,12 @@ mod fri_tests {
 
     #[test]
     fn get_rounds_count_test() {
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
         let subgroup_order = 512;
         let expansion_factor = 4;
-        let mut fri: Fri<Hasher> =
-            get_x_field_fri_test_object::<Hasher>(subgroup_order, expansion_factor, 2);
+        let mut fri: Fri<XFieldElement, H> =
+            get_x_field_fri_test_object::<H>(subgroup_order, expansion_factor, 2);
 
         assert_eq!((7, 0), fri.num_rounds());
         fri.colinearity_checks_count = 8;

--- a/twenty-first/src/shared_math/fri.rs
+++ b/twenty-first/src/shared_math/fri.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 use super::b_field_element::BFieldElement;
 use super::other::{log_2_ceil, log_2_floor};
 use super::polynomial::Polynomial;
-use super::traits::{CyclicGroupGenerator, FromVecu8, ModPowU32};
+use super::traits::{CyclicGroupGenerator, ModPowU32};
 use super::x_field_element::XFieldElement;
 use crate::shared_math::ntt::{intt, ntt};
 use crate::shared_math::traits::FiniteField;
@@ -581,8 +581,7 @@ mod fri_tests {
 
         let subgroup_order = 512;
         let expansion_factor = 4;
-        let mut fri: Fri<XFieldElement, H> =
-            get_x_field_fri_test_object::<H>(subgroup_order, expansion_factor, 2);
+        let mut fri: Fri<H> = get_x_field_fri_test_object::<H>(subgroup_order, expansion_factor, 2);
 
         assert_eq!((7, 0), fri.num_rounds());
         fri.colinearity_checks_count = 8;

--- a/twenty-first/src/shared_math/mpolynomial.rs
+++ b/twenty-first/src/shared_math/mpolynomial.rs
@@ -1595,12 +1595,12 @@ mod test_mpolynomials {
 
     #[test]
     fn evaluate_symbolic_test() {
-        let empty_intermediate_results: HashMap<Vec<u8>, Polynomial<BFieldElement>> =
+        let mut empty_intermediate_results: HashMap<Vec<u8>, Polynomial<BFieldElement>> =
             HashMap::new();
-        let empty_mod_pow_memoization: HashMap<(usize, u8), Polynomial<BFieldElement>> =
+        let mut empty_mod_pow_memoization: HashMap<(usize, u8), Polynomial<BFieldElement>> =
             HashMap::new();
         #[allow(clippy::type_complexity)]
-        let empty_mul_memoization: HashMap<
+        let mut empty_mul_memoization: HashMap<
             (Polynomial<BFieldElement>, (usize, u8)),
             Polynomial<BFieldElement>,
         > = HashMap::new();
@@ -1633,15 +1633,15 @@ mod test_mpolynomials {
                 &[x.clone(), x.clone(), x.clone()],
                 &mut empty_mod_pow_memoization.clone(),
                 &mut empty_mul_memoization.clone(),
-                &mut empty_intermediate_results.clone(),
+                &mut empty_intermediate_results,
             )
         );
         assert_eq!(
             x_cubed,
             xyz_m.evaluate_symbolic_with_memoization(
                 &[x.clone(), x.clone(), x.clone()],
-                &mut empty_mod_pow_memoization.clone(),
-                &mut empty_mul_memoization.clone(),
+                &mut empty_mod_pow_memoization,
+                &mut empty_mul_memoization,
                 &mut precalculated_intermediate_results.clone(),
             )
         );
@@ -2145,6 +2145,7 @@ mod test_mpolynomials {
         let max_degrees = vec![3, 5, 7];
         let degree_poly = mpoly.symbolic_degree_bound(&max_degrees);
 
+        #[allow(clippy::erasing_op, clippy::identity_op)]
         let expected = cmp::max(0 * 3 + 2 * 5 + 1 * 7, 0 * 3 + 0 * 5 + 1 * 7);
         assert_eq!(degree_poly, expected);
 
@@ -2158,7 +2159,7 @@ mod test_mpolynomials {
         assert_eq!(expected, mpoly_alt.symbolic_degree_bound(&max_degrees));
 
         // Verify that the result is different when the coefficient is non-zero
-        mcoef.insert(new_key.clone(), BFieldElement::new(4562));
+        mcoef.insert(new_key, BFieldElement::new(4562));
         let mpoly_alt_alt = MPolynomial::<BFieldElement> {
             variable_count: 3,
             coefficients: mcoef,

--- a/twenty-first/src/shared_math/other.rs
+++ b/twenty-first/src/shared_math/other.rs
@@ -279,8 +279,7 @@ mod test_other {
 
     #[test]
     fn powers_of_two_below_test() {
-        let powers_of_two: Vec<u32> = powers_of_two_below::<u32>(u32::MAX, u32::BITS).collect();
-        for i in powers_of_two.into_iter() {
+        for i in powers_of_two_below::<u32>(u32::MAX, u32::BITS) {
             assert!(is_power_of_two(i));
         }
 

--- a/twenty-first/src/shared_math/rescue_prime_digest.rs
+++ b/twenty-first/src/shared_math/rescue_prime_digest.rs
@@ -1,0 +1,188 @@
+use core::fmt;
+use std::str::FromStr;
+
+use get_size::GetSize;
+use num_traits::Zero;
+use serde::{Deserialize, Serialize};
+
+use crate::shared_math::b_field_element::BFieldElement;
+use crate::shared_math::rescue_prime_regular::DIGEST_LENGTH;
+use crate::shared_math::traits::FromVecu8;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Digest([BFieldElement; DIGEST_LENGTH]);
+
+pub const BYTES_PER_BFIELDELEMENT: usize = 8;
+pub const MSG_DIGEST_SIZE_IN_BYTES: usize = 32;
+pub const DIGEST_SIZE_IN_BYTES: usize = DIGEST_LENGTH * BYTES_PER_BFIELDELEMENT;
+
+impl GetSize for Digest {
+    fn get_stack_size() -> usize {
+        std::mem::size_of::<Self>()
+    }
+
+    fn get_heap_size(&self) -> usize {
+        0
+    }
+
+    fn get_size(&self) -> usize {
+        Self::get_stack_size()
+    }
+}
+
+impl Digest {
+    pub fn values(&self) -> [BFieldElement; DIGEST_LENGTH] {
+        self.0
+    }
+
+    pub fn new(digest: [BFieldElement; DIGEST_LENGTH]) -> Self {
+        Self(digest)
+    }
+
+    pub fn default() -> Self {
+        Self([BFieldElement::zero(); DIGEST_LENGTH])
+    }
+}
+
+impl fmt::Display for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.map(|elem| elem.to_string()).join(","))
+    }
+}
+
+impl FromStr for Digest {
+    type Err = String;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        let parsed_u64s: Vec<Result<u64, _>> = string
+            .split(',')
+            .map(|substring| substring.parse::<u64>())
+            .collect();
+        if parsed_u64s.len() != DIGEST_LENGTH {
+            Err("Given invalid number of BFieldElements in string.".to_owned())
+        } else {
+            let mut bf_elms: Vec<BFieldElement> = Vec::with_capacity(DIGEST_LENGTH);
+            for parse_result in parsed_u64s {
+                if let Ok(content) = parse_result {
+                    bf_elms.push(BFieldElement::new(content));
+                } else {
+                    return Err("Given invalid BFieldElement in string.".to_owned());
+                }
+            }
+            Ok(bf_elms.try_into()?)
+        }
+    }
+}
+
+impl TryFrom<Vec<BFieldElement>> for Digest {
+    type Error = String;
+
+    fn try_from(value: Vec<BFieldElement>) -> Result<Self, Self::Error> {
+        let len = value.len();
+        Ok(Digest::new(value.try_into().map_err(|_| {
+            format!(
+                "Expected {} BFieldElements for digest, but got {}",
+                DIGEST_LENGTH, len,
+            )
+        })?))
+    }
+}
+
+impl From<Digest> for Vec<BFieldElement> {
+    fn from(val: Digest) -> Self {
+        val.0.to_vec()
+    }
+}
+
+impl From<Digest> for [u8; DIGEST_SIZE_IN_BYTES] {
+    fn from(item: Digest) -> Self {
+        let u64s = item.0.iter().map(|x| x.value());
+        u64s.map(|x| x.to_ne_bytes())
+            .collect::<Vec<_>>()
+            .concat()
+            .try_into()
+            .unwrap()
+    }
+}
+
+impl From<[u8; DIGEST_SIZE_IN_BYTES]> for Digest {
+    fn from(item: [u8; DIGEST_SIZE_IN_BYTES]) -> Self {
+        let mut bfes: [BFieldElement; DIGEST_LENGTH] = [BFieldElement::zero(); DIGEST_LENGTH];
+        for (i, bfe) in bfes.iter_mut().enumerate() {
+            let start_index = i * BYTES_PER_BFIELDELEMENT;
+            let end_index = (i + 1) * BYTES_PER_BFIELDELEMENT;
+            *bfe = BFieldElement::from_vecu8(item[start_index..end_index].to_vec())
+        }
+
+        Self(bfes)
+    }
+}
+
+// The implementations for dev net byte arrays are not to be used on main net
+impl From<Digest> for [u8; MSG_DIGEST_SIZE_IN_BYTES] {
+    fn from(input: Digest) -> Self {
+        let whole: [u8; DIGEST_SIZE_IN_BYTES] = input.into();
+        whole[0..MSG_DIGEST_SIZE_IN_BYTES]
+            .to_vec()
+            .try_into()
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod digest_tests {
+    use super::*;
+
+    #[test]
+    fn signature_digest_conversion_test() {
+        let bfe_vec = vec![
+            BFieldElement::new(12),
+            BFieldElement::new(24),
+            BFieldElement::new(36),
+            BFieldElement::new(48),
+            BFieldElement::new(60),
+        ];
+        let digest_from_array: Digest = bfe_vec.try_into().unwrap();
+        let _shorter: [u8; MSG_DIGEST_SIZE_IN_BYTES] = digest_from_array.into();
+    }
+
+    #[test]
+    pub fn get_size() {
+        let stack = Digest::get_stack_size();
+
+        let bfe_vec = vec![
+            BFieldElement::new(12),
+            BFieldElement::new(24),
+            BFieldElement::new(36),
+            BFieldElement::new(48),
+            BFieldElement::new(60),
+        ];
+        let rescue_prime_digest_type_from_array: Digest = bfe_vec.try_into().unwrap();
+
+        let heap = rescue_prime_digest_type_from_array.get_heap_size();
+
+        let total = rescue_prime_digest_type_from_array.get_size();
+
+        println!("stack: {stack} + heap: {heap} = {total}");
+
+        assert_eq!(stack + heap, total)
+    }
+
+    #[test]
+    pub fn digest_from_str() {
+        // This tests a valid digest. It will fail if DIGEST_LENGTH is changed.
+        let valid_digest_string = "12063201067205522823,1529663126377206632,2090171368883726200,12975872837767296928,11492877804687889759";
+        let valid_digest = Digest::from_str(valid_digest_string);
+        assert!(valid_digest.is_ok());
+
+        // This ensures that it can fail when given a wrong number of BFieldElements.
+        let invalid_digest_string = "00059361073062755064,05168490802189810700";
+        let invalid_digest = Digest::from_str(invalid_digest_string);
+        assert!(invalid_digest.is_err());
+
+        // This ensures that it can fail if given something that isn't a valid string of a BFieldElement.
+        let second_invalid_digest_string = "this_is_not_a_bfield_element,05168490802189810700";
+        let second_invalid_digest = Digest::from_str(second_invalid_digest_string);
+        assert!(second_invalid_digest.is_err());
+    }
+}

--- a/twenty-first/src/shared_math/rescue_prime_digest.rs
+++ b/twenty-first/src/shared_math/rescue_prime_digest.rs
@@ -2,7 +2,10 @@ use core::fmt;
 use std::str::FromStr;
 
 use get_size::GetSize;
+use itertools::Itertools;
 use num_traits::Zero;
+use rand::Rng;
+use rand_distr::{Distribution, Standard};
 use serde::{Deserialize, Serialize};
 
 use crate::shared_math::b_field_element::BFieldElement;
@@ -47,6 +50,19 @@ impl Digest {
 impl fmt::Display for Digest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0.map(|elem| elem.to_string()).join(","))
+    }
+}
+
+impl Distribution<Digest> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Digest {
+        // FIXME: impl Fill for [BFieldElement] to rng.fill() a [BFieldElement; DIGEST_LENGTH].
+        let elements = rng
+            .sample_iter(Standard)
+            .take(DIGEST_LENGTH)
+            .collect_vec()
+            .try_into()
+            .unwrap();
+        Digest::new(elements)
     }
 }
 

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -1172,14 +1172,13 @@ mod rescue_prime_regular_tests {
                 5525683604796387635,
             ],
         ];
-        let mut targets_bfe: Vec<Vec<BFieldElement>> = targets_first_batch
-            .iter()
-            .map(|l| l.iter().map(|e| BFieldElement::new(*e)).collect_vec())
-            .collect_vec();
-        let mut input = [BFieldElement::zero(); 10];
-        for i in 0..10 {
-            input[input.len() - 1] = BFieldElement::new(i as u64);
-            assert_eq!(targets_bfe[i], RescuePrimeRegular::hash_10(&input).to_vec());
+
+        for (i, target) in targets_first_batch.into_iter().enumerate() {
+            let expected = target.map(BFieldElement::new);
+            let mut input = [BFieldElement::zero(); 10];
+            input[input.len() - 1] = BFieldElement::from(i as u64);
+            let actual = RescuePrimeRegular::hash_10(&input);
+            assert_eq!(expected, actual);
         }
 
         // hash 10, second batch
@@ -1255,15 +1254,12 @@ mod rescue_prime_regular_tests {
                 17624827189757302581,
             ],
         ];
-        targets_bfe = targets_second_batch
-            .iter()
-            .map(|l| l.iter().map(|e| BFieldElement::new(*e)).collect_vec())
-            .collect_vec();
-        input[input.len() - 1] = BFieldElement::zero();
-        for i in 0..10 {
+        for (i, target) in targets_second_batch.into_iter().enumerate() {
+            let expected = target.map(BFieldElement::new);
+            let mut input = [BFieldElement::zero(); 10];
             input[i] = BFieldElement::one();
-            assert_eq!(targets_bfe[i], RescuePrimeRegular::hash_10(&input).to_vec());
-            input[i] = BFieldElement::zero();
+            let actual = RescuePrimeRegular::hash_10(&input);
+            assert_eq!(expected, actual);
         }
 
         // hash varlen, third batch
@@ -1409,16 +1405,11 @@ mod rescue_prime_regular_tests {
                 7424726151688166928,
             ],
         ];
-        targets_bfe = targets_third_batch
-            .iter()
-            .map(|l| l.iter().map(|e| BFieldElement::new(*e)).collect_vec())
-            .collect_vec();
-        for i in 0..20 {
-            let var_input = (0..i).map(|e| BFieldElement::new(e as u64)).collect_vec();
-            assert_eq!(
-                RescuePrimeRegular::hash_varlen(&var_input).to_vec(),
-                targets_bfe[i]
-            );
+        for (i, target) in targets_third_batch.into_iter().enumerate() {
+            let expected = target.map(BFieldElement::new);
+            let input = (0..i as u64).map(BFieldElement::new).collect_vec();
+            let actual = RescuePrimeRegular::hash_varlen(&input);
+            assert_eq!(expected, actual);
         }
     }
 

--- a/twenty-first/src/shared_math/x_field_element.rs
+++ b/twenty-first/src/shared_math/x_field_element.rs
@@ -931,15 +931,15 @@ mod x_field_element_test {
 
     #[test]
     fn x_field_ntt_test() {
-        for i in [2, 4, 8, 16, 32] {
+        for root_order in [2, 4, 8, 16, 32] {
             // Verify that NTT and INTT are each other's inverses,
             // and that NTT corresponds to polynomial evaluation
-            let inputs_u64: Vec<u64> = (0..i).collect();
+            let inputs_u64: Vec<u64> = (0..root_order).collect();
             let inputs: Vec<XFieldElement> = inputs_u64
                 .iter()
                 .map(|&x| XFieldElement::new_const(BFieldElement::new(x)))
                 .collect();
-            let root = XFieldElement::primitive_root_of_unity(i).unwrap();
+            let root = XFieldElement::primitive_root_of_unity(root_order).unwrap();
             let log_2_of_n = log_2_floor(inputs.len() as u128) as u32;
             let mut rv = inputs.clone();
             ntt::<XFieldElement>(&mut rv, root.unlift().unwrap(), log_2_of_n);

--- a/twenty-first/src/shared_math/x_field_element.rs
+++ b/twenty-first/src/shared_math/x_field_element.rs
@@ -1,7 +1,3 @@
-use super::traits::{FromVecu8, Inverse, PrimitiveRootOfUnity};
-use crate::shared_math::b_field_element::BFieldElement;
-use crate::shared_math::polynomial::Polynomial;
-use crate::shared_math::traits::{CyclicGroupGenerator, FiniteField, ModPowU32, ModPowU64, New};
 use num_traits::{One, Zero};
 use rand::Rng;
 use rand_distr::{Distribution, Standard};
@@ -9,6 +5,11 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use crate::shared_math::b_field_element::{BFieldElement, EMOJI_PER_BFE};
+use crate::shared_math::polynomial::Polynomial;
+use crate::shared_math::traits::{CyclicGroupGenerator, FiniteField, ModPowU32, ModPowU64, New};
+use crate::shared_math::traits::{FromVecu8, Inverse, PrimitiveRootOfUnity};
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, Serialize, Deserialize)]
 pub struct XFieldElement {
@@ -115,7 +116,12 @@ impl XFieldElement {
 
     /// Convert item to pretty-printed string of emojis
     pub fn emojihash(&self) -> String {
-        let [a, b, c] = self.coefficients.map(|bfe| bfe.emojihash_raw());
+        let [a, b, c] = self.coefficients.map(|bfe| {
+            emojihash::hash(&bfe.value().to_be_bytes())
+                .chars()
+                .take(EMOJI_PER_BFE)
+                .collect::<String>()
+        });
         format!("[{a}|{b}|{c}]")
     }
 }

--- a/twenty-first/src/test_shared.rs
+++ b/twenty-first/src/test_shared.rs
@@ -1,1 +1,9 @@
+use crate::shared_math::rescue_prime_digest::Digest;
+
 pub mod mmr;
+
+pub fn corrupt_digest(digest: &Digest) -> Digest {
+    let mut bad_elements = digest.values();
+    bad_elements[0].increment();
+    Digest::new(bad_elements)
+}

--- a/twenty-first/src/test_shared/mmr.rs
+++ b/twenty-first/src/test_shared/mmr.rs
@@ -1,9 +1,7 @@
 use rusty_leveldb::DB;
 
-use crate::{
-    shared_math::rescue_prime_digest::Digest,
-    util_types::{algebraic_hasher::AlgebraicHasher, mmr::archival_mmr::ArchivalMmr},
-};
+use crate::shared_math::rescue_prime_digest::Digest;
+use crate::util_types::{algebraic_hasher::AlgebraicHasher, mmr::archival_mmr::ArchivalMmr};
 
 pub fn get_empty_archival_mmr<H: AlgebraicHasher>() -> ArchivalMmr<H> {
     let opt = rusty_leveldb::in_memory();

--- a/twenty-first/src/test_shared/mmr.rs
+++ b/twenty-first/src/test_shared/mmr.rs
@@ -1,22 +1,19 @@
 use rusty_leveldb::DB;
 
-use crate::util_types::{
-    mmr::archival_mmr::ArchivalMmr,
-    simple_hasher::{Hashable, Hasher},
+use crate::{
+    shared_math::rescue_prime_digest::Digest,
+    util_types::{algebraic_hasher::AlgebraicHasher, mmr::archival_mmr::ArchivalMmr},
 };
 
-pub fn get_empty_archival_mmr<H: Hasher>() -> ArchivalMmr<H>
-where
-    u128: Hashable<<H as Hasher>::T>,
-{
+pub fn get_empty_archival_mmr<H: AlgebraicHasher>() -> ArchivalMmr<H> {
     let opt = rusty_leveldb::in_memory();
     let db = DB::open("mydatabase", opt).unwrap();
     ArchivalMmr::new(db)
 }
 
-pub fn get_archival_mmr_from_digests<H: Hasher>(digests: Vec<H::Digest>) -> ArchivalMmr<H>
+pub fn get_archival_mmr_from_digests<H>(digests: Vec<Digest>) -> ArchivalMmr<H>
 where
-    u128: Hashable<<H as Hasher>::T>,
+    H: AlgebraicHasher,
 {
     let mut ammr = get_empty_archival_mmr();
     for digest in digests {

--- a/twenty-first/src/util_types.rs
+++ b/twenty-first/src/util_types.rs
@@ -1,3 +1,4 @@
+pub mod algebraic_hasher;
 pub mod blake3_wrapper;
 pub mod database_array;
 pub mod database_vector;
@@ -6,5 +7,5 @@ pub mod mmr;
 pub mod proof_stream;
 pub mod proof_stream_typed;
 pub mod shared;
-pub mod simple_hasher;
+// pub mod simple_hasher;
 pub mod tree_m_ary;

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -1,0 +1,113 @@
+use num_traits::Zero;
+use rayon::prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+
+use crate::shared_math::b_field_element::BFieldElement;
+use crate::shared_math::other;
+use crate::shared_math::rescue_prime_digest::Digest;
+use crate::shared_math::x_field_element::XFieldElement;
+
+pub trait AlgebraicHasher: Clone + Send + Sync {
+    fn hash_slice(elements: &[BFieldElement]) -> Digest;
+    fn hash_pair(left: &Digest, right: &Digest) -> Digest;
+    fn hash<T: Hashable>(item: &T) -> Digest {
+        Self::hash_slice(&item.to_sequence())
+    }
+
+    /// Given a uniform random `input` digest and a `max` that is a power of two,
+    /// produce a uniform random number in the interval `[0; max)`. The input should
+    /// be a Fiat-Shamir digest to ensure a high degree of randomness.
+    ///
+    /// - `input`: A hash digest
+    /// - `max`: The (non-inclusive) upper bound (a power of two)
+    fn sample_index(seed: &Digest, max: usize) -> usize {
+        assert!(other::is_power_of_two(max));
+
+        let bytes = bincode::serialize(&seed.values()).unwrap();
+        let length_prefix_offset: usize = 8;
+        let mut byte_counter: usize = length_prefix_offset;
+        let mut max_bits: usize = other::log_2_floor(max as u128) as usize;
+        let mut acc: usize = 0;
+
+        while max_bits > 0 {
+            let take = std::cmp::min(8, max_bits);
+            let add = (bytes[byte_counter] >> (8 - take)) as usize;
+            acc = (acc << take) + add;
+            max_bits -= take;
+            byte_counter += 1;
+        }
+
+        acc
+    }
+
+    // FIXME: This is not uniform.
+    fn sample_index_not_power_of_two(seed: &Digest, max: usize) -> usize {
+        Self::sample_index(seed, (1 << 16) * other::roundup_npo2(max as u64) as usize) % max
+    }
+
+    /// Given a uniform random `seed` digest, a `max` that is a power of two,
+    /// produce `count` uniform random numbers (sample indices) in the interval
+    /// `[0; max)`. The seed should be a Fiat-Shamir digest to ensure a high
+    /// degree of randomness.
+    ///
+    /// - `count`: The number of sample indices
+    /// - `seed`: A hash digest
+    /// - `max`: The (non-inclusive) upper bound (a power of two)
+    fn sample_indices(count: usize, seed: &Digest, max: usize) -> Vec<usize> {
+        Self::get_n_hash_rounds(seed, count)
+            .iter()
+            .map(|random_input| Self::sample_index(random_input, max))
+            .collect()
+    }
+
+    fn get_n_hash_rounds(seed: &Digest, count: usize) -> Vec<Digest> {
+        let mut digests = Vec::with_capacity(count);
+        (0..count)
+            .into_par_iter()
+            .map(|i: usize| Self::hash_slice(&[seed.to_sequence(), i.to_sequence()].concat()))
+            .collect_into_vec(&mut digests);
+
+        digests
+    }
+}
+
+pub trait Hashable {
+    fn to_sequence(&self) -> Vec<BFieldElement>;
+}
+
+impl Hashable for Digest {
+    fn to_sequence(&self) -> Vec<BFieldElement> {
+        self.values().to_vec()
+    }
+}
+
+impl Hashable for u128 {
+    fn to_sequence(&self) -> Vec<BFieldElement> {
+        // Only shifting with 63 *should* prevent collissions for all numbers below u64::MAX.
+        vec![
+            BFieldElement::zero(),
+            BFieldElement::zero(),
+            BFieldElement::new((self >> 126) as u64),
+            BFieldElement::new(((self >> 63) % BFieldElement::MAX as u128) as u64),
+            BFieldElement::new((self % BFieldElement::MAX as u128) as u64),
+        ]
+    }
+}
+
+impl Hashable for XFieldElement {
+    fn to_sequence(&self) -> Vec<BFieldElement> {
+        self.coefficients.to_vec()
+    }
+}
+
+// FIXME: Not safe.
+impl Hashable for usize {
+    fn to_sequence(&self) -> Vec<BFieldElement> {
+        vec![BFieldElement::new(*self as u64)]
+    }
+}
+
+impl Hashable for BFieldElement {
+    fn to_sequence(&self) -> Vec<BFieldElement> {
+        vec![*self]
+    }
+}

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -18,14 +18,18 @@ pub trait AlgebraicHasher: Clone + Send + Sync {
     /// be a Fiat-Shamir digest to ensure a high degree of randomness.
     ///
     /// - `input`: A hash digest
-    /// - `max`: The (non-inclusive) upper bound (a power of two)
-    fn sample_index(seed: &Digest, max: usize) -> usize {
-        assert!(other::is_power_of_two(max));
+    /// - `upper_bound`: The (non-inclusive) upper bound (a power of two)
+    fn sample_index(seed: &Digest, upper_bound: usize) -> usize {
+        assert!(
+            other::is_power_of_two(upper_bound),
+            "Non-inclusive upper bound {} is a power of two",
+            upper_bound
+        );
 
         let bytes = bincode::serialize(&seed.values()).unwrap();
         let length_prefix_offset: usize = 8;
         let mut byte_counter: usize = length_prefix_offset;
-        let mut max_bits: usize = other::log_2_floor(max as u128) as usize;
+        let mut max_bits: usize = other::log_2_floor(upper_bound as u128) as usize;
         let mut acc: usize = 0;
 
         while max_bits > 0 {
@@ -101,6 +105,12 @@ impl Hashable for XFieldElement {
 
 // FIXME: Not safe.
 impl Hashable for usize {
+    fn to_sequence(&self) -> Vec<BFieldElement> {
+        vec![BFieldElement::new(*self as u64)]
+    }
+}
+
+impl Hashable for u32 {
     fn to_sequence(&self) -> Vec<BFieldElement> {
         vec![BFieldElement::new(*self as u64)]
     }

--- a/twenty-first/src/util_types/blake3_wrapper.rs
+++ b/twenty-first/src/util_types/blake3_wrapper.rs
@@ -1,91 +1,34 @@
-use rand::Rng;
-use rand_distr::{Distribution, Standard};
-use serde::ser::SerializeTuple;
-use serde::{Deserialize, Serialize};
+use itertools::Itertools;
 
-/// A wrapper around `blake3::Hash` because it does not Serialize.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Blake3Hash(pub blake3::Hash);
+use crate::shared_math::b_field_element::BFieldElement;
+use crate::shared_math::rescue_prime_digest::Digest;
+use crate::shared_math::rescue_prime_regular::DIGEST_LENGTH;
+use crate::util_types::algebraic_hasher::{AlgebraicHasher, Hashable};
 
-impl From<blake3::Hash> for Blake3Hash {
-    fn from(digest: blake3::Hash) -> Self {
-        Blake3Hash(digest)
-    }
-}
-
-impl From<[u8; 32]> for Blake3Hash {
-    fn from(bytes: [u8; 32]) -> Self {
-        Blake3Hash(bytes.into())
-    }
-}
-
-impl From<u128> for Blake3Hash {
-    fn from(n: u128) -> Self {
-        Blake3Hash(blake3::Hash::from_hex(format!("{:064x}", n)).unwrap())
-    }
-}
-
-impl Serialize for Blake3Hash {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut seq = serializer.serialize_tuple(32)?;
-        let bytes: &[u8; 32] = self.0.as_bytes();
-        for byte in bytes {
-            seq.serialize_element(byte)?;
+impl AlgebraicHasher for blake3::Hasher {
+    fn hash_slice(elements: &[BFieldElement]) -> Digest {
+        let mut hasher = Self::new();
+        for elem in elements.iter() {
+            hasher.update(&elem.value().to_be_bytes());
         }
-        seq.end()
-    }
-}
+        let digest_elements: [BFieldElement; DIGEST_LENGTH] = hasher
+            .finalize()
+            .as_bytes()
+            .chunks(std::mem::size_of::<u64>())
+            .take(DIGEST_LENGTH)
+            .map(|bytes: &[u8]| {
+                let mut bytes_copied: [u8; 8] = [0; 8];
+                bytes_copied.copy_from_slice(bytes);
+                BFieldElement::new(u64::from_be_bytes(bytes_copied))
+            })
+            .collect_vec()
+            .try_into()
+            .expect("A BLAKE3 digest is larger than a Digest");
 
-impl<'de> Deserialize<'de> for Blake3Hash {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let bytes: [u8; 32] = Deserialize::deserialize(deserializer)?;
-        let digest: blake3::Hash = bytes.into();
-        Ok(Blake3Hash(digest))
-    }
-}
-
-pub fn hash(bytes: &[u8]) -> Blake3Hash {
-    Blake3Hash(blake3::hash(bytes))
-}
-
-impl Distribution<Blake3Hash> for Standard {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Blake3Hash {
-        Blake3Hash(rng.gen::<[u8; 32]>().into())
-    }
-}
-
-#[cfg(test)]
-mod blake3_wrapper_test {
-    use super::*;
-
-    #[test]
-    fn serialize_deserialize_identity_test() {
-        let before: Blake3Hash = blake3::hash(b"hello").into();
-
-        let ser = bincode::serialize(&before);
-        assert!(ser.is_ok());
-
-        let de = bincode::deserialize(&ser.unwrap());
-        assert!(de.is_ok());
-
-        let after = de.unwrap();
-        assert_eq!(before, after);
+        Digest::new(digest_elements)
     }
 
-    #[test]
-    fn blake3_wrapper_uses_32_bytes_test() {
-        let zero: Blake3Hash = [0; 32].into();
-
-        let res_bytes = bincode::serialize(&zero);
-        let bytes = res_bytes.unwrap();
-
-        assert_eq!(std::mem::size_of::<Blake3Hash>(), 32);
-        assert_eq!(bytes.len(), 32);
+    fn hash_pair(left: &Digest, right: &Digest) -> Digest {
+        Self::hash_slice(&vec![left.to_sequence(), right.to_sequence()].concat())
     }
 }

--- a/twenty-first/src/util_types/database_array.rs
+++ b/twenty-first/src/util_types/database_array.rs
@@ -105,7 +105,7 @@ mod database_array_tests {
         assert_eq!(0u64, db_array.get(79));
 
         // Test batch-set, verify that writes worked and that other values were unchanged
-        db_array.batch_set(&vec![(100, 10000), (11, 1100), (12, 1200)]);
+        db_array.batch_set(&[(100, 10000), (11, 1100), (12, 1200)]);
         assert_eq!(10000u64, db_array.get(100));
         assert_eq!(1100u64, db_array.get(11));
         assert_eq!(1200u64, db_array.get(12));

--- a/twenty-first/src/util_types/database_vector.rs
+++ b/twenty-first/src/util_types/database_vector.rs
@@ -196,7 +196,7 @@ mod database_vector_tests {
         }
 
         // Batch-write and verify that the values are set correctly
-        db_vector.batch_set(&vec![(40, 4040), (41, 4141), (44, 4444)]);
+        db_vector.batch_set(&[(40, 4040), (41, 4141), (44, 4444)]);
         assert_eq!(4040, db_vector.get(40));
         assert_eq!(4141, db_vector.get(41));
         assert_eq!(4444, db_vector.get(44));

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -53,10 +53,7 @@ pub struct PartialAuthenticationPath<Digest>(pub Vec<Option<Digest>>);
 /// the original `MerkleTree` object, but only partial information from it,
 /// in the form of the quadrupples: `(root_hash, index, digest, auth_path)`.
 /// These are exactly the arguments for the `verify_*` family of static methods.
-impl<H: AlgebraicHasher> MerkleTree<H>
-where
-    H: Sync + Send, // FIXME: Remove these.
-{
+impl<H: AlgebraicHasher> MerkleTree<H> {
     /// Calculate a Merkle root from a list of digests that is not necessarily a power of two.
     pub fn root_from_arbitrary_number_of_digests(digests: &[Digest]) -> Digest {
         // This function should preferably construct a whole Merkle tree data structure and not just the root,
@@ -1006,8 +1003,6 @@ mod merkle_tree_test {
         // through tests of `verify_authentication_structure_from_leaves` from which it is called.
         type H = blake3::Hasher;
 
-        let hasher = H::new();
-
         // 1: Create Merkle tree
         //
         //     root
@@ -1133,7 +1128,7 @@ mod merkle_tree_test {
         ));
 
         // 5: Change the value and verify that the proof does not work
-        let mut corrupt_leaf_a_digest = corrupt_digest(&leaf_a_digest);
+        let corrupt_leaf_a_digest = corrupt_digest(&leaf_a_digest);
         assert!(!SMT::verify_authentication_path(
             tree_a.get_root(),
             leaf_a_idx as u32,
@@ -1419,7 +1414,6 @@ mod merkle_tree_test {
         type H = blake3::Hasher;
         type SMT = SaltedMerkleTree<H>;
 
-        let hasher = H::new();
         let mut rng = rand::thread_rng();
 
         // Number of Merkle tree leaves
@@ -1465,7 +1459,7 @@ mod merkle_tree_test {
                     &selected_leaves,
                     &proof,
                 ));
-                let mut bad_root_hash = corrupt_digest(&tree.get_root());
+                let bad_root_hash = corrupt_digest(&tree.get_root());
 
                 assert!(!SMT::verify_authentication_structure(
                     bad_root_hash,

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -92,7 +92,7 @@ impl<H: AlgebraicHasher> MerkleTree<H> {
             "Size of input for Merkle tree must be a power of 2"
         );
 
-        let filler = digests[0].clone();
+        let filler = digests[0];
 
         // nodes[0] is never used for anything.
         let mut nodes = vec![filler; 2 * leaves_count];
@@ -151,7 +151,7 @@ impl<H: AlgebraicHasher> MerkleTree<H> {
         while node_index > 1 {
             // We get the sibling node by XOR'ing with 1.
             let sibling_i = node_index ^ 1;
-            auth_path.push(self.nodes[sibling_i].clone());
+            auth_path.push(self.nodes[sibling_i]);
             node_index /= 2;
         }
 
@@ -207,7 +207,7 @@ impl<H: AlgebraicHasher> MerkleTree<H> {
         }
 
         let mut i = node_index >> level_in_tree;
-        let mut acc_hash = partial_tree[&(i as u64)].clone();
+        let mut acc_hash = partial_tree[&(i as u64)];
         while i / 2 >= 1 {
             if i % 2 == 0 {
                 acc_hash = H::hash_pair(&acc_hash, &auth_path[level_in_tree]);
@@ -330,12 +330,12 @@ impl<H: AlgebraicHasher> MerkleTree<H> {
             let mut index = half_tree_size + *i as u64;
 
             // Insert hashes for known leaf hashes.
-            partial_tree.insert(index, leaf_hash.clone());
+            partial_tree.insert(index, *leaf_hash);
 
             // Insert hashes for known leaves from partial authentication paths.
             for hash_option in partial_auth_path.0.iter() {
                 if let Some(hash) = hash_option {
-                    partial_tree.insert(index ^ 1, hash.clone());
+                    partial_tree.insert(index ^ 1, *hash);
                 }
                 index /= 2;
             }
@@ -406,10 +406,9 @@ impl<H: AlgebraicHasher> MerkleTree<H> {
                         return false;
                     }
 
-                    *elem = Some(partial_tree[&sibling].clone());
+                    *elem = Some(partial_tree[&sibling]);
                 }
-                let elem_for_reals = elem.as_ref().unwrap();
-                partial_tree.insert(sibling, elem_for_reals.clone());
+                partial_tree.insert(sibling, elem.unwrap());
                 index /= 2;
             }
         }
@@ -471,7 +470,7 @@ impl<H: AlgebraicHasher> MerkleTree<H> {
     }
 
     pub fn get_root(&self) -> Digest {
-        self.nodes[1].clone()
+        self.nodes[1]
     }
 
     pub fn get_leaf_count(&self) -> usize {
@@ -496,7 +495,7 @@ impl<H: AlgebraicHasher> MerkleTree<H> {
             index < first_leaf_index || beyond_last_leaf_index <= index,
             "Out of bounds index requested"
         );
-        self.nodes[first_leaf_index + index].clone()
+        self.nodes[first_leaf_index + index]
     }
 
     pub fn get_leaves_by_indices(&self, leaf_indices: &[usize]) -> Vec<Digest> {
@@ -530,13 +529,13 @@ where
             "Size of input for Merkle tree must be a power of 2"
         );
 
-        let filler = leaves[0].clone();
+        let filler = leaves[0];
 
         // nodes[0] is never used for anything.
         let mut nodes: Vec<Digest> = vec![filler; 2 * leaves.len()];
 
         for i in 0..leaves.len() {
-            let value = leaves[i].clone();
+            let value = leaves[i];
             let leaf_digest = H::hash_pair(&value, &salts[i]);
 
             nodes[leaves.len() + i] = leaf_digest;
@@ -544,8 +543,8 @@ where
 
         // loop from `len(L) - 1` to 1
         for i in (1..(nodes.len() / 2)).rev() {
-            let left = nodes[i * 2].clone();
-            let right = nodes[i * 2 + 1].clone();
+            let left = nodes[i * 2];
+            let right = nodes[i * 2 + 1];
             nodes[i] = H::hash_pair(&left, &right);
         }
 
@@ -560,7 +559,7 @@ where
 
     pub fn get_authentication_path_and_salt(&self, index: usize) -> (Vec<Digest>, Digest) {
         let authentication_path = self.internal_merkle_tree.get_authentication_path(index);
-        let salt = self.salts[index].clone();
+        let salt = self.salts[index];
 
         (authentication_path, salt)
     }
@@ -593,7 +592,7 @@ where
         // salts are random data, so they cannot be compressed
         let mut ret: SaltedAuthenticationStructure<Digest> = Vec::with_capacity(indices.len());
         for (i, index) in indices.iter().enumerate() {
-            let salt = self.salts[*index].clone();
+            let salt = self.salts[*index];
             ret.push((partial_authentication_paths[i].clone(), salt));
         }
 
@@ -660,7 +659,7 @@ where
             index < first_leaf_index || beyond_last_leaf_index <= index,
             "Out of bounds index requested"
         );
-        self.internal_merkle_tree.nodes[first_leaf_index + index].clone()
+        self.internal_merkle_tree.nodes[first_leaf_index + index]
     }
 
     pub fn get_salted_leaves_by_indices(&self, leaf_indices: &[usize]) -> Vec<Digest> {

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -1,43 +1,40 @@
-use super::{
-    mmr_accumulator::MmrAccumulator,
-    mmr_trait::Mmr,
-    shared::{
-        data_index_to_node_index, left_child, left_sibling, leftmost_ancestor,
-        node_index_to_data_index, parent, right_child_and_height, right_sibling,
-    },
+use std::marker::PhantomData;
+
+use super::mmr_accumulator::MmrAccumulator;
+use super::mmr_membership_proof::MmrMembershipProof;
+use super::mmr_trait::Mmr;
+use super::shared::{
+    data_index_to_node_index, left_child, left_sibling, leftmost_ancestor,
+    node_index_to_data_index, parent, right_child_and_height, right_sibling,
 };
-use crate::{
-    util_types::{
-        database_vector::DatabaseVector,
-        mmr::mmr_membership_proof::MmrMembershipProof,
-        shared::bag_peaks,
-        simple_hasher::{Hashable, Hasher},
-    },
-    utils::has_unique_elements,
-};
+use crate::shared_math::rescue_prime_digest::Digest;
+use crate::util_types::algebraic_hasher::AlgebraicHasher;
+use crate::util_types::database_vector::DatabaseVector;
+use crate::util_types::shared::bag_peaks;
+use crate::utils::has_unique_elements;
 use rusty_leveldb::DB;
 
 /// A Merkle Mountain Range is a datastructure for storing a list of hashes.
 ///
 /// Merkle Mountain Ranges only know about hashes. When values are to be associated with
 /// MMRs, these values must be stored by the caller, or in a wrapper to this data structure.
-pub struct ArchivalMmr<H: Hasher> {
-    digests: DatabaseVector<H::Digest>,
+pub struct ArchivalMmr<H: AlgebraicHasher> {
+    digests: DatabaseVector<Digest>,
+    _hasher: PhantomData<H>,
 }
 
 impl<H> Mmr<H> for ArchivalMmr<H>
 where
-    H: Hasher,
-    u128: Hashable<H::T>,
+    H: AlgebraicHasher + Send + Sync,
 {
     /// Calculate the root for the entire MMR
-    fn bag_peaks(&mut self) -> <H as Hasher>::Digest {
-        let peaks: Vec<H::Digest> = self.get_peaks();
+    fn bag_peaks(&mut self) -> Digest {
+        let peaks: Vec<Digest> = self.get_peaks();
         bag_peaks::<H>(&peaks)
     }
 
     /// Return the digests of the peaks of the MMR
-    fn get_peaks(&mut self) -> Vec<<H as Hasher>::Digest> {
+    fn get_peaks(&mut self) -> Vec<Digest> {
         let peaks_and_heights = self.get_peaks_with_heights();
         peaks_and_heights.into_iter().map(|x| x.0).collect()
     }
@@ -61,7 +58,7 @@ where
     /// The membership proof is returned here since the accumulater MMR has no other way of
     /// retrieving a membership proof for a leaf. And the archival and accumulator MMR share
     /// this interface.
-    fn append(&mut self, new_leaf: H::Digest) -> MmrMembershipProof<H> {
+    fn append(&mut self, new_leaf: Digest) -> MmrMembershipProof<H> {
         let node_index = self.digests.len() as u128;
         let data_index = node_index_to_data_index(node_index).unwrap();
         self.append_raw(new_leaf);
@@ -71,7 +68,7 @@ where
     /// Mutate an existing leaf. It is the caller's responsibility that the
     /// membership proof is valid. If the membership proof is wrong, the MMR
     /// will end up in a broken state.
-    fn mutate_leaf(&mut self, old_membership_proof: &MmrMembershipProof<H>, new_leaf: &H::Digest) {
+    fn mutate_leaf(&mut self, old_membership_proof: &MmrMembershipProof<H>, new_leaf: &Digest) {
         // Sanity check
         let real_membership_proof: MmrMembershipProof<H> =
             self.prove_membership(old_membership_proof.data_index).0;
@@ -86,7 +83,7 @@ where
     fn batch_mutate_leaf_and_update_mps(
         &mut self,
         membership_proofs: &mut [&mut MmrMembershipProof<H>],
-        mutation_data: Vec<(MmrMembershipProof<H>, <H as Hasher>::Digest)>,
+        mutation_data: Vec<(MmrMembershipProof<H>, Digest)>,
     ) -> Vec<usize> {
         assert!(
             has_unique_elements(mutation_data.iter().map(|md| md.0.data_index)),
@@ -112,9 +109,9 @@ where
 
     fn verify_batch_update(
         &mut self,
-        new_peaks: &[H::Digest],
-        appended_leafs: &[H::Digest],
-        leaf_mutations: &[(H::Digest, MmrMembershipProof<H>)],
+        new_peaks: &[Digest],
+        appended_leafs: &[Digest],
+        leaf_mutations: &[(Digest, MmrMembershipProof<H>)],
     ) -> bool {
         let mut accumulator: MmrAccumulator<H> = self.into();
         accumulator.verify_batch_update(new_peaks, appended_leafs, leaf_mutations)
@@ -125,23 +122,23 @@ where
     }
 }
 
-impl<H> ArchivalMmr<H>
-where
-    H: Hasher,
-    u128: Hashable<H::T>,
-{
+impl<H: AlgebraicHasher> ArchivalMmr<H> {
     /// Create a new, empty archival MMR
     pub fn new(db: DB) -> Self {
-        let mut db_vector: DatabaseVector<H::Digest> = DatabaseVector::new(db);
-        let dummy_digest = H::new().hash_sequence(&0u128.to_sequence());
+        let mut db_vector: DatabaseVector<Digest> = DatabaseVector::new(db);
+        let dummy_digest = H::hash(&0u128);
         db_vector.push(dummy_digest);
-        Self { digests: db_vector }
+        Self {
+            digests: db_vector,
+            _hasher: PhantomData,
+        }
     }
 
     /// Restore an archival MMR object from a database object
     pub fn restore(db: DB) -> Self {
         Self {
             digests: DatabaseVector::restore(db),
+            _hasher: PhantomData,
         }
     }
 
@@ -151,14 +148,14 @@ where
     }
 
     /// Get a leaf from the MMR, will panic if index is out of range
-    pub fn get_leaf(&mut self, data_index: u128) -> H::Digest {
+    pub fn get_leaf(&mut self, data_index: u128) -> Digest {
         let node_index = data_index_to_node_index(data_index);
         // self.digests[node_index as usize].clone()
         self.digests.get(node_index)
     }
 
     /// Update a hash in the existing archival MMR
-    pub fn mutate_leaf_raw(&mut self, data_index: u128, new_leaf: H::Digest) {
+    pub fn mutate_leaf_raw(&mut self, data_index: u128, new_leaf: Digest) {
         // 1. change the leaf value
         let mut node_index = data_index_to_node_index(data_index);
         // self.digests[node_index as usize] = new_leaf.clone();
@@ -167,21 +164,18 @@ where
         // 2. Calculate hash changes for all parents
         let mut parent_index = parent(node_index);
         let mut acc_hash = new_leaf;
-        let hasher = H::new();
 
         // While parent exists in MMR, update parent
         while parent_index < self.digests.len() as u128 {
             let (is_right, height) = right_child_and_height(node_index);
             acc_hash = if is_right {
-                hasher.hash_pair(
-                    // &self.digests[left_sibling(node_index, height) as usize],
+                H::hash_pair(
                     &self.digests.get(left_sibling(node_index, height)),
                     &acc_hash,
                 )
             } else {
-                hasher.hash_pair(
+                H::hash_pair(
                     &acc_hash,
-                    // &self.digests[right_sibling(node_index, height) as usize],
                     &self.digests.get(right_sibling(node_index, height)),
                 )
             };
@@ -193,10 +187,7 @@ where
     }
 
     /// Return (membership_proof, peaks)
-    pub fn prove_membership(
-        &mut self,
-        data_index: u128,
-    ) -> (MmrMembershipProof<H>, Vec<H::Digest>) {
+    pub fn prove_membership(&mut self, data_index: u128) -> (MmrMembershipProof<H>, Vec<Digest>) {
         // A proof consists of an authentication path
         // and a list of peaks
         assert!(data_index < self.count_leaves());
@@ -211,7 +202,7 @@ where
         }
 
         // Build the authentication path
-        let mut authentication_path: Vec<H::Digest> = vec![];
+        let mut authentication_path: Vec<Digest> = vec![];
         let mut index = node_index;
         let (mut index_is_right_child, mut index_height): (bool, u128) =
             right_child_and_height(index);
@@ -231,22 +222,19 @@ where
             index_height = next_index_info.1;
         }
 
-        let peaks: Vec<H::Digest> = self
+        let peaks: Vec<Digest> = self
             .get_peaks_with_heights()
             .iter()
             .map(|x| x.0.clone())
             .collect();
 
-        let membership_proof = MmrMembershipProof {
-            authentication_path,
-            data_index,
-        };
+        let membership_proof = MmrMembershipProof::new(data_index, authentication_path);
 
         (membership_proof, peaks)
     }
 
     /// Return a list of tuples (peaks, height)
-    pub fn get_peaks_with_heights(&mut self) -> Vec<(H::Digest, u128)> {
+    pub fn get_peaks_with_heights(&mut self) -> Vec<(Digest, u128)> {
         if self.is_empty() {
             return vec![];
         }
@@ -256,7 +244,7 @@ where
         // 3. Take left child of sibling, continue until a node in tree is found
         // 4. Once new node is found, jump to right sibling (will not be included)
         // 5. Take left child of sibling, continue until a node in tree is found
-        let mut peaks_and_heights: Vec<(H::Digest, u128)> = vec![];
+        let mut peaks_and_heights: Vec<(Digest, u128)> = vec![];
         let (mut top_peak, mut top_height) = leftmost_ancestor(self.digests.len() as u128 - 1);
         if top_peak > self.digests.len() as u128 - 1 {
             top_peak = left_child(top_peak, top_height);
@@ -283,22 +271,19 @@ where
     }
 
     /// Append an element to the archival MMR
-    pub fn append_raw(&mut self, new_leaf: H::Digest) {
+    pub fn append_raw(&mut self, new_leaf: Digest) {
         let node_index = self.digests.len() as u128;
         self.digests.push(new_leaf.clone());
         let (parent_needed, own_height) = right_child_and_height(node_index);
         if parent_needed {
-            let left_sibling_hash =
-                // self.digests[left_sibling(node_index, own_height) as usize].clone();
-                self.digests.get(left_sibling(node_index, own_height));
-            let hasher = H::new();
-            let parent_hash: H::Digest = hasher.hash_pair(&left_sibling_hash, &new_leaf);
+            let left_sibling_hash = self.digests.get(left_sibling(node_index, own_height));
+            let parent_hash: Digest = H::hash_pair(&left_sibling_hash, &new_leaf);
             self.append_raw(parent_hash);
         }
     }
 
     /// Remove the last leaf from the archival MMR
-    pub fn remove_last_leaf(&mut self) -> Option<H::Digest> {
+    pub fn remove_last_leaf(&mut self) -> Option<Digest> {
         if self.is_empty() {
             return None;
         }
@@ -318,9 +303,9 @@ where
 #[cfg(test)]
 mod mmr_test {
     use super::*;
+    use crate::shared_math::other::random_elements;
     use crate::shared_math::rescue_prime_regular::RescuePrimeRegular;
     use crate::test_shared::mmr::{get_archival_mmr_from_digests, get_empty_archival_mmr};
-    use crate::util_types::blake3_wrapper::Blake3Hash;
     use crate::util_types::merkle_tree::MerkleTree;
     use crate::{
         shared_math::b_field_element::BFieldElement,
@@ -330,8 +315,9 @@ mod mmr_test {
         },
     };
     use itertools::izip;
+    use rand::Rng;
 
-    impl<H: Hasher> ArchivalMmr<H> {
+    impl<H: AlgebraicHasher> ArchivalMmr<H> {
         /// Return the number of nodes in all the trees in the MMR
         fn count_nodes(&mut self) -> u128 {
             self.digests.len() as u128 - 1
@@ -340,19 +326,19 @@ mod mmr_test {
 
     #[test]
     fn empty_mmr_behavior_test() {
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
-        let mut archival_mmr: ArchivalMmr<Hasher> = get_empty_archival_mmr();
-        let mut accumulator_mmr: MmrAccumulator<Hasher> = MmrAccumulator::<Hasher>::new(vec![]);
+        let mut archival_mmr: ArchivalMmr<H> = get_empty_archival_mmr();
+        let mut accumulator_mmr: MmrAccumulator<H> = MmrAccumulator::<H>::new(vec![]);
 
         assert_eq!(0, archival_mmr.count_leaves());
         assert_eq!(0, accumulator_mmr.count_leaves());
         assert_eq!(archival_mmr.get_peaks(), accumulator_mmr.get_peaks());
-        assert_eq!(Vec::<Blake3Hash>::new(), accumulator_mmr.get_peaks());
+        assert_eq!(Vec::<Digest>::new(), accumulator_mmr.get_peaks());
         assert_eq!(archival_mmr.bag_peaks(), accumulator_mmr.bag_peaks());
         assert_eq!(
             archival_mmr.bag_peaks(),
-            MerkleTree::<Hasher>::root_from_arbitrary_number_of_digests(&vec![]),
+            MerkleTree::<H>::root_from_arbitrary_number_of_digests(&vec![]),
             "Bagged peaks for empty MMR must agree with MT root finder"
         );
         assert_eq!(0, archival_mmr.count_nodes());
@@ -360,7 +346,7 @@ mod mmr_test {
         assert!(archival_mmr.is_empty());
 
         // Test behavior of appending to an empty MMR
-        let new_leaf: Blake3Hash = 0xbeefu128.into();
+        let new_leaf = H::hash(&0xbeefu128);
 
         let mut archival_mmr_appended = get_empty_archival_mmr();
         let archival_membership_proof = archival_mmr_appended.append(new_leaf);
@@ -411,8 +397,7 @@ mod mmr_test {
 
     #[test]
     fn verify_against_correct_peak_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
         // This test addresses a bug that was discovered late in the development process
         // where it was possible to fake a verification proof by providing a valid leaf
@@ -420,14 +405,11 @@ mod mmr_test {
         // because the derived hash was compared against all of the peaks to find a match
         // and it wasn't verified that the accumulated hash matched the *correct* peak.
         // This error was fixed and this test fails without that fix.
-        let leaf_hashes: Vec<Blake3Hash> = vec![14u128, 15u128, 16u128]
-            .iter()
-            .map(|&x| x.into())
-            .collect();
+        let leaf_hashes: Vec<Digest> = random_elements(3);
 
         // let archival_mmr = ArchivalMmr::<Hasher>::new(leaf_hashes.clone());
         let mut archival_mmr = get_archival_mmr_from_digests(leaf_hashes.clone());
-        let (mut membership_proof, peaks): (MmrMembershipProof<Hasher>, Vec<Digest>) =
+        let (mut membership_proof, peaks): (MmrMembershipProof<H>, Vec<Digest>) =
             archival_mmr.prove_membership(0);
 
         // Verify that the accumulated hash in the verifier is compared against the **correct** hash,
@@ -438,7 +420,7 @@ mod mmr_test {
         membership_proof.data_index = 0;
 
         // verify the same behavior in the accumulator MMR
-        let mut accumulator_mmr = MmrAccumulator::<Hasher>::new(leaf_hashes.clone());
+        let mut accumulator_mmr = MmrAccumulator::<H>::new(leaf_hashes.clone());
         assert!(
             membership_proof
                 .verify(
@@ -462,23 +444,17 @@ mod mmr_test {
 
     #[test]
     fn mutate_leaf_archival_test() {
-        type Digest = [BFieldElement; 5];
-        type Hasher = RescuePrimeRegular;
+        type H = RescuePrimeRegular;
 
-        let rp = RescuePrimeRegular::new();
-        let leaf_hashes: Vec<Digest> = (14..17)
-            .map(|x| rp.hash_sequence(&vec![BFieldElement::new(x)]))
-            .collect();
-        // let mut archival_mmr = ArchivalMmr::<Hasher>::new(leaf_hashes.clone());
+        let leaf_hashes: Vec<Digest> = random_elements(3);
         let mut archival_mmr = get_archival_mmr_from_digests(leaf_hashes.clone());
-        let (mp, old_peaks): (MmrMembershipProof<Hasher>, Vec<Digest>) =
+        let (mp, old_peaks): (MmrMembershipProof<H>, Vec<Digest>) =
             archival_mmr.prove_membership(2);
 
         assert!(mp.verify(&old_peaks, &leaf_hashes[2], 3).0);
-        let new_leaf = rp.hash_sequence(&vec![BFieldElement::new(10000)]);
+        let new_leaf = H::hash(&BFieldElement::new(10000));
 
-        // let mut archival_mmr_clone = archival_mmr.clone();
-        let mut archival_mmr_clone: ArchivalMmr<Hasher> =
+        let mut archival_mmr_clone: ArchivalMmr<H> =
             get_archival_mmr_from_digests(leaf_hashes.clone());
         let mp = archival_mmr_clone.prove_membership(2).0;
         archival_mmr_clone.mutate_leaf(&mp, &new_leaf);
@@ -501,12 +477,11 @@ mod mmr_test {
         // Create a new archival MMR with the same leaf hashes as in the
         // modified MMR, and verify that the two MMRs are equivalent
         let leaf_hashes_new = vec![
-            rp.hash_sequence(&vec![BFieldElement::new(14)]),
-            rp.hash_sequence(&vec![BFieldElement::new(15)]),
-            rp.hash_sequence(&vec![BFieldElement::new(10000)]),
+            H::hash(&BFieldElement::new(14)),
+            H::hash(&BFieldElement::new(15)),
+            H::hash(&BFieldElement::new(10000)),
         ];
-        let mut archival_mmr_new: ArchivalMmr<Hasher> =
-            get_archival_mmr_from_digests(leaf_hashes_new);
+        let mut archival_mmr_new: ArchivalMmr<H> = get_archival_mmr_from_digests(leaf_hashes_new);
         // let archival_mmr_new = ArchivalMmr::<Hasher>::new(leaf_hashes_new);
         assert_eq!(archival_mmr.digests.len(), archival_mmr_new.digests.len());
         for i in 0..3 {
@@ -514,28 +489,19 @@ mod mmr_test {
         }
     }
 
-    #[test]
-    fn bag_peaks_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
-
+    fn bag_peaks_gen<H: AlgebraicHasher>() {
         // Verify that archival and accumulator MMR produce the same root
-        // First with blake3
-        let leaf_hashes_blake3: Vec<Digest> = vec![14u128, 15u128, 16u128]
-            .iter()
-            .map(|&x| x.into())
-            .collect();
-        // let archival_mmr_small = ArchivalMmr::<Hasher>::new(leaf_hashes_blake3.clone());
-        let mut archival_mmr_small: ArchivalMmr<Hasher> =
+        let leaf_hashes_blake3: Vec<Digest> = random_elements(3);
+        let mut archival_mmr_small: ArchivalMmr<H> =
             get_archival_mmr_from_digests(leaf_hashes_blake3.clone());
-        let mut accumulator_mmr_small = MmrAccumulator::<Hasher>::new(leaf_hashes_blake3);
+        let mut accumulator_mmr_small = MmrAccumulator::<H>::new(leaf_hashes_blake3);
         assert_eq!(
             archival_mmr_small.bag_peaks(),
             accumulator_mmr_small.bag_peaks()
         );
         assert_eq!(
             archival_mmr_small.bag_peaks(),
-            bag_peaks::<Hasher>(&accumulator_mmr_small.get_peaks())
+            bag_peaks::<H>(&accumulator_mmr_small.get_peaks())
         );
         assert!(!accumulator_mmr_small
             .get_peaks()
@@ -544,72 +510,28 @@ mod mmr_test {
     }
 
     #[test]
-    fn bag_peaks_rp_test() {
-        type Digest = [BFieldElement; 5];
-        type Hasher = RescuePrimeRegular;
-        let rp = Hasher::new();
-
-        // Then with Rescue Prime
-        let leaf_hashes_rescue_prime: Vec<Digest> = (14..17)
-            .map(|x| rp.hash_sequence(&vec![BFieldElement::new(x)]))
-            .collect();
-        // let archival_mmr_small_rp = ArchivalMmr::<Hasher>::new(leaf_hashes_rescue_prime.clone());
-        let mut archival_mmr_small_rp: ArchivalMmr<Hasher> =
-            get_archival_mmr_from_digests(leaf_hashes_rescue_prime.clone());
-        let mut accumulator_mmr_small_rp = MmrAccumulator::<Hasher>::new(leaf_hashes_rescue_prime);
-        assert_eq!(
-            archival_mmr_small_rp.bag_peaks(),
-            accumulator_mmr_small_rp.bag_peaks()
-        );
-        assert!(!accumulator_mmr_small_rp
-            .get_peaks()
-            .iter()
-            .any(|peak| *peak == accumulator_mmr_small_rp.bag_peaks()));
-    }
-
-    #[test]
     fn bag_peaks_blake3_test() {
-        type Hasher = blake3::Hasher;
-
-        // Then with a bigger dataset
-        let leaf_hashes_bigger_blake3: Vec<Blake3Hash> =
-            vec![14u128, 15u128, 16u128, 206, 1232, 123, 9989]
-                .iter()
-                .map(|&x| x.into())
-                .collect();
-        // let archival_mmr_bigger = ArchivalMmr::<Hasher>::new(leaf_hashes_bigger_blake3.clone());
-        let mut archival_mmr_bigger: ArchivalMmr<Hasher> =
-            get_archival_mmr_from_digests(leaf_hashes_bigger_blake3.clone());
-        let mut accumulator_mmr_bigger = MmrAccumulator::<Hasher>::new(leaf_hashes_bigger_blake3);
-        assert_eq!(
-            archival_mmr_bigger.bag_peaks(),
-            accumulator_mmr_bigger.bag_peaks()
-        );
-        assert!(!accumulator_mmr_bigger
-            .get_peaks()
-            .iter()
-            .any(|peak| *peak == accumulator_mmr_bigger.bag_peaks()));
+        bag_peaks_gen::<blake3::Hasher>();
+        bag_peaks_gen::<RescuePrimeRegular>();
     }
 
     #[test]
     fn accumulator_mmr_mutate_leaf_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
         // Verify that upating leafs in archival and in accumulator MMR results in the same peaks
         // and verify that updating all leafs in an MMR results in the expected MMR
         for size in 1..150 {
-            let new_leaf: Digest = 314159265358979u128.into();
-            let leaf_hashes_blake3: Vec<Digest> = (500u128..500 + size).map(|x| x.into()).collect();
+            let new_leaf: Digest = H::hash(&314159265358979u128);
+            let leaf_hashes_blake3: Vec<Digest> = random_elements(size);
 
-            let mut acc = MmrAccumulator::<Hasher>::new(leaf_hashes_blake3.clone());
-            // let mut archival = ArchivalMmr::<Hasher>::new(leaf_hashes_blake3.clone());
-            let mut archival: ArchivalMmr<Hasher> =
+            let mut acc = MmrAccumulator::<H>::new(leaf_hashes_blake3.clone());
+            let mut archival: ArchivalMmr<H> =
                 get_archival_mmr_from_digests(leaf_hashes_blake3.clone());
-            // let archival_end_state = ArchivalMmr::<Hasher>::new(vec![new_leaf; size as usize]);
-            let mut archival_end_state: ArchivalMmr<Hasher> =
+            let mut archival_end_state: ArchivalMmr<H> =
                 get_archival_mmr_from_digests(vec![new_leaf; size as usize]);
             for i in 0..size {
+                let i = i as u128;
                 let (mp, _archival_peaks) = archival.prove_membership(i);
                 assert_eq!(i, mp.data_index);
                 acc.mutate_leaf(&mp, &new_leaf);
@@ -624,21 +546,19 @@ mod mmr_test {
 
     #[test]
     fn mmr_prove_verify_leaf_mutation_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
         for size in 1..150 {
-            let new_leaf: Digest = 314159265358979u128.into();
-            let bad_leaf: Digest = 27182818284590452353u128.into();
-            let leaf_hashes_blake3: Vec<Digest> = (500u128..500 + size).map(|x| x.into()).collect();
-            let mut acc = MmrAccumulator::<Hasher>::new(leaf_hashes_blake3.clone());
-            // let mut archival = ArchivalMmr::<Hasher>::new(leaf_hashes_blake3.clone());
-            let mut archival: ArchivalMmr<Hasher> =
+            let new_leaf: Digest = H::hash(&314159265358979u128);
+            let bad_leaf: Digest = H::hash(&27182818284590452353u128);
+            let leaf_hashes_blake3: Vec<Digest> = random_elements(size);
+            let mut acc = MmrAccumulator::<H>::new(leaf_hashes_blake3.clone());
+            let mut archival: ArchivalMmr<H> =
                 get_archival_mmr_from_digests(leaf_hashes_blake3.clone());
-            // let archival_end_state = ArchivalMmr::<Hasher>::new(vec![new_leaf; size as usize]);
-            let mut archival_end_state: ArchivalMmr<Hasher> =
+            let mut archival_end_state: ArchivalMmr<H> =
                 get_archival_mmr_from_digests(vec![new_leaf; size as usize]);
             for i in 0..size {
+                let i = i as u128;
                 let (mp, peaks_before_update) = archival.prove_membership(i);
                 assert_eq!(archival.get_peaks(), peaks_before_update);
 
@@ -656,8 +576,8 @@ mod mmr_test {
                 acc.mutate_leaf(&mp, &new_leaf);
                 let new_archival_peaks = archival.get_peaks();
                 assert_eq!(new_archival_peaks, acc.get_peaks());
-                assert_eq!(size, archival.count_leaves());
-                assert_eq!(size, acc.count_leaves());
+                assert_eq!(size as u128, archival.count_leaves());
+                assert_eq!(size as u128, acc.count_leaves());
             }
             assert_eq!(archival_end_state.get_peaks(), acc.get_peaks());
         }
@@ -665,21 +585,18 @@ mod mmr_test {
 
     #[test]
     fn mmr_append_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
         // Verify that building an MMR iteratively or in *one* function call results in the same MMR
         for size in 1..260 {
-            let leaf_hashes_blake3: Vec<Digest> = (500u128..500 + size).map(|x| x.into()).collect();
-            // let mut archival_iterative = ArchivalMmr::<Hasher>::new(vec![]);
-            let mut archival_iterative: ArchivalMmr<Hasher> = get_archival_mmr_from_digests(vec![]);
-            // let archival_batch = ArchivalMmr::<Hasher>::new(leaf_hashes_blake3.clone());
-            let mut archival_batch: ArchivalMmr<Hasher> =
+            let leaf_hashes_blake3: Vec<Digest> = random_elements(size);
+            let mut archival_iterative: ArchivalMmr<H> = get_archival_mmr_from_digests(vec![]);
+            let mut archival_batch: ArchivalMmr<H> =
                 get_archival_mmr_from_digests(leaf_hashes_blake3.clone());
-            let mut accumulator_iterative = MmrAccumulator::<Hasher>::new(vec![]);
-            let mut accumulator_batch = MmrAccumulator::<Hasher>::new(leaf_hashes_blake3.clone());
+            let mut accumulator_iterative = MmrAccumulator::<H>::new(vec![]);
+            let mut accumulator_batch = MmrAccumulator::<H>::new(leaf_hashes_blake3.clone());
             for (data_index, leaf_hash) in leaf_hashes_blake3.clone().into_iter().enumerate() {
-                let archival_membership_proof: MmrMembershipProof<Hasher> =
+                let archival_membership_proof: MmrMembershipProof<H> =
                     archival_iterative.append(leaf_hash);
                 let accumulator_membership_proof = accumulator_iterative.append(leaf_hash);
 
@@ -698,15 +615,13 @@ mod mmr_test {
                         .0
                 );
 
-                // Verify that membership proofs are the same as generating them from an
-                // archival MMR
+                // Verify that membership proofs are the same as generating them from an archival MMR
                 let archival_membership_proof_direct =
                     archival_iterative.prove_membership(data_index as u128).0;
                 assert_eq!(archival_membership_proof_direct, archival_membership_proof);
             }
 
-            // Verify that the MMRs built iteratively from `append` and
-            // in *one* batch are the same
+            // Verify that the MMRs built iteratively from `append` and in *one* batch are the same
             assert_eq!(
                 accumulator_batch.get_peaks(),
                 accumulator_iterative.get_peaks()
@@ -715,14 +630,14 @@ mod mmr_test {
                 accumulator_batch.count_leaves(),
                 accumulator_iterative.count_leaves()
             );
-            assert_eq!(size, accumulator_iterative.count_leaves());
+            assert_eq!(size as u128, accumulator_iterative.count_leaves());
             assert_eq!(
                 archival_iterative.get_peaks(),
                 accumulator_iterative.get_peaks()
             );
 
             // Run a batch-append verification on the entire mutation of the MMR and verify that it succeeds
-            let mut empty_accumulator = MmrAccumulator::<Hasher>::new(vec![]);
+            let mut empty_accumulator = MmrAccumulator::<H>::new(vec![]);
             assert!(empty_accumulator.verify_batch_update(
                 &archival_batch.get_peaks(),
                 &leaf_hashes_blake3,
@@ -733,18 +648,14 @@ mod mmr_test {
 
     #[test]
     fn one_input_mmr_test() {
-        type Digest = [BFieldElement; 5];
-        type Hasher = RescuePrimeRegular;
+        type H = RescuePrimeRegular;
 
-        let element = vec![BFieldElement::new(14)];
-        let rp = RescuePrimeRegular::new();
-        let input_hash = rp.hash_sequence(&element);
-        let new_input_hash = rp.hash_sequence(&vec![BFieldElement::new(201)]);
-        // let mut mmr = ArchivalMmr::<Hasher>::new(vec![input_hash.clone()]);
-        let mut mmr: ArchivalMmr<Hasher> = get_archival_mmr_from_digests(vec![input_hash.clone()]);
-        let mut original_mmr: ArchivalMmr<Hasher> =
+        let input_hash = H::hash(&BFieldElement::new(14));
+        let new_input_hash = H::hash(&BFieldElement::new(201));
+        let mut mmr: ArchivalMmr<H> = get_archival_mmr_from_digests(vec![input_hash.clone()]);
+        let mut original_mmr: ArchivalMmr<H> =
             get_archival_mmr_from_digests(vec![input_hash.clone()]);
-        let mut mmr_after_append: ArchivalMmr<Hasher> =
+        let mut mmr_after_append: ArchivalMmr<H> =
             get_archival_mmr_from_digests(vec![input_hash.clone(), new_input_hash.clone()]);
         assert_eq!(1, mmr.count_leaves());
         assert_eq!(1, mmr.count_nodes());
@@ -774,12 +685,12 @@ mod mmr_test {
         );
 
         // let mmr_after_append = mmr.clone();
-        let new_leaf: Digest = rp.hash_sequence(&vec![BFieldElement::new(987223)]);
+        let new_leaf: Digest = H::hash(&BFieldElement::new(987223));
 
         // When verifying the batch update with two consequtive leaf mutations, we must get the
         // membership proofs prior to all mutations. This is because the `verify_batch_update` method
         // updates the membership proofs internally to account for the mutations.
-        let leaf_mutations: Vec<(Digest, MmrMembershipProof<Hasher>)> = (0..2)
+        let leaf_mutations: Vec<(Digest, MmrMembershipProof<H>)> = (0..2)
             .map(|i| (new_leaf.clone(), mmr_after_append.prove_membership(i).0))
             .collect();
         for &data_index in &[0u128, 1] {
@@ -800,14 +711,10 @@ mod mmr_test {
 
     #[test]
     fn two_input_mmr_test() {
-        type Hasher = RescuePrimeRegular;
-        type Digest = [BFieldElement; 5];
+        type H = RescuePrimeRegular;
 
-        let values: Vec<Vec<BFieldElement>> = (0..2).map(|x| vec![BFieldElement::new(x)]).collect();
-        let rp = RescuePrimeRegular::new();
-        let input_hashes: Vec<Digest> = values.iter().map(|x| rp.hash_sequence(x)).collect();
-        // let mut mmr = ArchivalMmr::<Hasher>::new(input_hashes.clone());
-        let mut mmr: ArchivalMmr<Hasher> = get_archival_mmr_from_digests(input_hashes.clone());
+        let input_hashes: Vec<Digest> = random_elements(3);
+        let mut mmr: ArchivalMmr<H> = get_archival_mmr_from_digests(input_hashes.clone());
         assert_eq!(2, mmr.count_leaves());
         assert_eq!(3, mmr.count_nodes());
         let original_peaks_and_heights: Vec<(Digest, u128)> = mmr.get_peaks_with_heights();
@@ -827,13 +734,13 @@ mod mmr_test {
                 .0
         );
 
-        let new_leaf_hash: Digest = rp.hash_sequence(&vec![BFieldElement::new(201)]);
+        let new_leaf_hash: Digest = H::hash(&BFieldElement::new(201));
         mmr.append(new_leaf_hash.clone());
         assert_eq!(3, mmr.count_leaves());
         assert_eq!(4, mmr.count_nodes());
 
         for &data_index in &[0u128, 1, 2] {
-            let new_leaf: Digest = rp.hash_sequence(&vec![BFieldElement::new(987223)]);
+            let new_leaf: Digest = H::hash(&BFieldElement::new(987223));
             let mp = mmr.prove_membership(data_index).0;
             mmr.mutate_leaf(&mp, &new_leaf);
             assert_eq!(new_leaf, mmr.get_leaf(data_index));
@@ -842,7 +749,7 @@ mod mmr_test {
 
     #[test]
     fn variable_size_rescue_prime_mmr_test() {
-        type Hasher = RescuePrimeRegular;
+        type H = RescuePrimeRegular;
 
         let node_counts: Vec<u128> = vec![
             1, 3, 4, 7, 8, 10, 11, 15, 16, 18, 19, 22, 23, 25, 26, 31, 32, 34, 35, 38, 39, 41, 42,
@@ -852,33 +759,23 @@ mod mmr_test {
             1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4,
             4, 5, 1, 2,
         ];
-        for (data_size, node_count, peak_count) in
-            izip!((1u128..34).collect::<Vec<u128>>(), node_counts, peak_counts)
-        {
-            let input_prehashes: Vec<Vec<BFieldElement>> = (0..data_size)
-                .map(|x| vec![BFieldElement::new(x as u64 + 14)])
-                .collect();
-            let rp = RescuePrimeRegular::new();
-            type Digest = [BFieldElement; 5];
-            let input_hashes: Vec<Digest> = input_prehashes
-                .iter()
-                .map(|x| rp.hash_sequence(x))
-                .collect();
-            // let mut mmr = ArchivalMmr::<Hasher>::new(input_hashes.clone());
-            let mut mmr: ArchivalMmr<Hasher> = get_archival_mmr_from_digests(input_hashes.clone());
-            assert_eq!(data_size, mmr.count_leaves());
+        let data_sizes: Vec<usize> = (1..34).collect();
+        for (i, node_count, peak_count) in izip!(data_sizes, node_counts, peak_counts) {
+            let data_size = i as u128;
+            let input_hashes: Vec<Digest> = random_elements(i);
+            let mut mmr: ArchivalMmr<H> = get_archival_mmr_from_digests(input_hashes.clone());
+            assert_eq!(data_size as u128, mmr.count_leaves());
             assert_eq!(node_count, mmr.count_nodes());
             let original_peaks_and_heights = mmr.get_peaks_with_heights();
             let peak_heights_1: Vec<u128> =
                 original_peaks_and_heights.iter().map(|x| x.1).collect();
             let (peak_heights_2, _) = get_peak_heights_and_peak_node_indices(data_size);
             assert_eq!(peak_heights_1, peak_heights_2);
-            assert_eq!(peak_count, original_peaks_and_heights.len() as u128);
+            assert_eq!(i, original_peaks_and_heights.len());
 
             // Verify that MMR root from odd number of digests and MMR bagged peaks agree
             let mmra_root = mmr.bag_peaks();
-            let mt_root =
-                MerkleTree::<Hasher>::root_from_arbitrary_number_of_digests(&input_hashes);
+            let mt_root = MerkleTree::<H>::root_from_arbitrary_number_of_digests(&input_hashes);
             assert_eq!(
                 mmra_root, mt_root,
                 "MMRA bagged peaks and MT root must agree"
@@ -896,7 +793,7 @@ mod mmr_test {
             }
 
             // // Make a new MMR where we append with a value and run the verify_append
-            let new_leaf_hash = rp.hash_sequence(&vec![BFieldElement::new(201)]);
+            let new_leaf_hash = H::hash(&BFieldElement::new(201));
             let orignal_peaks = mmr.get_peaks();
             let mp = mmr.append(new_leaf_hash.clone());
             assert!(
@@ -913,35 +810,34 @@ mod mmr_test {
 
     #[test]
     fn remove_last_leaf_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
-        let input_prehashes: Vec<Digest> = (0..12).map(|x| (x + 14).into()).collect();
-        let mut mmr: ArchivalMmr<Hasher> = get_archival_mmr_from_digests(input_prehashes.clone());
+        let input_digests: Vec<Digest> = random_elements(12);
+        let mut mmr: ArchivalMmr<H> = get_archival_mmr_from_digests(input_digests.clone());
         assert_eq!(22, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[11]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[11]), mmr.remove_last_leaf());
         assert_eq!(19, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[10]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[10]), mmr.remove_last_leaf());
         assert_eq!(18, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[9]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[9]), mmr.remove_last_leaf());
         assert_eq!(16, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[8]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[8]), mmr.remove_last_leaf());
         assert_eq!(15, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[7]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[7]), mmr.remove_last_leaf());
         assert_eq!(11, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[6]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[6]), mmr.remove_last_leaf());
         assert_eq!(10, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[5]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[5]), mmr.remove_last_leaf());
         assert_eq!(8, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[4]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[4]), mmr.remove_last_leaf());
         assert_eq!(7, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[3]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[3]), mmr.remove_last_leaf());
         assert_eq!(4, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[2]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[2]), mmr.remove_last_leaf());
         assert_eq!(3, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[1]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[1]), mmr.remove_last_leaf());
         assert_eq!(1, mmr.count_nodes());
-        assert_eq!(Some(input_prehashes[0]), mmr.remove_last_leaf());
+        assert_eq!(Some(input_digests[0]), mmr.remove_last_leaf());
         assert_eq!(0, mmr.count_nodes());
         assert!(mmr.is_empty());
         assert!(mmr.remove_last_leaf().is_none());
@@ -949,17 +845,15 @@ mod mmr_test {
 
     #[test]
     fn remove_last_leaf_pbt() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
         let small_size: u128 = 100;
         let big_size: u128 = 350;
-        let input_prehashes_small: Vec<Digest> = (0..100).map(|x| (x + 19999872).into()).collect();
-        let input_prehashes_big: Vec<Digest> = (0..350).map(|x| (x + 19999872).into()).collect();
-        let mut mmr_small: ArchivalMmr<Hasher> =
-            get_archival_mmr_from_digests(input_prehashes_small.clone());
-        let mut mmr_big: ArchivalMmr<Hasher> =
-            get_archival_mmr_from_digests(input_prehashes_big.clone());
+        let input_digests_small: Vec<Digest> = random_elements(100);
+        let input_digests_big: Vec<Digest> = random_elements(350);
+        let mut mmr_small: ArchivalMmr<H> =
+            get_archival_mmr_from_digests(input_digests_small.clone());
+        let mut mmr_big: ArchivalMmr<H> = get_archival_mmr_from_digests(input_digests_big.clone());
 
         for _ in 0..(big_size - small_size) {
             mmr_big.remove_last_leaf();
@@ -973,8 +867,7 @@ mod mmr_test {
 
     #[test]
     fn variable_size_blake3_mmr_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
         let node_counts: Vec<u128> = vec![
             1, 3, 4, 7, 8, 10, 11, 15, 16, 18, 19, 22, 23, 25, 26, 31, 32, 34, 35, 38, 39, 41, 42,
@@ -984,19 +877,16 @@ mod mmr_test {
             1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4,
             4, 5, 1, 2,
         ];
-        for (data_size, node_count, peak_count) in
-            izip!((1u128..34).collect::<Vec<u128>>(), node_counts, peak_counts)
-        {
-            let input_prehashes: Vec<Digest> = (0..data_size).map(|x| (x + 14).into()).collect();
-
-            let mut mmr: ArchivalMmr<Hasher> =
-                get_archival_mmr_from_digests(input_prehashes.clone());
-            let mut mmr_original: ArchivalMmr<Hasher> =
-                get_archival_mmr_from_digests(input_prehashes.clone());
-            // let mut mmr = ArchivalMmr::<Hasher>::new(input_prehashes.clone());
+        let data_sizes: Vec<usize> = (1..34).collect();
+        for (i, node_count, peak_count) in izip!(data_sizes, node_counts, peak_counts) {
+            let data_size = i as u128;
+            let input_digests: Vec<Digest> = random_elements(i);
+            let mut mmr: ArchivalMmr<H> = get_archival_mmr_from_digests(input_digests.clone());
+            let mut mmr_original: ArchivalMmr<H> =
+                get_archival_mmr_from_digests(input_digests.clone());
             assert_eq!(data_size, mmr.count_leaves());
             assert_eq!(node_count, mmr.count_nodes());
-            let original_peaks_and_heights: Vec<(Blake3Hash, u128)> = mmr.get_peaks_with_heights();
+            let original_peaks_and_heights: Vec<(Digest, u128)> = mmr.get_peaks_with_heights();
             let peak_heights_1: Vec<u128> =
                 original_peaks_and_heights.iter().map(|x| x.1).collect();
             let (peak_heights_2, _) = get_peak_heights_and_peak_node_indices(data_size);
@@ -1005,8 +895,7 @@ mod mmr_test {
 
             // Verify that MMR root from odd number of digests and MMR bagged peaks agree
             let mmra_root = mmr.bag_peaks();
-            let mt_root =
-                MerkleTree::<Hasher>::root_from_arbitrary_number_of_digests(&input_prehashes);
+            let mt_root = MerkleTree::<H>::root_from_arbitrary_number_of_digests(&input_digests);
             assert_eq!(
                 mmra_root, mt_root,
                 "MMRA bagged peaks and MT root must agree"
@@ -1016,15 +905,12 @@ mod mmr_test {
             // verify that it is valid
             for data_index in 0..data_size {
                 let (mut membership_proof, peaks) = mmr.prove_membership(data_index);
-                let valid_res = membership_proof.verify(
-                    &peaks,
-                    &input_prehashes[data_index as usize],
-                    data_size,
-                );
+                let valid_res =
+                    membership_proof.verify(&peaks, &input_digests[data_index as usize], data_size);
                 assert!(valid_res.0);
                 assert!(valid_res.1.is_some());
 
-                let new_leaf: Blake3Hash = 98723u128.into();
+                let new_leaf: Digest = H::hash(&98723u128);
 
                 // The below verify_modify tests should only fail if `wrong_data_index` is
                 // different than `data_index`.
@@ -1037,7 +923,7 @@ mod mmr_test {
                 membership_proof.data_index = data_index;
 
                 // Modify an element in the MMR and run prove/verify for membership
-                let old_leaf = input_prehashes[data_index as usize];
+                let old_leaf = input_digests[data_index as usize];
                 mmr.mutate_leaf_raw(data_index, new_leaf.clone());
 
                 let (new_mp, new_peaks) = mmr.prove_membership(data_index);
@@ -1052,7 +938,7 @@ mod mmr_test {
             }
 
             // Make a new MMR where we append with a value and run the verify_append
-            let new_leaf_hash: Digest = 519u128.into();
+            let new_leaf_hash: Digest = H::hash(&519u128);
             mmr.append(new_leaf_hash);
             assert!(mmr_original.verify_batch_update(&mmr.get_peaks(), &[new_leaf_hash], &[]));
         }

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -91,7 +91,7 @@ where
         );
 
         for (mp, digest) in mutation_data.iter() {
-            self.mutate_leaf_raw(mp.data_index, digest.clone());
+            self.mutate_leaf_raw(mp.data_index, *digest);
         }
 
         let mut modified_mps: Vec<usize> = vec![];
@@ -150,7 +150,6 @@ impl<H: AlgebraicHasher> ArchivalMmr<H> {
     /// Get a leaf from the MMR, will panic if index is out of range
     pub fn get_leaf(&mut self, data_index: u128) -> Digest {
         let node_index = data_index_to_node_index(data_index);
-        // self.digests[node_index as usize].clone()
         self.digests.get(node_index)
     }
 
@@ -158,8 +157,7 @@ impl<H: AlgebraicHasher> ArchivalMmr<H> {
     pub fn mutate_leaf_raw(&mut self, data_index: u128, new_leaf: Digest) {
         // 1. change the leaf value
         let mut node_index = data_index_to_node_index(data_index);
-        // self.digests[node_index as usize] = new_leaf.clone();
-        self.digests.set(node_index, new_leaf.clone());
+        self.digests.set(node_index, new_leaf);
 
         // 2. Calculate hash changes for all parents
         let mut parent_index = parent(node_index);
@@ -179,8 +177,7 @@ impl<H: AlgebraicHasher> ArchivalMmr<H> {
                     &self.digests.get(right_sibling(node_index, height)),
                 )
             };
-            // self.digests[parent_index as usize] = acc_hash.clone();
-            self.digests.set(parent_index, acc_hash.clone());
+            self.digests.set(parent_index, acc_hash);
             node_index = parent_index;
             parent_index = parent(parent_index);
         }
@@ -222,11 +219,7 @@ impl<H: AlgebraicHasher> ArchivalMmr<H> {
             index_height = next_index_info.1;
         }
 
-        let peaks: Vec<Digest> = self
-            .get_peaks_with_heights()
-            .iter()
-            .map(|x| x.0.clone())
-            .collect();
+        let peaks: Vec<Digest> = self.get_peaks_with_heights().iter().map(|x| x.0).collect();
 
         let membership_proof = MmrMembershipProof::new(data_index, authentication_path);
 
@@ -273,7 +266,7 @@ impl<H: AlgebraicHasher> ArchivalMmr<H> {
     /// Append an element to the archival MMR
     pub fn append_raw(&mut self, new_leaf: Digest) {
         let node_index = self.digests.len() as u128;
-        self.digests.push(new_leaf.clone());
+        self.digests.push(new_leaf);
         let (parent_needed, own_height) = right_child_and_height(node_index);
         if parent_needed {
             let left_sibling_hash = self.digests.get(left_sibling(node_index, own_height));

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -315,7 +315,6 @@ mod mmr_test {
         },
     };
     use itertools::izip;
-    use rand::Rng;
 
     impl<H: AlgebraicHasher> ArchivalMmr<H> {
         /// Return the number of nodes in all the trees in the MMR

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -759,7 +759,7 @@ mod mmr_test {
             4, 5, 1, 2,
         ];
         let data_sizes: Vec<usize> = (1..34).collect();
-        for (i, node_count, peak_count) in izip!(data_sizes, node_counts, peak_counts) {
+        for (i, node_count, _peak_count) in izip!(data_sizes, node_counts, peak_counts) {
             let data_size = i as u128;
             let input_hashes: Vec<Digest> = random_elements(i);
             let mut mmr: ArchivalMmr<H> = get_archival_mmr_from_digests(input_hashes.clone());

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -1,72 +1,61 @@
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use std::{collections::HashMap, fmt::Debug};
 
-use serde::{Deserialize, Serialize};
-
-use crate::util_types::mmr::shared::{leaf_index_to_peak_index, left_sibling, right_sibling};
+use super::archival_mmr::ArchivalMmr;
+use super::mmr_membership_proof::MmrMembershipProof;
+use super::mmr_trait::Mmr;
+use super::shared::calculate_new_peaks_from_leaf_mutation;
+use super::shared::{
+    calculate_new_peaks_from_append, data_index_to_node_index, parent, right_child_and_height,
+};
+use super::shared::{leaf_index_to_peak_index, left_sibling, right_sibling};
+use crate::shared_math::rescue_prime_digest::Digest;
+use crate::util_types::algebraic_hasher::AlgebraicHasher;
 use crate::util_types::shared::bag_peaks;
-use crate::util_types::simple_hasher::{self, Hashable};
-use crate::{
-    util_types::{mmr::shared::calculate_new_peaks_from_leaf_mutation, simple_hasher::Hasher},
-    utils::has_unique_elements,
-};
+use crate::utils::has_unique_elements;
 
-use super::{
-    archival_mmr::ArchivalMmr,
-    mmr_membership_proof::MmrMembershipProof,
-    mmr_trait::Mmr,
-    shared::{
-        calculate_new_peaks_from_append, data_index_to_node_index, parent, right_child_and_height,
-    },
-};
-
-impl<H: Hasher> From<ArchivalMmr<H>> for MmrAccumulator<H>
-where
-    u128: Hashable<<H as simple_hasher::Hasher>::T>,
-{
+impl<H: AlgebraicHasher> From<ArchivalMmr<H>> for MmrAccumulator<H> {
     fn from(mut ammr: ArchivalMmr<H>) -> Self {
         MmrAccumulator {
             leaf_count: ammr.count_leaves(),
             peaks: ammr.get_peaks(),
+            _hasher: PhantomData,
         }
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct MmrAccumulator<H: Hasher>
-where
-    H: Hasher,
-{
+pub struct MmrAccumulator<H: AlgebraicHasher> {
     leaf_count: u128,
-    peaks: Vec<H::Digest>,
+    peaks: Vec<Digest>,
+    _hasher: PhantomData<H>,
 }
 
-impl<H> From<&mut ArchivalMmr<H>> for MmrAccumulator<H>
-where
-    H: Hasher,
-    u128: Hashable<H::T>,
-{
+impl<H: AlgebraicHasher> From<&mut ArchivalMmr<H>> for MmrAccumulator<H> {
     fn from(archive: &mut ArchivalMmr<H>) -> Self {
         Self {
             leaf_count: archive.count_leaves(),
             peaks: archive.get_peaks(),
+            _hasher: PhantomData,
         }
     }
 }
 
-// u128: ToDigest<HashDigest>,
-impl<H> MmrAccumulator<H>
-where
-    H: Hasher,
-    u128: Hashable<H::T>,
-{
-    pub fn init(peaks: Vec<H::Digest>, leaf_count: u128) -> Self {
-        Self { leaf_count, peaks }
+impl<H: AlgebraicHasher> MmrAccumulator<H> {
+    pub fn init(peaks: Vec<Digest>, leaf_count: u128) -> Self {
+        Self {
+            leaf_count,
+            peaks,
+            _hasher: PhantomData,
+        }
     }
 
-    pub fn new(digests: Vec<H::Digest>) -> Self {
+    pub fn new(digests: Vec<Digest>) -> Self {
         let mut mmra = MmrAccumulator {
             leaf_count: 0,
             peaks: vec![],
+            _hasher: PhantomData,
         };
         for digest in digests {
             mmra.append(digest);
@@ -76,16 +65,12 @@ where
     }
 }
 
-impl<H> Mmr<H> for MmrAccumulator<H>
-where
-    H: Hasher,
-    u128: Hashable<H::T>,
-{
-    fn bag_peaks(&mut self) -> H::Digest {
+impl<H: AlgebraicHasher> Mmr<H> for MmrAccumulator<H> {
+    fn bag_peaks(&mut self) -> Digest {
         bag_peaks::<H>(&self.peaks)
     }
 
-    fn get_peaks(&mut self) -> Vec<H::Digest> {
+    fn get_peaks(&mut self) -> Vec<Digest> {
         self.peaks.clone()
     }
 
@@ -97,7 +82,7 @@ where
         self.leaf_count
     }
 
-    fn append(&mut self, new_leaf: H::Digest) -> MmrMembershipProof<H> {
+    fn append(&mut self, new_leaf: Digest) -> MmrMembershipProof<H> {
         let (new_peaks, membership_proof) =
             calculate_new_peaks_from_append::<H>(self.leaf_count, self.peaks.clone(), new_leaf)
                 .unwrap();
@@ -110,17 +95,16 @@ where
     /// Mutate an existing leaf. It is the caller's responsibility that the
     /// membership proof is valid. If the membership proof is wrong, the MMR
     /// will end up in a broken state.
-    fn mutate_leaf(&mut self, old_membership_proof: &MmrMembershipProof<H>, new_leaf: &H::Digest) {
+    fn mutate_leaf(&mut self, old_membership_proof: &MmrMembershipProof<H>, new_leaf: &Digest) {
         let node_index = data_index_to_node_index(old_membership_proof.data_index);
-        let hasher = H::new();
-        let mut acc_hash: H::Digest = new_leaf.to_owned();
+        let mut acc_hash: Digest = new_leaf.to_owned();
         let mut acc_index: u128 = node_index;
         for hash in old_membership_proof.authentication_path.iter() {
             let (acc_right, _acc_height) = right_child_and_height(acc_index);
             acc_hash = if acc_right {
-                hasher.hash_pair(hash, &acc_hash)
+                H::hash_pair(hash, &acc_hash)
             } else {
-                hasher.hash_pair(&acc_hash, hash)
+                H::hash_pair(&acc_hash, hash)
             };
             acc_index = parent(acc_index);
         }
@@ -140,9 +124,9 @@ where
     /// provided appends and mutations.
     fn verify_batch_update(
         &mut self,
-        new_peaks: &[H::Digest],
-        appended_leafs: &[H::Digest],
-        leaf_mutations: &[(H::Digest, MmrMembershipProof<H>)],
+        new_peaks: &[Digest],
+        appended_leafs: &[Digest],
+        leaf_mutations: &[(Digest, MmrMembershipProof<H>)],
     ) -> bool {
         // Verify that all leaf mutations operate on unique leafs and that they do
         // not exceed the total leaf count
@@ -160,7 +144,7 @@ where
             return false;
         }
 
-        let mut leaf_mutation_target_values: Vec<H::Digest> =
+        let mut leaf_mutation_target_values: Vec<Digest> =
             leaf_mutations.iter().map(|x| x.0.to_owned()).collect();
         let mut updated_membership_proofs: Vec<MmrMembershipProof<H>> =
             leaf_mutations.iter().map(|x| x.1.to_owned()).collect();
@@ -171,7 +155,7 @@ where
         updated_membership_proofs.reverse();
 
         // First we apply all the leaf mutations
-        let mut running_peaks: Vec<H::Digest> = self.peaks.clone();
+        let mut running_peaks: Vec<Digest> = self.peaks.clone();
         while let Some(membership_proof) = updated_membership_proofs.pop() {
             // `new_leaf_value` is guaranteed to exist since `leaf_mutation_target_values`
             // has the same length as `updated_membership_proofs`
@@ -201,7 +185,7 @@ where
         }
 
         // Then apply all the leaf appends
-        let mut new_leafs_cloned: Vec<H::Digest> = appended_leafs.to_vec();
+        let mut new_leafs_cloned: Vec<Digest> = appended_leafs.to_vec();
 
         // Reverse the new leafs to apply them in the same order as they were input,
         // using pop
@@ -229,11 +213,10 @@ where
     fn batch_mutate_leaf_and_update_mps(
         &mut self,
         membership_proofs: &mut [&mut MmrMembershipProof<H>],
-        mut mutation_data: Vec<(MmrMembershipProof<H>, <H as Hasher>::Digest)>,
+        mut mutation_data: Vec<(MmrMembershipProof<H>, Digest)>,
     ) -> Vec<usize> {
         // Calculate all derivable paths
-        let mut new_ap_digests: HashMap<u128, H::Digest> = HashMap::new();
-        let hasher = H::new();
+        let mut new_ap_digests: HashMap<u128, Digest> = HashMap::new();
 
         // Calculate the derivable digests from a number of leaf mutations and their
         // associated authentication paths. Notice that all authentication paths
@@ -247,7 +230,7 @@ where
                 former_value.is_none(),
                 "Duplicated leaf indices are not allowed in membership proof updater"
             );
-            let mut acc_hash: H::Digest = new_leaf.to_owned();
+            let mut acc_hash: Digest = new_leaf.to_owned();
 
             for (count, hash) in ap.authentication_path.iter().enumerate() {
                 // If sibling node is something that has already been calculated, we use that
@@ -255,21 +238,21 @@ where
                 let (right, height) = right_child_and_height(node_index);
                 if right {
                     let left_sibling_index = left_sibling(node_index, height);
-                    let sibling_hash: &H::Digest = match new_ap_digests.get(&left_sibling_index) {
+                    let sibling_hash: &Digest = match new_ap_digests.get(&left_sibling_index) {
                         Some(h) => h,
                         None => hash,
                     };
-                    acc_hash = hasher.hash_pair(sibling_hash, &acc_hash);
+                    acc_hash = H::hash_pair(sibling_hash, &acc_hash);
 
                     // Find parent node index
                     node_index += 1;
                 } else {
                     let right_sibling_index = right_sibling(node_index, height);
-                    let sibling_hash: &H::Digest = match new_ap_digests.get(&right_sibling_index) {
+                    let sibling_hash: &Digest = match new_ap_digests.get(&right_sibling_index) {
                         Some(h) => h,
                         None => hash,
                     };
-                    acc_hash = hasher.hash_pair(&acc_hash, sibling_hash);
+                    acc_hash = H::hash_pair(&acc_hash, sibling_hash);
 
                     // Find parent node index
                     node_index += 1 << (height + 1);
@@ -337,26 +320,19 @@ mod accumulator_mmr_tests {
     use rand::Rng;
 
     use crate::shared_math::b_field_element::BFieldElement;
-    use crate::shared_math::other::random_elements_range;
+    use crate::shared_math::other::{random_elements, random_elements_range};
     use crate::shared_math::rescue_prime_regular::RescuePrimeRegular;
     use crate::test_shared::mmr::get_archival_mmr_from_digests;
-    use crate::util_types::blake3_wrapper::Blake3Hash;
 
     use super::*;
 
     #[test]
     fn conversion_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
-        let leaf_hashes: Vec<Digest> = vec![14u128, 15u128, 16u128]
-            .into_iter()
-            .map(|x| x.into())
-            .collect();
-
-        let mut archival_mmr: ArchivalMmr<Hasher> =
-            get_archival_mmr_from_digests(leaf_hashes.clone());
-        let mut accumulator_mmr: MmrAccumulator<Hasher> = (&mut archival_mmr).into();
+        let leaf_hashes: Vec<Digest> = random_elements(3);
+        let mut archival_mmr: ArchivalMmr<H> = get_archival_mmr_from_digests(leaf_hashes.clone());
+        let mut accumulator_mmr: MmrAccumulator<H> = (&mut archival_mmr).into();
 
         assert_eq!(archival_mmr.get_peaks(), accumulator_mmr.get_peaks());
         assert_eq!(archival_mmr.bag_peaks(), accumulator_mmr.bag_peaks());
@@ -368,51 +344,43 @@ mod accumulator_mmr_tests {
 
     #[test]
     fn verify_batch_update_single_append_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
-        let leaf_hashes_start: Vec<Digest> = vec![14u128, 15u128, 16u128]
-            .into_iter()
-            .map(|x| x.into())
-            .collect();
-        let appended_leaf: Digest = 17u128.into();
+        let leaf_hashes_start: Vec<Digest> = random_elements(3);
+        let appended_leaf: Digest = H::hash(&17u128);
 
-        let leaf_hashes_end: Vec<Digest> = vec![14u128, 15u128, 16u128, 17u128]
-            .into_iter()
-            .map(|x| x.into())
-            .collect();
-        let mut accumulator_mmr_start: MmrAccumulator<Hasher> =
-            MmrAccumulator::<Hasher>::new(leaf_hashes_start.clone());
-        let mut accumulator_mmr_end: MmrAccumulator<Hasher> =
-            MmrAccumulator::new(leaf_hashes_end.clone());
-        assert!(accumulator_mmr_start.verify_batch_update(
+        let mut leaf_hashes_end: Vec<Digest> = leaf_hashes_start.clone();
+        leaf_hashes_end.push(appended_leaf);
+
+        let mut accumulator_mmr_start: MmrAccumulator<H> = MmrAccumulator::new(leaf_hashes_start);
+        let mut accumulator_mmr_end: MmrAccumulator<H> = MmrAccumulator::new(leaf_hashes_end);
+
+        let leaves_were_appended = accumulator_mmr_start.verify_batch_update(
             &accumulator_mmr_end.get_peaks(),
             &[appended_leaf],
-            &[]
-        ));
+            &[],
+        );
+        assert!(leaves_were_appended);
     }
 
     #[test]
     fn verify_batch_update_single_mutate_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
-        let leaf_hashes_start: Vec<Digest> = vec![14u128, 15u128, 16u128, 18u128]
-            .into_iter()
-            .map(|x| x.into())
-            .collect();
-        let new_leaf_value: Digest = 17u128.into();
-        let leaf_hashes_end: Vec<Digest> = vec![14u128, 15u128, 16u128, 17u128]
-            .into_iter()
-            .map(|x| x.into())
-            .collect();
-        let mut accumulator_mmr_start: MmrAccumulator<Hasher> =
-            MmrAccumulator::<Hasher>::new(leaf_hashes_start.clone());
-        // let archive_mmr_start = ArchivalMmr::new(leaf_hashes_start);
-        let mut archive_mmr_start: ArchivalMmr<Hasher> =
+        let leaf_hashes_start: Vec<Digest> =
+            [14, 15, 16, 18].iter().map(|x: &u128| H::hash(x)).collect();
+
+        let new_leaf_value: Digest = H::hash(&17u128);
+
+        let leaf_hashes_end: Vec<Digest> =
+            [14, 15, 16, 17].iter().map(|x: &u128| H::hash(x)).collect();
+
+        let mut accumulator_mmr_start: MmrAccumulator<H> =
+            MmrAccumulator::new(leaf_hashes_start.clone());
+        let mut archive_mmr_start: ArchivalMmr<H> =
             get_archival_mmr_from_digests(leaf_hashes_start);
         let membership_proof = archive_mmr_start.prove_membership(3).0;
-        let mut accumulator_mmr_end: MmrAccumulator<Hasher> =
+        let mut accumulator_mmr_end: MmrAccumulator<H> =
             MmrAccumulator::new(leaf_hashes_end.clone());
         assert!(accumulator_mmr_start.verify_batch_update(
             &accumulator_mmr_end.get_peaks(),
@@ -433,52 +401,43 @@ mod accumulator_mmr_tests {
 
     #[test]
     fn verify_batch_update_two_append_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
-        let leaf_hashes_start: Vec<Digest> = vec![14u128, 15u128, 16u128]
-            .into_iter()
-            .map(|x| x.into())
-            .collect();
-        let appended_leafs: Vec<Digest> =
-            vec![25u128, 29u128].into_iter().map(|x| x.into()).collect();
-        let leaf_hashes_end: Vec<Digest> = vec![14u128, 15u128, 16u128, 25u128, 29u128]
-            .into_iter()
-            .map(|x| x.into())
-            .collect();
-        let mut accumulator_mmr_start: MmrAccumulator<Hasher> =
+        let leaf_hashes_start: Vec<Digest> = random_elements(3);
+        let appended_leafs: Vec<Digest> = random_elements(2);
+        let leaf_hashes_end: Vec<Digest> = vec![leaf_hashes_start, appended_leafs].concat();
+        let mut accumulator_mmr_start: MmrAccumulator<H> =
             MmrAccumulator::new(leaf_hashes_start.clone());
-        let mut accumulator_mmr_end: MmrAccumulator<Hasher> =
+        let mut accumulator_mmr_end: MmrAccumulator<H> =
             MmrAccumulator::new(leaf_hashes_end.clone());
-        assert!(accumulator_mmr_start.verify_batch_update(
+
+        let leaves_were_appended = accumulator_mmr_start.verify_batch_update(
             &accumulator_mmr_end.get_peaks(),
             &appended_leafs,
-            &[]
-        ));
+            &[],
+        );
+        assert!(leaves_were_appended);
     }
 
     #[test]
     fn verify_batch_update_two_mutate_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
-        let leaf_hashes_start: Vec<Digest> = vec![14u128, 15u128, 16u128, 17u128]
-            .into_iter()
-            .map(|x| x.into())
-            .collect();
-        let new_leafs: Vec<Digest> = vec![20u128, 21u128].into_iter().map(|x| x.into()).collect();
-        let leaf_hashes_end: Vec<Digest> = vec![14u128, 20u128, 16u128, 21u128]
-            .into_iter()
-            .map(|x| x.into())
-            .collect();
-        let mut accumulator_mmr_start: MmrAccumulator<Hasher> =
-            MmrAccumulator::<Hasher>::new(leaf_hashes_start.clone());
-        // let archive_mmr_start = ArchivalMmr::new(leaf_hashes_start);
-        let mut archive_mmr_start: ArchivalMmr<Hasher> =
+        let leaf_hashes_start: Vec<Digest> =
+            [14, 15, 16, 17].iter().map(|x: &u128| H::hash(x)).collect();
+
+        let new_leafs: Vec<Digest> = [20, 21].iter().map(|x: &u128| H::hash(x)).collect();
+
+        let leaf_hashes_end: Vec<Digest> =
+            [14, 20, 16, 21].iter().map(|x: &u128| H::hash(x)).collect();
+
+        let mut accumulator_mmr_start: MmrAccumulator<H> =
+            MmrAccumulator::<H>::new(leaf_hashes_start.clone());
+        let mut archive_mmr_start: ArchivalMmr<H> =
             get_archival_mmr_from_digests(leaf_hashes_start);
         let membership_proof1 = archive_mmr_start.prove_membership(1).0;
         let membership_proof3 = archive_mmr_start.prove_membership(3).0;
-        let mut accumulator_mmr_end: MmrAccumulator<Hasher> =
+        let mut accumulator_mmr_end: MmrAccumulator<H> =
             MmrAccumulator::new(leaf_hashes_end.clone());
         assert!(accumulator_mmr_start.verify_batch_update(
             &accumulator_mmr_end.get_peaks(),
@@ -492,24 +451,20 @@ mod accumulator_mmr_tests {
 
     #[test]
     fn batch_mutate_leaf_and_update_mps_test() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
         let mut rng = rand::thread_rng();
         for mmr_leaf_count in 1..100 {
-            let initial_leaf_digests: Vec<Digest> = (4000u128..4000u128 + mmr_leaf_count)
-                .map(|x| x.into())
-                .collect();
-            let mut mmra: MmrAccumulator<Hasher> =
-                MmrAccumulator::new(initial_leaf_digests.clone());
-            // let mut ammr: ArchivalMmr<Hasher> = ArchivalMmr::new(initial_leaf_digests.clone());
-            let mut ammr: ArchivalMmr<Hasher> =
+            let initial_leaf_digests: Vec<Digest> = random_elements(mmr_leaf_count);
+
+            let mut mmra: MmrAccumulator<H> = MmrAccumulator::new(initial_leaf_digests.clone());
+            let mut ammr: ArchivalMmr<H> =
                 get_archival_mmr_from_digests(initial_leaf_digests.clone());
-            let mut ammr_copy: ArchivalMmr<Hasher> =
+            let mut ammr_copy: ArchivalMmr<H> =
                 get_archival_mmr_from_digests(initial_leaf_digests.clone());
 
             let mutated_leaf_count = rng.gen_range(0..mmr_leaf_count);
-            let all_indices: Vec<u128> = (0..mmr_leaf_count).collect();
+            let all_indices: Vec<u128> = (0..mmr_leaf_count as u128).collect();
 
             // Pick indices for leaves that are being mutated
             let mut all_indices_mut0 = all_indices.clone();
@@ -530,8 +485,7 @@ mod accumulator_mmr_tests {
 
             // Calculate the terminal leafs, as they look after the batch leaf mutation
             // that we are preparing to execute
-            let new_leafs: Vec<Digest> =
-                (6u128..6 + mutated_leaf_count).map(|x| x.into()).collect();
+            let new_leafs: Vec<Digest> = random_elements(mutated_leaf_count);
             let mut terminal_leafs: Vec<Digest> = initial_leaf_digests;
             for (i, new_leaf) in mutated_leaf_indices.iter().zip(new_leafs.iter()) {
                 terminal_leafs[*i as usize] = new_leaf.to_owned();
@@ -545,22 +499,21 @@ mod accumulator_mmr_tests {
             }
 
             // Construct the mutation data
-            let mutated_leaf_mps: Vec<MmrMembershipProof<Hasher>> = mutated_leaf_indices
+            let mutated_leaf_mps: Vec<MmrMembershipProof<H>> = mutated_leaf_indices
                 .iter()
                 .map(|i| ammr.prove_membership(*i).0)
                 .collect();
-            let mutation_data: Vec<(MmrMembershipProof<Hasher>, Digest)> = mutated_leaf_mps
+            let mutation_data: Vec<(MmrMembershipProof<H>, Digest)> = mutated_leaf_mps
                 .into_iter()
                 .zip(new_leafs.into_iter())
                 .collect();
 
             assert_eq!(mutated_leaf_count as usize, mutation_data.len());
 
-            let original_membership_proofs: Vec<MmrMembershipProof<Hasher>> =
-                membership_proof_indices
-                    .iter()
-                    .map(|i| ammr.prove_membership(*i).0)
-                    .collect();
+            let original_membership_proofs: Vec<MmrMembershipProof<H>> = membership_proof_indices
+                .iter()
+                .map(|i| ammr.prove_membership(*i).0)
+                .collect();
 
             // Do the update on both MMRs
             let mut mmra_mps = original_membership_proofs.clone();
@@ -603,38 +556,37 @@ mod accumulator_mmr_tests {
 
     #[test]
     fn verify_batch_update_pbt() {
-        type Digest = Blake3Hash;
-        type Hasher = blake3::Hasher;
+        type H = blake3::Hasher;
 
         for start_size in 1..35 {
-            let leaf_hashes_start: Vec<Digest> = (4000u128..4000u128 + start_size)
-                .map(|x| x.into())
+            let leaf_hashes_start: Vec<Digest> = random_elements(start_size);
+
+            let bad_digests: Vec<Digest> = (12..12 + start_size)
+                .map(|x| H::hash(&(x as u128)))
                 .collect();
-            let bad_digests: Vec<Digest> =
-                (12u128..12u128 + start_size).map(|x| x.into()).collect();
-            // let bad_mmr = ArchivalMmr::<Hasher>::new(bad_digests.clone());
-            let mut bad_mmr: ArchivalMmr<Hasher> =
-                get_archival_mmr_from_digests(bad_digests.clone());
-            let bad_membership_proof: MmrMembershipProof<Hasher> = bad_mmr.prove_membership(0).0;
+
+            let mut bad_mmr: ArchivalMmr<H> = get_archival_mmr_from_digests(bad_digests.clone());
+            let bad_membership_proof: MmrMembershipProof<H> = bad_mmr.prove_membership(0).0;
             let bad_membership_proof_digest = bad_digests[0];
-            let bad_leaf: Digest = 8765432165123u128.into();
-            // let archival_mmr_init = ArchivalMmr::<Hasher>::new(leaf_hashes_start.clone());
-            let mut archival_mmr_init: ArchivalMmr<Hasher> =
+            let bad_leaf: Digest = H::hash(&8765432165123u128);
+            let mut archival_mmr_init: ArchivalMmr<H> =
                 get_archival_mmr_from_digests(leaf_hashes_start.clone());
-            let mut accumulator_mmr = MmrAccumulator::<Hasher>::new(leaf_hashes_start.clone());
+            let mut accumulator_mmr = MmrAccumulator::<H>::new(leaf_hashes_start.clone());
+
             for append_size in 0..18 {
-                let appends: Vec<Digest> = (2000u128..2000u128 + append_size)
-                    .map(|x| x.into())
+                let appends: Vec<Digest> = (2000..2000 + append_size)
+                    .map(|x| H::hash(&(x as u128)))
                     .collect();
                 let mutate_count = cmp::min(12, start_size);
                 for mutate_size in 0..mutate_count {
-                    let new_leaf_values: Vec<Digest> =
-                        (13u128..13u128 + mutate_size).map(|x| x.into()).collect();
+                    let new_leaf_values: Vec<Digest> = (13..13 + mutate_size)
+                        .map(|x| H::hash(&(x as u128)))
+                        .collect();
 
                     // Ensure that indices are unique since batch updating cannot update
                     // the same leaf twice in one go
                     let mutated_indices: Vec<u128> =
-                        random_elements_range(mutate_size as usize, 0..start_size)
+                        random_elements_range(mutate_size, 0..start_size as u128)
                             .into_iter()
                             .sorted()
                             .unique()
@@ -652,10 +604,9 @@ mod accumulator_mmr_tests {
 
                     // let mutated_archival_mmr =
                     //     ArchivalMmr::<Hasher>::new(leaf_hashes_mutated.clone());
-                    let mut mutated_archival_mmr: ArchivalMmr<Hasher> =
+                    let mut mutated_archival_mmr: ArchivalMmr<H> =
                         get_archival_mmr_from_digests(leaf_hashes_mutated.clone());
-                    let mut mutated_accumulator_mmr =
-                        MmrAccumulator::<Hasher>::new(leaf_hashes_mutated);
+                    let mut mutated_accumulator_mmr = MmrAccumulator::<H>::new(leaf_hashes_mutated);
                     let expected_new_peaks_from_archival = mutated_archival_mmr.get_peaks();
                     let expected_new_peaks_from_accumulator = mutated_accumulator_mmr.get_peaks();
                     assert_eq!(
@@ -664,17 +615,16 @@ mod accumulator_mmr_tests {
                     );
 
                     // Create the inputs to the method call
-                    let membership_proofs: Vec<MmrMembershipProof<Hasher>> = mutated_indices
+                    let membership_proofs: Vec<MmrMembershipProof<H>> = mutated_indices
                         .iter()
                         .map(|&i| archival_mmr_init.prove_membership(i).0)
                         .collect();
-                    let mut leaf_mutations: Vec<(Digest, MmrMembershipProof<Hasher>)> =
-                        new_leaf_values
-                            .clone()
-                            .into_iter()
-                            .zip(membership_proofs.into_iter())
-                            .map(|(v, mp)| (v, mp))
-                            .collect();
+                    let mut leaf_mutations: Vec<(Digest, MmrMembershipProof<H>)> = new_leaf_values
+                        .clone()
+                        .into_iter()
+                        .zip(membership_proofs.into_iter())
+                        .map(|(v, mp)| (v, mp))
+                        .collect();
                     assert!(accumulator_mmr.verify_batch_update(
                         &expected_new_peaks_from_accumulator,
                         &appends,
@@ -723,11 +673,10 @@ mod accumulator_mmr_tests {
         // You could argue that this test doesn't belong here, as it tests the behavior of
         // an imported library. I included it here, though, because the setup seems a bit clumsy
         // to me so far.
-        type Hasher = RescuePrimeRegular;
-        let hasher = Hasher::new();
-        type Mmr = MmrAccumulator<Hasher>;
+        type H = RescuePrimeRegular;
+        type Mmr = MmrAccumulator<H>;
         let mut mmra: Mmr = MmrAccumulator::new(vec![]);
-        mmra.append(hasher.hash_sequence(&vec![BFieldElement::zero()]));
+        mmra.append(H::hash(&BFieldElement::zero()));
 
         let json = serde_json::to_string(&mmra).unwrap();
         let mut s_back = serde_json::from_str::<Mmr>(&json).unwrap();

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -225,7 +225,7 @@ impl<H: AlgebraicHasher> Mmr<H> for MmrAccumulator<H> {
         // The hash map `new_ap_digests` takes care of that.
         while let Some((ap, new_leaf)) = mutation_data.pop() {
             let mut node_index = data_index_to_node_index(ap.data_index);
-            let former_value = new_ap_digests.insert(node_index, new_leaf.clone());
+            let former_value = new_ap_digests.insert(node_index, new_leaf);
             assert!(
                 former_value.is_none(),
                 "Duplicated leaf indices are not allowed in membership proof updater"
@@ -262,7 +262,7 @@ impl<H: AlgebraicHasher> Mmr<H> for MmrAccumulator<H> {
                 // This is not inserted in the hash map, as it will never be in any
                 // authentication path
                 if count < ap.authentication_path.len() - 1 {
-                    new_ap_digests.insert(node_index, acc_hash.clone());
+                    new_ap_digests.insert(node_index, acc_hash);
                 }
             }
 
@@ -296,7 +296,7 @@ impl<H: AlgebraicHasher> Mmr<H> for MmrAccumulator<H> {
                 if new_ap_digests.contains_key(&authentication_path_indices)
                     && *digest != new_ap_digests[&authentication_path_indices]
                 {
-                    *digest = new_ap_digests[&authentication_path_indices].clone();
+                    *digest = new_ap_digests[&authentication_path_indices];
                     modified_membership_proof_indices.push(i);
                 }
             }

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -405,7 +405,8 @@ mod accumulator_mmr_tests {
 
         let leaf_hashes_start: Vec<Digest> = random_elements(3);
         let appended_leafs: Vec<Digest> = random_elements(2);
-        let leaf_hashes_end: Vec<Digest> = vec![leaf_hashes_start, appended_leafs].concat();
+        let leaf_hashes_end: Vec<Digest> =
+            vec![leaf_hashes_start.clone(), appended_leafs.clone()].concat();
         let mut accumulator_mmr_start: MmrAccumulator<H> =
             MmrAccumulator::new(leaf_hashes_start.clone());
         let mut accumulator_mmr_end: MmrAccumulator<H> =

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -1078,7 +1078,6 @@ mod mmr_membership_proof_test {
         // leaf index for MMR, modifying its membership proof with a
         // leaf update.
         for leaf_count in 0..=22 {
-            let start: u128 = 543217893265643843678;
             let leaf_hashes: Vec<Digest> = random_elements(leaf_count);
             let new_leaf: Digest = H::hash(&133333333333333333333337u128);
             let mut archival_mmr: ArchivalMmr<H> =

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -572,7 +572,6 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
 
 #[cfg(test)]
 mod mmr_membership_proof_test {
-    use itertools::Itertools;
     use rand::Rng;
 
     use crate::shared_math::b_field_element::BFieldElement;
@@ -589,8 +588,7 @@ mod mmr_membership_proof_test {
     #[test]
     fn equality_and_hash_test() {
         type H = blake3::Hasher;
-        let _hasher = PhantomData;
-        let rng = rand::thread_rng();
+        let mut rng = rand::thread_rng();
 
         let some_digest: Digest = rng.gen();
 

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -227,7 +227,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
         // 6
         for missing_digest_node_index in node_indices_for_missing_digests {
             self.authentication_path
-                .push(known_digests[&missing_digest_node_index].clone());
+                .push(known_digests[&missing_digest_node_index]);
         }
 
         true
@@ -313,7 +313,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
             for missing_digest_node_index in node_indices_for_missing_digests {
                 membership_proof
                     .authentication_path
-                    .push(known_digests[&missing_digest_node_index].clone());
+                    .push(known_digests[&missing_digest_node_index]);
             }
         }
 
@@ -352,7 +352,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
         // `membership_proof` until we meet the intersecting node.
         let mut deducible_hashes: HashMap<u128, Digest> = HashMap::new();
         let mut node_index = data_index_to_node_index(leaf_mutation_membership_proof.data_index);
-        deducible_hashes.insert(node_index, new_leaf.clone());
+        deducible_hashes.insert(node_index, *new_leaf);
         let mut acc_hash: Digest = new_leaf.to_owned();
 
         // Calculate hashes from the bottom towards the peak. Break when
@@ -374,7 +374,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
                 H::hash_pair(&acc_hash, hash)
             };
             node_index = parent(node_index);
-            deducible_hashes.insert(node_index, acc_hash.clone());
+            deducible_hashes.insert(node_index, acc_hash);
         }
 
         // Some of the hashes in `self` need to be updated. We can loop over
@@ -389,7 +389,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
             if !deducible_hashes.contains_key(&own_node_index) {
                 continue;
             }
-            *digest = deducible_hashes[&own_node_index].clone();
+            *digest = deducible_hashes[&own_node_index];
         }
 
         true
@@ -411,7 +411,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
 
         let mut deducible_hashes: HashMap<u128, Digest> = HashMap::new();
         let mut node_index = data_index_to_node_index(leaf_mutation_membership_proof.data_index);
-        deducible_hashes.insert(node_index, new_leaf.clone());
+        deducible_hashes.insert(node_index, *new_leaf);
         let mut acc_hash: Digest = new_leaf.to_owned();
 
         // Calculate hashes from the bottom towards the peak. Break before we
@@ -434,7 +434,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
                 H::hash_pair(&acc_hash, hash)
             };
             node_index = parent(node_index);
-            deducible_hashes.insert(node_index, acc_hash.clone());
+            deducible_hashes.insert(node_index, acc_hash);
         }
 
         let mut modified_membership_proofs: Vec<u128> = vec![];
@@ -459,7 +459,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
                 if deducible_hashes.contains_key(&authentication_path_indices)
                     && *digest != deducible_hashes[&authentication_path_indices]
                 {
-                    *digest = deducible_hashes[&authentication_path_indices].clone();
+                    *digest = deducible_hashes[&authentication_path_indices];
                     modified_membership_proofs.push(i as u128);
                     break;
                 }
@@ -494,7 +494,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
         // The hash map `new_ap_digests` takes care of that.
         while let Some((ap, new_leaf)) = authentication_paths_and_leafs.pop() {
             let mut node_index = data_index_to_node_index(ap.data_index);
-            let former_value = new_ap_digests.insert(node_index, new_leaf.clone());
+            let former_value = new_ap_digests.insert(node_index, new_leaf);
             assert!(
                 former_value.is_none(),
                 "Duplicated leaves are not allowed in membership proof updater"
@@ -534,7 +534,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
                     node_index += 1 << (height + 1);
                 }
 
-                new_ap_digests.insert(node_index, acc_hash.clone());
+                new_ap_digests.insert(node_index, acc_hash);
             }
         }
 
@@ -560,7 +560,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
                     && *digest != new_ap_digests[&authentication_path_indices]
                 {
                     modified_membership_proof_indices.push(i);
-                    *digest = new_ap_digests[&authentication_path_indices].clone();
+                    *digest = new_ap_digests[&authentication_path_indices];
                 }
             }
         }

--- a/twenty-first/src/util_types/mmr/mmr_trait.rs
+++ b/twenty-first/src/util_types/mmr/mmr_trait.rs
@@ -1,24 +1,24 @@
-use super::{mmr_accumulator::MmrAccumulator, mmr_membership_proof::MmrMembershipProof};
-use crate::util_types::simple_hasher::Hasher;
+use crate::{
+    shared_math::rescue_prime_digest::Digest, util_types::algebraic_hasher::AlgebraicHasher,
+};
 
-pub trait Mmr<H>
-where
-    H: Hasher,
-{
+use super::{mmr_accumulator::MmrAccumulator, mmr_membership_proof::MmrMembershipProof};
+
+pub trait Mmr<H: AlgebraicHasher> {
     /// Create a new MMR instanc from a list of hash digests. The supplied digests
     /// are the leaves of the MMR.
 
     // constructors cannot be part of the interface sicne the archival version requires a
     // database which we want the caller to create, and the accumulator does not need a
     // constructor.
-    // fn new(digests: Vec<H::Digest>) -> Self;
+    // fn new(digests: Vec<Digest>) -> Self;
 
     /// Calculate a single hash digest committing to the entire MMR.
-    fn bag_peaks(&mut self) -> H::Digest;
+    fn bag_peaks(&mut self) -> Digest;
 
     /// Returns the peaks of the MMR, which are roots of the Merkle trees that constitute
     /// the MMR
-    fn get_peaks(&mut self) -> Vec<H::Digest>;
+    fn get_peaks(&mut self) -> Vec<Digest>;
 
     /// Returns `true` iff the MMR has no leaves
     fn is_empty(&mut self) -> bool;
@@ -27,28 +27,28 @@ where
     fn count_leaves(&mut self) -> u128;
 
     /// Append a hash digest to the MMR
-    fn append(&mut self, new_leaf: H::Digest) -> MmrMembershipProof<H>;
+    fn append(&mut self, new_leaf: Digest) -> MmrMembershipProof<H>;
 
     /// Mutate an existing leaf. It is the caller's responsibility that the
     /// membership proof is valid. If the membership proof is wrong, the MMR
     /// will end up in a broken state.
-    fn mutate_leaf(&mut self, old_membership_proof: &MmrMembershipProof<H>, new_leaf: &H::Digest);
+    fn mutate_leaf(&mut self, old_membership_proof: &MmrMembershipProof<H>, new_leaf: &Digest);
 
     /// Batch mutate an MMR while updating a list of membership proofs. Returns the indices of the
     /// membership proofs that have changed as a result of this operation.
     fn batch_mutate_leaf_and_update_mps(
         &mut self,
         membership_proofs: &mut [&mut MmrMembershipProof<H>],
-        mutation_data: Vec<(MmrMembershipProof<H>, H::Digest)>,
+        mutation_data: Vec<(MmrMembershipProof<H>, Digest)>,
     ) -> Vec<usize>;
 
     /// Returns true if a list of leaf mutations and a list of appends results in the expected
     /// `new_peaks`.
     fn verify_batch_update(
         &mut self,
-        new_peaks: &[H::Digest],
-        appended_leafs: &[H::Digest],
-        leaf_mutations: &[(H::Digest, MmrMembershipProof<H>)],
+        new_peaks: &[Digest],
+        appended_leafs: &[Digest],
+        leaf_mutations: &[(Digest, MmrMembershipProof<H>)],
     ) -> bool;
 
     /// Return an MMR accumulator containing only peaks and leaf count

--- a/twenty-first/src/util_types/mmr/mmr_trait.rs
+++ b/twenty-first/src/util_types/mmr/mmr_trait.rs
@@ -1,6 +1,5 @@
-use crate::{
-    shared_math::rescue_prime_digest::Digest, util_types::algebraic_hasher::AlgebraicHasher,
-};
+use crate::shared_math::rescue_prime_digest::Digest;
+use crate::util_types::algebraic_hasher::AlgebraicHasher;
 
 use super::{mmr_accumulator::MmrAccumulator, mmr_membership_proof::MmrMembershipProof};
 

--- a/twenty-first/src/util_types/mmr/shared.rs
+++ b/twenty-first/src/util_types/mmr/shared.rs
@@ -581,7 +581,8 @@ mod mmr_test {
 
     #[test]
     fn get_peak_heights_and_peak_node_indices_test() {
-        let leaf_count_and_expected: Vec<(u128, (Vec<u128>, Vec<u128>))> = vec![
+        type TestCase = (u128, (Vec<u128>, Vec<u128>));
+        let leaf_count_and_expected: Vec<TestCase> = vec![
             (0, (vec![], vec![])),
             (1, (vec![0], vec![1])),
             (2, (vec![1], vec![3])),
@@ -621,7 +622,9 @@ mod mmr_test {
 
     #[test]
     fn get_authentication_path_node_indices_test() {
-        let start_end_node_count_expected: Vec<((u128, u128, u128), Option<Vec<u128>>)> = vec![
+        type Interval = (u128, u128, u128);
+        type TestCase = (Interval, Option<Vec<u128>>);
+        let start_end_node_count_expected: Vec<TestCase> = vec![
             ((1, 31, 31), Some(vec![2, 6, 14, 30])),
             ((2, 31, 31), Some(vec![1, 6, 14, 30])),
             ((3, 31, 31), Some(vec![6, 14, 30])),
@@ -646,16 +649,11 @@ mod mmr_test {
         // Verify that the helper function `calculate_new_peaks_from_leaf_mutation` does
         // not crash if called on an empty list of peaks
         let new_leaf = H::hash(&BFieldElement::new(10000));
-        let mut acc: ArchivalMmr<H> = get_archival_mmr_from_digests(vec![new_leaf.clone()]);
+        let mut acc: ArchivalMmr<H> = get_archival_mmr_from_digests(vec![new_leaf]);
         let mp = acc.prove_membership(0).0;
         assert!(
-            calculate_new_peaks_from_leaf_mutation::<RescuePrimeRegular>(
-                &vec![],
-                &new_leaf,
-                0,
-                &mp,
-            )
-            .is_none()
+            calculate_new_peaks_from_leaf_mutation::<RescuePrimeRegular>(&[], &new_leaf, 0, &mp,)
+                .is_none()
         );
     }
 }

--- a/twenty-first/src/util_types/mmr/shared.rs
+++ b/twenty-first/src/util_types/mmr/shared.rs
@@ -1,11 +1,8 @@
+use crate::shared_math::other::{bit_representation, log_2_floor};
+use crate::shared_math::rescue_prime_digest::Digest;
+use crate::util_types::algebraic_hasher::AlgebraicHasher;
+
 use super::mmr_membership_proof::MmrMembershipProof;
-use crate::{
-    shared_math::{
-        other::{bit_representation, log_2_floor},
-        rescue_prime_digest::Digest,
-    },
-    util_types::algebraic_hasher::AlgebraicHasher,
-};
 
 #[inline]
 pub fn left_child(node_index: u128, height: u128) -> u128 {

--- a/twenty-first/src/util_types/mmr/shared.rs
+++ b/twenty-first/src/util_types/mmr/shared.rs
@@ -297,9 +297,7 @@ pub fn calculate_new_peaks_from_append<H: AlgebraicHasher>(
             None => return None,
             Some(peak) => peak,
         };
-        membership_proof
-            .authentication_path
-            .push(previous_peak.clone());
+        membership_proof.authentication_path.push(previous_peak);
         peaks.push(H::hash_pair(&previous_peak, &new_hash));
         new_node_index += 1;
         new_node_is_right_child = right_child_and_height(new_node_index).0;

--- a/twenty-first/src/util_types/proof_stream.rs
+++ b/twenty-first/src/util_types/proof_stream.rs
@@ -1,6 +1,10 @@
 use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt, result::Result};
 
+use crate::shared_math::rescue_prime_digest::Digest;
+
+use super::blake3_wrapper::from_blake3_digest;
+
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ProofStream {
     read_index: usize,
@@ -134,14 +138,12 @@ impl ProofStream {
         Ok(item)
     }
 
-    pub fn prover_fiat_shamir(&self) -> Vec<u8> {
-        blake3::hash(&self.transcript).as_bytes().to_vec()
+    pub fn prover_fiat_shamir(&self) -> Digest {
+        from_blake3_digest(&blake3::hash(&self.transcript))
     }
 
-    pub fn verifier_fiat_shamir(&self) -> Vec<u8> {
-        blake3::hash(&self.transcript[0..self.read_index])
-            .as_bytes()
-            .to_vec()
+    pub fn verifier_fiat_shamir(&self) -> Digest {
+        from_blake3_digest(&blake3::hash(&self.transcript[0..self.read_index]))
     }
 }
 
@@ -156,13 +158,6 @@ pub mod test_proof_stream {
         assert!(proof_stream.is_empty());
         assert_eq!(0, proof_stream.get_read_index());
     }
-
-    // make random Blake3Hash'es
-    // push to stream
-    // pop
-    //
-    // To test: can we push single BFieldElement?
-    // To can: we push a merkle tree?
 
     #[test]
     fn ps_empty_ts() {

--- a/twenty-first/src/util_types/proof_stream_typed.rs
+++ b/twenty-first/src/util_types/proof_stream_typed.rs
@@ -228,7 +228,7 @@ mod proof_stream_typed_tests {
 
         let digest_1 = H::hash(&BFieldElement::one());
         ps.enqueue(&TestItem::ManyB(digest_1.values().to_vec()));
-        let _result = ps.dequeue();
+        let _ = ps.dequeue();
 
         assert_eq!(
             ps.prover_fiat_shamir(),
@@ -245,7 +245,7 @@ mod proof_stream_typed_tests {
             "prover_fiat_shamir() and verifier_fiat_shamir() are different when the stream isn't fully read"
         );
 
-        let _result = ps.dequeue();
+        let _ = ps.dequeue();
 
         assert_eq!(
             ps.prover_fiat_shamir(),

--- a/twenty-first/src/util_types/proof_stream_typed.rs
+++ b/twenty-first/src/util_types/proof_stream_typed.rs
@@ -1,12 +1,10 @@
 use itertools::Itertools;
-
 use std::error::Error;
 use std::fmt::Display;
 use std::marker::PhantomData;
 
 use crate::shared_math::{b_field_element::BFieldElement, rescue_prime_digest::Digest};
-
-use super::algebraic_hasher::{AlgebraicHasher, Hashable};
+use crate::util_types::algebraic_hasher::AlgebraicHasher;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ProofStream<Item, H: AlgebraicHasher> {
@@ -17,18 +15,14 @@ pub struct ProofStream<Item, H: AlgebraicHasher> {
     _hasher: PhantomData<H>,
 }
 
-impl<Item, H> Default for ProofStream<Item, H>
-where
-    H: Default + AlgebraicHasher,
-    Item: Default + Hashable,
-{
+impl<Item, H: AlgebraicHasher> Default for ProofStream<Item, H> {
     fn default() -> Self {
         Self {
-            items: Default::default(),
-            items_index: Default::default(),
-            transcript: Default::default(),
-            transcript_index: Default::default(),
-            _hasher: Default::default(),
+            items: vec![],
+            items_index: 0,
+            transcript: vec![],
+            transcript_index: 0,
+            _hasher: PhantomData,
         }
     }
 }
@@ -60,7 +54,7 @@ impl Error for ProofStreamError {}
 
 impl<Item, H> ProofStream<Item, H>
 where
-    Item: IntoIterator<Item = BFieldElement> + Clone + Default,
+    Item: IntoIterator<Item = BFieldElement> + Clone,
     H: AlgebraicHasher,
 {
     pub fn default() -> Self {

--- a/twenty-first/src/utils.rs
+++ b/twenty-first/src/utils.rs
@@ -831,31 +831,6 @@ where
     iter.into_iter().all(move |x| uniq.insert(x))
 }
 
-pub fn blake3_digest(input: &[u8]) -> [u8; 32] {
-    *blake3::hash(input).as_bytes()
-}
-
-pub fn get_n_hash_rounds(input: &[u8], n: u32) -> Vec<[u8; 32]> {
-    let mut output: Vec<[u8; 32]> = vec![];
-    for i in 0..n {
-        let mut input_clone = input.to_vec();
-
-        input_clone.extend_from_slice(&i.to_le_bytes());
-        let hash = *blake3::hash(input_clone.as_slice()).as_bytes();
-        output.push(hash);
-    }
-    output
-}
-
-// TODO: Not sure I trust the uniformity of this!!
-pub fn get_index_from_bytes(buf: &[u8], length: usize) -> usize {
-    let mut result = 0usize;
-    for elem in buf.iter() {
-        result = (result << 8 ^ *elem as usize) % length;
-    }
-    result
-}
-
 // Used in Merkle Tree tests and in STARK tests
 #[allow(dead_code)]
 pub fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
@@ -874,52 +849,13 @@ pub fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
 #[cfg(test)]
 mod test_utils {
     use super::*;
-    use crate::utils::decode_hex;
-
-    #[test]
-    fn get_index_from_bytes_test() {
-        let mut res = get_index_from_bytes(&[1], 4);
-        assert_eq!(1, res);
-        res = get_index_from_bytes(&[2], 4);
-        assert_eq!(2, res);
-        assert_eq!(3, get_index_from_bytes(&[3], 4));
-        assert_eq!(0, get_index_from_bytes(&[4], 4));
-        assert_eq!(9, get_index_from_bytes(&[9], 100));
-        assert_eq!(10, get_index_from_bytes(&[10], 100));
-        assert_eq!(11, get_index_from_bytes(&[11], 100));
-    }
-
-    #[test]
-    fn get_n_hash_rounds_test() {
-        let v: Vec<u8> = vec![1, 2];
-        let res3 = get_n_hash_rounds(&v[..], 3u32);
-        assert_eq!(3, res3.len());
-        let res5 = get_n_hash_rounds(&v[..], 5);
-        assert_eq!(5, res5.len());
-        for (r3_elem, r5_elem) in res3.iter().zip(res5.iter()) {
-            assert_eq!(*r3_elem, *r5_elem);
-        }
-
-        let mut prev = res5[0];
-        for r5_elem in res5.iter().skip(1) {
-            assert_ne!(prev, *r5_elem);
-            prev = *r5_elem;
-        }
-
-        // blake3(0x010200000000) =
-        // 677ff528c2a35e8f94d2f40b647392691bc05e6585f506169c797ec07087bc9c
-        assert_eq!(
-            decode_hex("677ff528c2a35e8f94d2f40b647392691bc05e6585f506169c797ec07087bc9c").unwrap(),
-            res3[0]
-        );
-    }
 
     #[test]
     fn has_unique_elements_test() {
-        let v = vec![10, 20, 30, 10, 50];
-        assert!(!has_unique_elements(v));
+        let v1 = vec![10, 20, 30, 10, 50];
+        assert!(!has_unique_elements(v1));
 
-        let v = vec![10, 20, 30, 40, 50];
-        assert!(has_unique_elements(v));
+        let v2 = vec![10, 20, 30, 40, 50];
+        assert!(has_unique_elements(v2));
     }
 }


### PR DESCRIPTION
The AlgebraicHasher trait outputs a `Digest`, consisting of `DIGEST_LEN` `BFieldElement`s, no matter if `blake3::Hasher` or `RescuePrimeRegular` is used. This means that `blake3::Hasher` can be used throughout the pipeline, including in Triton VM where digests have an expected format and size.

In `simple_hasher`:
- Remove `Hasher`
- Remove `SamplableFrom` in favor of `XFieldElement::sample()`
- Move `Hashable` to `AlgebraicHasher`

Associated types and type parameters are hardcoded in `AlgebraicHasher`
- `Hashable`'s parameter is always `BFieldElement`
- `Hasher`'s `T` (the associated type denoting the unit element of a digest) is always `BFieldElement`
- `Hasher`'s `Digest` (the associated type) is always `Digest` (the struct)

Refactor `.emojihash()`:
- Drop `.emojihash_raw()`
- Use `u64::to_be_bytes()` instead of Hasher's `.to_sequence()`

`impl Distribution<Digest> for Standard`:
- Makes `random_values()` capable of generating random digests.

Add `PhantomData<H>` back to:
- `MerkleTree`
- `MmrAccumulator`

...since they do not pass their 'H' onto their fields' types.