### PR TITLE
Arithmetic overloading

### DIFF
--- a/twenty-first/src/shared_math/traits.rs
+++ b/twenty-first/src/shared_math/traits.rs
@@ -66,16 +66,16 @@ pub trait FiniteField:
     + DeserializeOwned
     + PartialEq
     + Debug
-    + One
     + Zero
+    + One
     + Add<Output = Self>
-    + AddAssign
-    + SubAssign
-    + MulAssign
-    + Sub<Output = Self>
     + Mul<Output = Self>
+    + Sub<Output = Self>
     + Div<Output = Self>
     + Neg<Output = Self>
+    + AddAssign
+    + MulAssign
+    + SubAssign
     + FromVecu8
     + New
     + CyclicGroupGenerator

--- a/twenty-first/src/shared_math/x_field_element.rs
+++ b/twenty-first/src/shared_math/x_field_element.rs
@@ -12,9 +12,11 @@ use crate::shared_math::polynomial::Polynomial;
 use crate::shared_math::traits::{CyclicGroupGenerator, FiniteField, ModPowU32, ModPowU64, New};
 use crate::shared_math::traits::{FromVecu8, Inverse, PrimitiveRootOfUnity};
 
+pub const EXTENSION_DEGREE: usize = 3;
+
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, Serialize, Deserialize)]
 pub struct XFieldElement {
-    pub coefficients: [BFieldElement; 3],
+    pub coefficients: [BFieldElement; EXTENSION_DEGREE],
 }
 
 impl Default for XFieldElement {
@@ -58,7 +60,7 @@ impl From<Polynomial<BFieldElement>> for XFieldElement {
     fn from(poly: Polynomial<BFieldElement>) -> Self {
         let (_, rem) = poly.divide(Self::shah_polynomial());
         let zero = BFieldElement::zero();
-        let mut rem_arr: [BFieldElement; 3] = [zero; 3];
+        let mut rem_arr: [BFieldElement; EXTENSION_DEGREE] = [zero; EXTENSION_DEGREE];
 
         for i in 0..rem.degree() + 1 {
             rem_arr[i as usize] = rem.coefficients[i as usize];
@@ -80,12 +82,12 @@ impl XFieldElement {
     }
 
     #[inline]
-    pub fn new(coefficients: [BFieldElement; 3]) -> Self {
+    pub fn new(coefficients: [BFieldElement; EXTENSION_DEGREE]) -> Self {
         Self { coefficients }
     }
 
     #[inline]
-    pub fn new_u64(coeffs: [u64; 3]) -> Self {
+    pub fn new_u64(coeffs: [u64; EXTENSION_DEGREE]) -> Self {
         Self {
             coefficients: [
                 BFieldElement::new(coeffs[0]),
@@ -256,7 +258,7 @@ impl FromVecu8 for XFieldElement {
 impl Zero for XFieldElement {
     fn zero() -> Self {
         Self {
-            coefficients: [BFieldElement::zero(); 3],
+            coefficients: [BFieldElement::zero(); EXTENSION_DEGREE],
         }
     }
 

--- a/twenty-first/src/util_types/proof_stream_typed.rs
+++ b/twenty-first/src/util_types/proof_stream_typed.rs
@@ -119,8 +119,9 @@ mod proof_stream_typed_tests {
 
     use super::*;
     use crate::shared_math::{
-        b_field_element::BFieldElement, rescue_prime_regular::RescuePrimeRegular,
-        x_field_element::XFieldElement,
+        b_field_element::BFieldElement,
+        rescue_prime_regular::RescuePrimeRegular,
+        x_field_element::{XFieldElement, EXTENSION_DEGREE},
     };
 
     #[derive(Clone, Debug, PartialEq)]
@@ -180,7 +181,7 @@ mod proof_stream_typed_tests {
         // B
 
         let b_one = BFieldElement::one();
-        let bs_expected = vec![b_one; 3];
+        let bs_expected = vec![b_one; EXTENSION_DEGREE];
         let item_1 = TestItem::ManyB(bs_expected.clone());
         ps.enqueue(&item_1);
 
@@ -203,7 +204,7 @@ mod proof_stream_typed_tests {
 
         let x_one = XFieldElement::one();
 
-        let xs_expected = vec![x_one; 3];
+        let xs_expected = vec![x_one; EXTENSION_DEGREE];
         let item_2 = TestItem::ManyX(xs_expected.clone());
         ps.enqueue(&item_2);
 


### PR DESCRIPTION
- `pub const EXTENSION_DEGREE: usize = 3;`
- Add the following instances:
  - `impl Add<XFieldElement> for XFieldElement` (original)
  - `impl Add<BFieldElement> for XFieldElement` (new)
  - `impl Add<XFieldElement> for BFieldElement` (new)
  - `impl Mul<XFieldElement> for XFieldElement` (original)
  - `impl Mul<BFieldElement> for XFieldElement` (new)
  - `impl Mul<XFieldElement> for BFieldElement` (new)
  - `impl Sub<XFieldElement> for XFieldElement` (original)
  - `impl Sub<BFieldElement> for XFieldElement` (new)
  - `impl Sub<XFieldElement> for BFieldElement` (new)

Assert that they corresponding to lifting the BFieldElements.

**Note:** This only warrants a minor bump.