### PR TITLE
Hashable objects

### DIFF
--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -181,41 +181,6 @@ impl BFieldElement {
         BFieldElement::new(u64::from_ne_bytes(bytes_copied))
     }
 
-    /// Convert a byte array to a vector of B field elements
-    pub fn from_byte_array<const N: usize>(input: [u8; N]) -> Vec<Self> {
-        // Although the output size should be known at compile time, Rust cannot handle constant
-        // expressions, so we have to accept a vector as output.
-        // Cf. https://github.com/rust-lang/rust/issues/76560
-        let bytes_per_element = 7;
-        let output_length = N / 7 + if N % 7 == 0 { 0 } else { 1 };
-        let full_iterations = N / 7;
-        let mut ret: Vec<BFieldElement> = Vec::with_capacity(output_length);
-        for i in 0..full_iterations {
-            let bytes: [u8; 7] = input[i * bytes_per_element..(i + 1) * bytes_per_element]
-                .try_into()
-                .expect("slice with incorrect length");
-
-            // I think a specific function can be used here, we shouldn't use a for-loop
-            let mut u64_input: [u8; 8] = [0u8; 8];
-            u64_input[..bytes_per_element].copy_from_slice(&bytes[..bytes_per_element]);
-
-            let u64_value: u64 = u64::from_le_bytes(u64_input);
-            ret.push(BFieldElement(u64_value));
-        }
-
-        // Handle any remaining bits, if input length is not a factor of 7.
-        if full_iterations + 1 == output_length {
-            // We are missing `7 % N` bytes
-            let remaining = N % 7;
-            let mut u64_input: [u8; 8] = [0u8; 8];
-            u64_input[..remaining].copy_from_slice(&input[full_iterations * bytes_per_element..]);
-            let u64_value: u64 = u64::from_le_bytes(u64_input);
-            ret.push(BFieldElement(u64_value));
-        }
-
-        ret
-    }
-
     #[inline(always)]
     fn mod_reduce(x: u128) -> u64 {
         // Copied from (MIT licensed):
@@ -601,52 +566,6 @@ mod b_prime_field_element_test {
             let array: [u8; 8] = x.into();
             let x_recalculated: BFieldElement = array.into();
             assert_eq!(x, x_recalculated);
-        }
-    }
-
-    #[test]
-    fn byte_array_conversion_multiple_test() {
-        // Ensure we can't overflow
-        {
-            let byte_array_0: [u8; 7] = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
-            let output = BFieldElement::from_byte_array(byte_array_0);
-            assert_eq!(1, output.len());
-            assert_eq!(BFieldElement((1 << 56) - 1), output[0]);
-        }
-
-        // Ensure we're using little-endianness
-        {
-            let byte_array_1: [u8; 7] = [100, 0, 0, 0, 0, 0, 0];
-            let output = BFieldElement::from_byte_array(byte_array_1);
-            assert_eq!(1, output.len());
-            assert_eq!(BFieldElement(100), output[0]);
-        }
-
-        {
-            // Ensure we can handle bigger inputs, with lengths not multiple of 7
-            let byte_array_3: [u8; 33] = [
-                100, 0, 0, 0, 0, 0, 0, 200, 0, 0, 0, 0, 0, 0, 100, 100, 0, 0, 0, 0, 0, 100, 0, 0,
-                0, 0, 0, 0, 150, 0, 0, 0, 0,
-            ];
-            let output = BFieldElement::from_byte_array(byte_array_3);
-            assert_eq!(5, output.len());
-            assert_eq!(BFieldElement(100), output[0]);
-            assert_eq!(BFieldElement(200), output[1]);
-            assert_eq!(BFieldElement(100 * 256 + 100), output[2]);
-            assert_eq!(BFieldElement(100), output[3]);
-            assert_eq!(BFieldElement(150), output[4]);
-
-            // Assert more sizes can be handled, without crashing
-            assert_eq!(1, BFieldElement::from_byte_array([0u8; 1]).len());
-            assert_eq!(1, BFieldElement::from_byte_array([0u8; 3]).len());
-            assert_eq!(1, BFieldElement::from_byte_array([0u8; 2]).len());
-            assert_eq!(1, BFieldElement::from_byte_array([0u8; 4]).len());
-            assert_eq!(1, BFieldElement::from_byte_array([0u8; 5]).len());
-            assert_eq!(1, BFieldElement::from_byte_array([0u8; 6]).len());
-            assert_eq!(2, BFieldElement::from_byte_array([0u8; 8]).len());
-            assert_eq!(2, BFieldElement::from_byte_array([0u8; 9]).len());
-            assert_eq!(2, BFieldElement::from_byte_array([0u8; 14]).len());
-            assert_eq!(3, BFieldElement::from_byte_array([0u8; 15]).len());
         }
     }
 

--- a/twenty-first/src/shared_math/rescue_prime_digest.rs
+++ b/twenty-first/src/shared_math/rescue_prime_digest.rs
@@ -16,8 +16,6 @@ use crate::shared_math::traits::FromVecu8;
 pub struct Digest([BFieldElement; DIGEST_LENGTH]);
 // FIXME: Make Digest a record instead of a tuple.
 
