### PR TITLE
Inline tip5-related functions for a small speedup

### DIFF
--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -221,11 +221,13 @@ impl BFieldElement {
         )
     }
 
+    #[inline]
     pub fn raw_u128(&self) -> u128 {
         self.0.into()
     }
 
-    pub fn from_raw_u64(e: u64) -> BFieldElement {
+    #[inline]
+    pub const fn from_raw_u64(e: u64) -> BFieldElement {
         BFieldElement(e)
     }
 }

--- a/twenty-first/src/shared_math/tip5.rs
+++ b/twenty-first/src/shared_math/tip5.rs
@@ -87,6 +87,7 @@ impl Tip5 {
     }
 
     #[allow(clippy::many_single_char_names)]
+    #[inline]
     fn ntt_noswap(x: &mut [BFieldElement]) {
         const POWERS_OF_OMEGA_BITREVERSED: [BFieldElement; 8] = [
             BFieldElement::new(1),
@@ -140,6 +141,7 @@ impl Tip5 {
     }
 
     #[allow(clippy::many_single_char_names)]
+    #[inline]
     fn intt_noswap(x: &mut [BFieldElement]) {
         const POWERS_OF_OMEGA_INVERSE: [BFieldElement; 8] = [
             BFieldElement::new(1),
@@ -341,6 +343,7 @@ impl Tip5 {
     }
 
     // permutation
+    #[inline]
     fn permutation(&self, sponge: &mut Tip5State) {
         for i in 0..NUM_ROUNDS {
             self.round(sponge, i);


### PR DESCRIPTION
Inline a few functions used in tip5 to gain a 1-3 % speedup on the tip5 benchmark.

No inling
tip5/hash_10/Tip5 / Hash 10/10
                        time:   [747.29 ns 752.33 ns 758.48 ns]

tip5/hash_varlen/Tip5 / Hash Variable Length/16384
                        time:   [2.5593 ms 2.5771 ms 2.6001 ms]

tip5/parallel/Tip5 / Parallel Hash/65536
                        time:   [1.4635 ms 1.4834 ms 1.5058 ms]

With inlining
tip5/hash_10/Tip5 / Hash 10/10
                        time:   [722.53 ns 727.50 ns 733.53 ns]

tip5/hash_varlen/Tip5 / Hash Variable Length/16384
                        time:   [2.5468 ms 2.5718 ms 2.5997 ms]

tip5/parallel/Tip5 / Parallel Hash/65536
                        time:   [1.4324 ms 1.4548 ms 1.4830 ms]