### PR TITLE
Drain padded input instead of re-allocating vector

### DIFF
--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -1024,7 +1024,7 @@ impl RescuePrimeRegular {
             {
                 *sponge_state_element += input_element.to_owned();
             }
-            padded_input = padded_input[RATE..].to_vec();
+            padded_input.drain(..RATE);
             Self::xlix(&mut sponge);
         }
 


### PR DESCRIPTION
This results in a ~19% speedup of `RescuePrimeRegular::hash_varlen()`.

Running `cargo bench varlen` before and after:

```
Benchmarking rescue_prime_regular/hash_varlen/RescuePrimeRegular / Hash Variable Length/16384:
time before:  [28.763 ms 28.812 ms 28.866 ms]
time after:   [23.233 ms 23.252 ms 23.277 ms]
change:      [-19.462%  -19.296%  -19.133%] (p = 0.00 < 0.05)
```