### PR TITLE
Hashing: Increase OUTPUT_LENGTH from 5 to 10

### DIFF
--- a/stark-rescue-prime/src/stark_rp.rs
+++ b/stark-rescue-prime/src/stark_rp.rs
@@ -9,6 +9,7 @@ use std::convert::TryInto;
 use std::error::Error;
 use std::fmt;
 use std::iter::zip;
+use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
 
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::fri::Fri;

--- a/twenty-first/benches/rescue_prime_optimized.rs
+++ b/twenty-first/benches/rescue_prime_optimized.rs
@@ -4,7 +4,8 @@ use rand::RngCore;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::other::random_elements;
-use twenty_first::shared_math::rescue_prime_optimized::{RescuePrimeOptimized, DIGEST_LENGTH};
+use twenty_first::shared_math::rescue_prime_optimized::RescuePrimeOptimized;
+use twenty_first::util_types::algebraic_hasher::OUTPUT_LENGTH;
 
 fn bench_10(c: &mut Criterion) {
     let mut group = c.benchmark_group("rescue_prime_optimized/hash_10");
@@ -59,7 +60,7 @@ fn bench_parallel(c: &mut Criterion) {
                 elements
                     .par_iter()
                     .map(RescuePrimeOptimized::hash_10)
-                    .collect::<Vec<[BFieldElement; DIGEST_LENGTH]>>()
+                    .collect::<Vec<[BFieldElement; OUTPUT_LENGTH]>>()
             });
         },
     );

--- a/twenty-first/benches/rescue_prime_regular.rs
+++ b/twenty-first/benches/rescue_prime_regular.rs
@@ -4,8 +4,8 @@ use rand::RngCore;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::other::random_elements;
-use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
 use twenty_first::shared_math::rescue_prime_regular::RescuePrimeRegular;
+use twenty_first::util_types::algebraic_hasher::OUTPUT_LENGTH;
 
 fn bench_10(c: &mut Criterion) {
     let mut group = c.benchmark_group("rescue_prime_regular/hash_10");
@@ -60,7 +60,7 @@ fn bench_parallel(c: &mut Criterion) {
                 elements
                     .par_iter()
                     .map(RescuePrimeRegular::hash_10)
-                    .collect::<Vec<[BFieldElement; DIGEST_LENGTH]>>()
+                    .collect::<Vec<[BFieldElement; OUTPUT_LENGTH]>>()
             });
         },
     );

--- a/twenty-first/benches/rescue_prime_regular.rs
+++ b/twenty-first/benches/rescue_prime_regular.rs
@@ -4,7 +4,8 @@ use rand::RngCore;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::other::random_elements;
-use twenty_first::shared_math::rescue_prime_regular::{RescuePrimeRegular, DIGEST_LENGTH};
+use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
+use twenty_first::shared_math::rescue_prime_regular::RescuePrimeRegular;
 
 fn bench_10(c: &mut Criterion) {
     let mut group = c.benchmark_group("rescue_prime_regular/hash_10");

--- a/twenty-first/benches/tip5.rs
+++ b/twenty-first/benches/tip5.rs
@@ -4,7 +4,7 @@ use rand::RngCore;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::other::random_elements;
-use twenty_first::shared_math::rescue_prime_regular::DIGEST_LENGTH;
+use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
 use twenty_first::shared_math::tip5::Tip5;
 
 fn bench_10(c: &mut Criterion) {

--- a/twenty-first/benches/tip5.rs
+++ b/twenty-first/benches/tip5.rs
@@ -4,8 +4,8 @@ use rand::RngCore;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::other::random_elements;
-use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
 use twenty_first::shared_math::tip5::Tip5;
+use twenty_first::util_types::algebraic_hasher::OUTPUT_LENGTH;
 
 fn bench_10(c: &mut Criterion) {
     let mut group = c.benchmark_group("tip5/hash_10");
@@ -59,7 +59,7 @@ fn bench_parallel(c: &mut Criterion) {
             elements
                 .par_iter()
                 .map(|e| tip5.hash_10(e))
-                .collect::<Vec<[BFieldElement; DIGEST_LENGTH]>>()
+                .collect::<Vec<[BFieldElement; OUTPUT_LENGTH]>>()
         });
     });
 }

--- a/twenty-first/src/shared_math/rescue_prime_digest.rs
+++ b/twenty-first/src/shared_math/rescue_prime_digest.rs
@@ -9,13 +9,14 @@ use rand_distr::{Distribution, Standard};
 use serde::{Deserialize, Serialize};
 
 use crate::shared_math::b_field_element::{BFieldElement, BFIELD_ZERO};
