### PR TITLE
Allow hashing of multivariate polynomials

### DIFF
--- a/twenty-first/src/shared_math/mpolynomial.rs
+++ b/twenty-first/src/shared_math/mpolynomial.rs
@@ -2421,7 +2421,7 @@ mod test_mpolynomials {
             let mut hasher3 = DefaultHasher::new();
             rnd_mvpoly.hash(&mut hasher3);
             let hash3 = hasher3.finish();
-            assert_ne!(hash0, hash3, "hashing must change if mpoly changes");
+            assert_ne!(hash0, hash3, "hash digest must change if mpoly changes");
 
             // Digest must change if coefficient changes
             rnd_mvpoly.scalar_mul_mut(BFieldElement::new(4));


### PR DESCRIPTION
This allows us to put the multivariate polynomials into HashSet which will
be required for an efficient implementation of circuits. Through this HashSet
we can check if we are inserting a value that has already been encountered
and if so then use that already encountered value instead.