### PR TITLE
Switch to Montgomery representation on B field

### DIFF
--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twenty-first"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Triton Software AG"]
 edition = "2021"
 

--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -477,6 +477,7 @@ mod b_prime_field_element_test {
     use crate::shared_math::polynomial::Polynomial;
     use itertools::izip;
     use proptest::prelude::*;
+    use rand::thread_rng;
 
     #[test]
     fn display_test() {
@@ -1036,5 +1037,22 @@ mod b_prime_field_element_test {
         } else {
             assert_eq!(one, elem * elem.inverse_or_zero());
         }
+    }
+
+    #[test]
+    fn test_random_squares() {
+        let mut rng = thread_rng();
+        let p = 0xffff_ffff_0000_0001u128;
+        let a = rng.next_u64() % (p as u64);
+        for _ in 0..100 {
+            let asq = (((a as u128) * (a as u128)) % p) as u64;
+            let b = BFieldElement::new(a);
+            let bsq = BFieldElement::new(asq);
+            assert_eq!(bsq, b * b);
+            assert_eq!(bsq.value(), (b * b).value());
+            assert_eq!(b.value(), a);
+        }
+        let one = BFieldElement::new(1);
+        assert_eq!(one, one * one);
     }
 }

--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -15,7 +15,7 @@ use std::num::TryFromIntError;
 use std::ops::{AddAssign, MulAssign, SubAssign};
 use std::{
     fmt::{self},
-    ops::{Add, Div, Mul, Neg, Rem, Sub},
+    ops::{Add, Div, Mul, Neg, Sub},
 };
 
 static PRIMITIVE_ROOTS: phf::Map<u64, u64> = phf_map! {
@@ -423,15 +423,6 @@ impl Neg for BFieldElement {
     #[inline]
     fn neg(self) -> Self {
         Self::zero() - self
-    }
-}
-
-impl Rem for BFieldElement {
-    type Output = Self;
-
-    // TODO: We should probably get rid of this
-    fn rem(self, _other: Self) -> Self {
-        Self::zero()
     }
 }
 

--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -68,7 +68,8 @@ impl Sum for BFieldElement {
 
 impl PartialEq for BFieldElement {
     fn eq(&self, other: &Self) -> bool {
-        Self::equals(self.0, other.0) == 0xFFFFFFFFFFFFFFFF
+        let t = self.0 ^ other.0;
+        !((((t | t.wrapping_neg()) as i64) >> 63) as u64) == 0xFFFFFFFFFFFFFFFF
     }
 }
 
@@ -189,12 +190,6 @@ impl BFieldElement {
 
         let (r, c) = xh.overflowing_sub(b);
         r.wrapping_sub(0u32.wrapping_sub(c as u32) as u64)
-    }
-
-    #[inline(always)]
-    pub fn equals(lhs: u64, rhs: u64) -> u64 {
-        let t = lhs ^ rhs;
-        !((((t | t.wrapping_neg()) as i64) >> 63) as u64)
     }
 }
 


### PR DESCRIPTION
This leads to a 20-30 % reduction in time for NTT on my P17 machine and a 15-25 % reduction in runtime with an AMD Threadripper 5995.

The internal representation of the B field element is a bit more complicated now, so some of the tests had to be changed as well as they shouldn't access or have opinions about the internal representation, only the results of various calculations.