-use crate::shared_math::rescue_prime_regular::DIGEST_LENGTH;
 use crate::shared_math::traits::FromVecu8;
+use crate::util_types::algebraic_hasher::OUTPUT_LENGTH;
 use crate::util_types::emojihash_trait::Emojihash;
+
+pub const DIGEST_LENGTH: usize = 5;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Digest([BFieldElement; DIGEST_LENGTH]);
-// FIXME: Make Digest a record instead of a tuple.
 
 impl GetSize for Digest {
     fn get_stack_size() -> usize {
@@ -40,6 +41,10 @@ impl Digest {
 
     pub fn new(digest: [BFieldElement; DIGEST_LENGTH]) -> Self {
         Self(digest)
+    }
+
+    pub fn from_hash_op(input: [BFieldElement; OUTPUT_LENGTH]) -> Self {
+        Self((&input[..DIGEST_LENGTH]).try_into().unwrap())
     }
 }
 

--- a/twenty-first/src/shared_math/rescue_prime_optimized.rs
+++ b/twenty-first/src/shared_math/rescue_prime_optimized.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::shared_math::b_field_element::BFieldElement;
 use crate::shared_math::traits::FiniteField;
-use crate::util_types::algebraic_hasher::AlgebraicHasher;
+use crate::util_types::algebraic_hasher::{AlgebraicHasher, INPUT_LENGTH, OUTPUT_LENGTH};
 
 use super::rescue_prime_digest::Digest;
 
@@ -816,15 +816,12 @@ impl RescuePrimeOptimized {
 }
 
 impl AlgebraicHasher for RescuePrimeOptimized {
-    fn hash_slice(elements: &[BFieldElement]) -> Digest {
-        Digest::new(RescuePrimeOptimized::hash_varlen(elements))
+    fn hash_op(input: &[BFieldElement; INPUT_LENGTH]) -> [BFieldElement; OUTPUT_LENGTH] {
+        RescuePrimeOptimized::hash_10(input)
     }
 
-    fn hash_pair(left: &Digest, right: &Digest) -> Digest {
-        let mut input = [BFieldElement::zero(); 10];
-        input[..DIGEST_LENGTH].copy_from_slice(&left.values());
-        input[DIGEST_LENGTH..].copy_from_slice(&right.values());
-        Digest::new(RescuePrimeOptimized::hash_10(&input))
+    fn hash_slice(elements: &[BFieldElement]) -> Digest {
+        Digest::new(RescuePrimeOptimized::hash_varlen(elements))
     }
 }
 

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -4,11 +4,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::shared_math::b_field_element::{BFieldElement, BFIELD_ONE, BFIELD_ZERO};
 use crate::shared_math::traits::FiniteField;
-use crate::util_types::algebraic_hasher::AlgebraicHasher;
+use crate::util_types::algebraic_hasher::{AlgebraicHasher, INPUT_LENGTH, OUTPUT_LENGTH};
 
-use super::rescue_prime_digest::Digest;
+use super::rescue_prime_digest::{Digest, DIGEST_LENGTH};
 
-pub const DIGEST_LENGTH: usize = 5;
 pub const STATE_SIZE: usize = 16;
 pub const CAPACITY: usize = 6;
 pub const RATE: usize = 10;
@@ -1078,15 +1077,12 @@ impl RescuePrimeRegular {
 }
 
 impl AlgebraicHasher for RescuePrimeRegular {
-    fn hash_slice(elements: &[BFieldElement]) -> Digest {
-        Digest::new(RescuePrimeRegular::hash_varlen(elements))
+    fn hash_op(input: &[BFieldElement; INPUT_LENGTH]) -> [BFieldElement; OUTPUT_LENGTH] {
+        RescuePrimeRegular::hash_10(input)
     }
 
-    fn hash_pair(left: &Digest, right: &Digest) -> Digest {
-        let mut input = [BFIELD_ZERO; 10];
-        input[..DIGEST_LENGTH].copy_from_slice(&left.values());
-        input[DIGEST_LENGTH..].copy_from_slice(&right.values());
-        Digest::new(RescuePrimeRegular::hash_10(&input))
+    fn hash_slice(elements: &[BFieldElement]) -> Digest {
+        Digest::new(RescuePrimeRegular::hash_varlen(elements))
     }
 }
 

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -6,7 +6,7 @@ use crate::shared_math::rescue_prime_digest::{Digest, DIGEST_LENGTH};
 use crate::shared_math::x_field_element::XFieldElement;
 
 pub const INPUT_LENGTH: usize = 10;
-pub const OUTPUT_LENGTH: usize = 5;
+pub const OUTPUT_LENGTH: usize = 10;
 
 pub trait AlgebraicHasher: Clone + Send + Sync {
     /// The `hash_op` method corresponds to the `hash` instruction in Triton VM.

--- a/twenty-first/src/util_types/blake3_wrapper.rs
+++ b/twenty-first/src/util_types/blake3_wrapper.rs
@@ -3,9 +3,19 @@ use num_traits::Zero;
 
 use crate::shared_math::b_field_element::BFieldElement;
 use crate::shared_math::rescue_prime_digest::Digest;
-use crate::util_types::algebraic_hasher::{AlgebraicHasher, Hashable};
+use crate::util_types::algebraic_hasher::AlgebraicHasher;
+
+use super::algebraic_hasher::{INPUT_LENGTH, OUTPUT_LENGTH};
 
 impl AlgebraicHasher for blake3::Hasher {
+    fn hash_op(input: &[BFieldElement; INPUT_LENGTH]) -> [BFieldElement; OUTPUT_LENGTH] {
+        let mut hasher = Self::new();
+        for elem in input.iter() {
+            hasher.update(&elem.value().to_be_bytes());
+        }
+        blake3_hash_op(&hasher.finalize())
+    }
+
     fn hash_slice(elements: &[BFieldElement]) -> Digest {
         let mut hasher = Self::new();
         for elem in elements.iter() {
@@ -13,20 +23,25 @@ impl AlgebraicHasher for blake3::Hasher {
         }
         from_blake3_digest(&hasher.finalize())
     }
-
-    fn hash_pair(left: &Digest, right: &Digest) -> Digest {
-        Self::hash_slice(&vec![left.to_sequence(), right.to_sequence()].concat())
-    }
 }
 
-pub fn from_blake3_digest(digest: &blake3::Hash) -> Digest {
+/// Convert a `blake3::Hash` to a `[BFieldElement; OUTPUT_LENGTH]`.
+///
+/// This is used by legacy STARKs as well as twenty-first unit tests.
+pub fn blake3_hash_op(digest: &blake3::Hash) -> [BFieldElement; OUTPUT_LENGTH] {
     let bytes: &[u8; OUT_LEN] = digest.as_bytes();
-    let elements = [
+    [
         BFieldElement::from_ne_bytes(&bytes[0..8]),
         BFieldElement::from_ne_bytes(&bytes[8..16]),
         BFieldElement::from_ne_bytes(&bytes[16..24]),
         BFieldElement::from_ne_bytes(&bytes[24..32]),
         BFieldElement::zero(),
-    ];
-    Digest::new(elements)
+    ]
+}
+
+/// Convert a `blake3::Hash` to a `rescue_prime_digest::Digest`.
+///
+/// This is used by legacy STARKs as well as twenty-first unit tests.
+pub fn from_blake3_digest(digest: &blake3::Hash) -> Digest {
+    Digest::new(blake3_hash_op(digest))
 }

--- a/twenty-first/src/util_types/mmr/shared.rs
+++ b/twenty-first/src/util_types/mmr/shared.rs
@@ -676,7 +676,7 @@ mod mmr_test {
         for _ in 0..10000 {
             let rand = rng.next_u64();
             println!("{rand}");
-            let rll = right_lineage_length(rand as u128) as u32;
+            let rll = right_lineage_length(rand as u128);
             let rac = right_lineage_length_and_own_height(rand as u128).0;
             assert_eq!(rac, rll);
         }


### PR DESCRIPTION
AlgebraicHasher:
 - hash_op: The interface now holds a function that is essentially hash_10, but 1) does not mention the number 10, and 2) lives on the interface.
 - hash_pair: Since hash_op is available on the interface, it can be defined generally instead of in the trait instance for each hash function.
 - INPUT_LENGTH: This is currently 10. Now it has a variable!
 - OUTPUT_LENGTH: This is currently 5, but will be increased to 10.

Digest:
 - DIGEST_LENGTH: Move to rescue_prime_digest because it's a part of the interface for digests rather than any concrete hash function implementation. (There are currently 3 competing, and they all adhere to the same digest length, but redefine the constant.)