-pub const MSG_DIGEST_SIZE_IN_BYTES: usize = 32;
-
 impl GetSize for Digest {
     fn get_stack_size() -> usize {
         std::mem::size_of::<Self>()
@@ -155,33 +153,9 @@ impl From<[u8; Digest::BYTES]> for Digest {
     }
 }
 
-// The implementations for dev net byte arrays are not to be used on main net
-impl From<Digest> for [u8; MSG_DIGEST_SIZE_IN_BYTES] {
-    fn from(input: Digest) -> Self {
-        let whole: [u8; Digest::BYTES] = input.into();
-        whole[0..MSG_DIGEST_SIZE_IN_BYTES]
-            .to_vec()
-            .try_into()
-            .unwrap()
-    }
-}
-
 #[cfg(test)]
 mod digest_tests {
     use super::*;
-
-    #[test]
-    fn signature_digest_conversion_test() {
-        let bfe_vec = vec![
-            BFieldElement::new(12),
-            BFieldElement::new(24),
-            BFieldElement::new(36),
-            BFieldElement::new(48),
-            BFieldElement::new(60),
-        ];
-        let digest_from_array: Digest = bfe_vec.try_into().unwrap();
-        let _shorter: [u8; MSG_DIGEST_SIZE_IN_BYTES] = digest_from_array.into();
-    }
 
     #[test]
     pub fn get_size() {

--- a/twenty-first/src/shared_math/rescue_prime_digest.rs
+++ b/twenty-first/src/shared_math/rescue_prime_digest.rs
@@ -42,6 +42,16 @@ impl Digest {
     pub fn new(digest: [BFieldElement; DIGEST_LENGTH]) -> Self {
         Self(digest)
     }
+
+    pub fn emojihash(&self) -> String {
+        let [a, b, c, d, e] = self.0.map(|bfe| {
+            emojihash::hash(&bfe.value().to_be_bytes())
+                .chars()
+                .take(DIGEST_LENGTH)
+                .collect::<String>()
+        });
+        format!("[{a}|{b}|{c}|{d}|{e}]")
+    }
 }
 
 impl Default for Digest {

--- a/twenty-first/src/shared_math/traits.rs
+++ b/twenty-first/src/shared_math/traits.rs
@@ -86,7 +86,6 @@ pub trait FiniteField:
     + Copy
     + Hash
     + Inverse
-    + Default
 {
     /// Montgomery Batch Inversion
     // Adapted from https://paulmillr.com/posts/noble-secp256k1-fast-ecc/#batch-inversion

--- a/twenty-first/src/shared_math/x_field_element.rs
+++ b/twenty-first/src/shared_math/x_field_element.rs
@@ -19,14 +19,6 @@ pub struct XFieldElement {
     pub coefficients: [BFieldElement; EXTENSION_DEGREE],
 }
 
-impl Default for XFieldElement {
-    fn default() -> Self {
-        Self {
-            coefficients: [1u64.into(), 0u64.into(), 0u64.into()],
-        }
-    }
-}
-
 impl Sum for XFieldElement {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.reduce(|a, b| a + b)

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -121,3 +121,40 @@ impl Hashable for BFieldElement {
         vec![*self]
     }
 }
+
+#[cfg(test)]
+mod algebraic_hasher_tests {
+    use rand::Rng;
+
+    use crate::shared_math::rescue_prime_regular::DIGEST_LENGTH;
+    use crate::shared_math::x_field_element::EXTENSION_DEGREE;
+
+    use super::*;
+
+    #[test]
+    fn to_sequence_length_test() {
+        let mut rng = rand::thread_rng();
+        let bfe_max = BFieldElement::new(BFieldElement::MAX);
+
+        let some_digest: Digest = rng.gen();
+        let zero_digest: Digest = Digest::new([BFieldElement::zero(); DIGEST_LENGTH]);
+        let max_digest: Digest = Digest::new([bfe_max; DIGEST_LENGTH]);
+        for digest in [some_digest, zero_digest, max_digest] {
+            assert_eq!(DIGEST_LENGTH, digest.to_sequence().len());
+        }
+
+        let some_u128: u128 = rng.gen();
+        let zero_u128: u128 = 0;
+        let max_u128: u128 = u128::MAX;
+        for u128 in [some_u128, zero_u128, max_u128] {
+            assert_eq!(DIGEST_LENGTH, u128.to_sequence().len());
+        }
+
+        let some_xfe: XFieldElement = rng.gen();
+        let zero_xfe: XFieldElement = XFieldElement::zero();
+        let max_xfe: XFieldElement = XFieldElement::new([bfe_max; EXTENSION_DEGREE]);
+        for xfe in [some_xfe, zero_xfe, max_xfe] {
+            assert_eq!(EXTENSION_DEGREE, xfe.to_sequence().len());
+        }
+    }
+}


### PR DESCRIPTION
Various small changes
- Add Digest::emojihash(&self)
- Remove 'impl Default for XFieldElement'
- Remove BFieldElement::from_byte_array() 
- Hashable: Test that .to_sequence() returns expectable lengths
- Remove impl From<Digest> for [u8; MSG_DIGEST_SIZE_IN_BYTES]