### PR TITLE
Generate random `U32s<N>`s

### DIFF
--- a/twenty-first/src/amount/u32s.rs
+++ b/twenty-first/src/amount/u32s.rs
@@ -1,14 +1,15 @@
+use std::convert::TryFrom;
+use std::fmt::Display;
+use std::iter::Sum;
+use std::ops::{Add, Div, Mul, Rem, Sub};
+
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
+use rand::Rng;
+use rand_distr::{Distribution, Standard};
 use serde_big_array;
 use serde_big_array::BigArray;
 use serde_derive::{Deserialize, Serialize};
-use std::{
-    convert::TryFrom,
-    fmt::Display,
-    iter::Sum,
-    ops::{Add, Div, Mul, Rem, Sub},
-};
 
 use crate::shared_math::b_field_element::BFieldElement;
 use crate::util_types::algebraic_hasher::Hashable;
@@ -295,6 +296,13 @@ impl<const N: usize> Mul for U32s<N> {
 impl<const N: usize> Sum for U32s<N> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), |a, b| a + b)
+    }
+}
+
+impl<const N: usize> Distribution<U32s<N>> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> U32s<N> {
+        let values = rng.sample::<[u32; N], Standard>(Standard);
+        U32s { values }
     }
 }
 


### PR DESCRIPTION
- `impl<const N: usize> Distribution<U32s<N>> for Standard`
- U32s tests: Split `get_u32s()` use into `random_elements()` and `random_masked_u32s()`

The motivation is to make [tasm-lib](https://github.com/TritonVM/tasm-lib) tests for `u64` operators more readable.

The main part of this commit is:

```rust
impl<const N: usize> Distribution<U32s<N>> for Standard {
    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> U32s<N> {
        let values = rng.sample::<[u32; N], Standard>(Standard);
        U32s { values }
    }
}
```

This enables:

```rust
// Generate a single random value
let mut rng = rand::thread_rng();
let single: U32s<N> = rng.gen();

use twenty_first::shared_math::other::{random_elements, random_elements_array};

// Generate a vector of `n: usize` random values
let many_vec: Vec<U32s<N>> = random_elements(n);

// Generate an array of `const K: usize` random values
let many_arr: [U32s<N>; K] = random_elements_array();
```