### PR TITLE
MerkleTreeMaker

### DIFF
--- a/stark-brainfuck/Cargo.toml
+++ b/stark-brainfuck/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stark-brainfuck"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Triton Software AG"]
 edition = "2021"
 

--- a/stark-rescue-prime/Cargo.toml
+++ b/stark-rescue-prime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stark-rescue-prime"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Triton Software AG"]
 edition = "2021"
 

--- a/twenty-first/src/util_types.rs
+++ b/twenty-first/src/util_types.rs
@@ -3,6 +3,7 @@ pub mod blake3_wrapper;
 pub mod database_array;
 pub mod database_vector;
 pub mod merkle_tree;
+pub mod merkle_tree_maker;
 pub mod mmr;
 pub mod proof_stream;
 pub mod proof_stream_typed;

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -730,21 +730,6 @@ mod merkle_tree_test {
             .sum()
     }
 
-    impl<H: AlgebraicHasher> MerkleTree<H> {
-        /// For writing negative tests only.
-        fn set_root(&mut self, new_root: Digest) {
-            self.nodes[1] = new_root
-        }
-    }
-
-    impl<H: AlgebraicHasher> SaltedMerkleTree<H> {
-        /// For writing negative tests only.
-        #[allow(dead_code)]
-        fn set_root(&mut self, new_root: Digest) {
-            self.internal_merkle_tree.set_root(new_root)
-        }
-    }
-
     #[test]
     fn merkle_tree_test_32() {
         type H = blake3::Hasher;

--- a/twenty-first/src/util_types/merkle_tree_maker.rs
+++ b/twenty-first/src/util_types/merkle_tree_maker.rs
@@ -1,0 +1,13 @@
+use crate::shared_math::rescue_prime_digest::Digest;
+use crate::util_types::algebraic_hasher::AlgebraicHasher;
+use crate::util_types::merkle_tree::MerkleTree;
+
+/// A `MerkleTree<M, T>` is parameterised over both
+///
+/// - `H: AlgebraicHasher`
+/// - `M: MerkleTreeMaker`
+///
+/// so that both the hash function and the method of assembling the Merkle tree may vary.
+pub trait MerkleTreeMaker<H: AlgebraicHasher> {
+    fn from_digests(digests: &[Digest]) -> MerkleTree<H, Self>;
+}

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -299,7 +299,7 @@ mod mmr_test {
     use crate::shared_math::other::random_elements;
     use crate::shared_math::rescue_prime_regular::RescuePrimeRegular;
     use crate::test_shared::mmr::{get_archival_mmr_from_digests, get_empty_archival_mmr};
-    use crate::util_types::merkle_tree::MerkleTree;
+    use crate::util_types::merkle_tree::{CpuParallel, MerkleTree};
     use crate::{
         shared_math::b_field_element::BFieldElement,
         util_types::mmr::{
@@ -319,6 +319,8 @@ mod mmr_test {
     #[test]
     fn empty_mmr_behavior_test() {
         type H = blake3::Hasher;
+        type M = CpuParallel;
+        type MT = MerkleTree<H, M>;
 
         let mut archival_mmr: ArchivalMmr<H> = get_empty_archival_mmr();
         let mut accumulator_mmr: MmrAccumulator<H> = MmrAccumulator::<H>::new(vec![]);
@@ -330,7 +332,7 @@ mod mmr_test {
         assert_eq!(archival_mmr.bag_peaks(), accumulator_mmr.bag_peaks());
         assert_eq!(
             archival_mmr.bag_peaks(),
-            MerkleTree::<H>::root_from_arbitrary_number_of_digests(&[]),
+            MT::root_from_arbitrary_number_of_digests(&[]),
             "Bagged peaks for empty MMR must agree with MT root finder"
         );
         assert_eq!(0, archival_mmr.count_nodes());
@@ -781,6 +783,8 @@ mod mmr_test {
     #[test]
     fn variable_size_rescue_prime_mmr_test() {
         type H = RescuePrimeRegular;
+        type M = CpuParallel;
+        type MT = MerkleTree<H, M>;
 
         let data_sizes: Vec<u128> = (1..34).collect();
         let node_counts: Vec<u128> = vec![
@@ -811,7 +815,7 @@ mod mmr_test {
 
             // Verify that MMR root from odd number of digests and MMR bagged peaks agree
             let mmra_root = mmr.bag_peaks();
-            let mt_root = MerkleTree::<H>::root_from_arbitrary_number_of_digests(&input_hashes);
+            let mt_root = MT::root_from_arbitrary_number_of_digests(&input_hashes);
 
             assert_eq!(
                 mmra_root, mt_root,
@@ -905,6 +909,8 @@ mod mmr_test {
     #[test]
     fn variable_size_blake3_mmr_test() {
         type H = blake3::Hasher;
+        type M = CpuParallel;
+        type MT = MerkleTree<H, M>;
 
         let node_counts: Vec<u128> = vec![
             1, 3, 4, 7, 8, 10, 11, 15, 16, 18, 19, 22, 23, 25, 26, 31, 32, 34, 35, 38, 39, 41, 42,
@@ -932,7 +938,7 @@ mod mmr_test {
 
             // Verify that MMR root from odd number of digests and MMR bagged peaks agree
             let mmra_root = mmr.bag_peaks();
-            let mt_root = MerkleTree::<H>::root_from_arbitrary_number_of_digests(&input_digests);
+            let mt_root = MT::root_from_arbitrary_number_of_digests(&input_digests);
             assert_eq!(
                 mmra_root, mt_root,
                 "MMRA bagged peaks and MT root must agree"


### PR DESCRIPTION
A `MerkleTree<M, T>` is parameterised over both

- `H: AlgebraicHasher`
- `M: MerkleTreeMaker`

so that both the hash function and the method of assembling the Merkle tree may vary.

This warrants a `0.x+1.0` version bump on next release.

The reviewer may benefit from reviewing one commit at a time.