### PR TITLE
SpongeHasher

### DIFF
--- a/stark-rescue-prime/benches/stark_rp.rs
+++ b/stark-rescue-prime/benches/stark_rp.rs
@@ -3,6 +3,7 @@ use num_traits::{One, Zero};
 
 use stark_shared::proof_stream::ProofStream;
 use twenty_first::shared_math::b_field_element::BFieldElement;
+use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
 use twenty_first::shared_math::rescue_prime_regular::{RescuePrimeRegular, STATE_SIZE};
 use twenty_first::shared_math::traits::PrimitiveRootOfUnity;
 use twenty_first::timing_reporter::TimingReporter;

--- a/stark-rescue-prime/benches/stark_rp.rs
+++ b/stark-rescue-prime/benches/stark_rp.rs
@@ -25,13 +25,15 @@ fn stark_medium(criterion: &mut Criterion) {
 
         let mut input = [BFieldElement::zero(); 10];
         input[0] = BFieldElement::one();
-        let (output, trace) = RescuePrimeRegular::hash_10_with_trace(&input);
+        let trace = RescuePrimeRegular::trace(&input);
+        let output = &trace[trace.len() - 1][0..DIGEST_LENGTH];
+
         timer.elapsed("rp.eval_and_trace(...)");
         let omicron = BFieldElement::primitive_root_of_unity(32).unwrap();
         timer.elapsed("BFieldElement::get_primitive_root_of_unity(32)");
         let air_constraints = StarkRp::get_air_constraints(omicron);
         timer.elapsed("rp.get_air_constraints(omicron)");
-        let boundary_constraints = StarkRp::get_boundary_constraints(&output);
+        let boundary_constraints = StarkRp::get_boundary_constraints(output);
         timer.elapsed("rp.get_boundary_constraints(...)");
 
         let report = timer.finish();

--- a/stark-rescue-prime/benches/stark_rp.rs
+++ b/stark-rescue-prime/benches/stark_rp.rs
@@ -1,10 +1,11 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use num_traits::{One, Zero};
 
+use stark_rescue_prime::rescue_prime_trace;
 use stark_shared::proof_stream::ProofStream;
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
-use twenty_first::shared_math::rescue_prime_regular::{RescuePrimeRegular, STATE_SIZE};
+use twenty_first::shared_math::rescue_prime_regular::STATE_SIZE;
 use twenty_first::shared_math::traits::PrimitiveRootOfUnity;
 use twenty_first::timing_reporter::TimingReporter;
 
@@ -25,7 +26,7 @@ fn stark_medium(criterion: &mut Criterion) {
 
         let mut input = [BFieldElement::zero(); 10];
         input[0] = BFieldElement::one();
-        let trace = RescuePrimeRegular::trace(&input);
+        let trace = rescue_prime_trace(&input);
         let output = &trace[trace.len() - 1][0..DIGEST_LENGTH];
 
         timer.elapsed("rp.eval_and_trace(...)");

--- a/stark-rescue-prime/src/lib.rs
+++ b/stark-rescue-prime/src/lib.rs
@@ -1,2 +1,26 @@
+use twenty_first::shared_math::b_field_element::{BFieldElement, BFIELD_ONE, BFIELD_ZERO};
+use twenty_first::shared_math::rescue_prime_regular::RescuePrimeRegular;
+use twenty_first::shared_math::rescue_prime_regular::{NUM_ROUNDS, RATE, STATE_SIZE};
+
 pub mod stark_constraints;
 pub mod stark_rp;
+
+/// trace
+/// Produces the execution trace for one invocation of XLIX
+///
+/// `RescuePrimeRegular::trace()` function was extended to include the full state
+/// width for purposes that are unrelated to tracing the tutorial Rescue-Prime function.
+/// This function serves as a legacy wrapper
+pub fn rescue_prime_trace(
+    input: &[BFieldElement; 10],
+) -> [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS] {
+    let mut state: [BFieldElement; STATE_SIZE] = [BFIELD_ZERO; STATE_SIZE];
+
+    // absorb
+    state[..10].copy_from_slice(input);
+
+    // domain separation
+    state[RATE] = BFIELD_ONE;
+
+    RescuePrimeRegular::trace(state)
+}

--- a/stark-rescue-prime/src/stark_rp.rs
+++ b/stark-rescue-prime/src/stark_rp.rs
@@ -1179,7 +1179,6 @@ pub mod test_stark {
     use rand::Rng;
     use serde_json;
 
-    use twenty_first::shared_math::rescue_prime_regular::RescuePrimeRegular;
     use twenty_first::timing_reporter::TimingReporter;
 
     fn gen_polynomial() -> Polynomial<BFieldElement> {

--- a/stark-rescue-prime/src/stark_rp.rs
+++ b/stark-rescue-prime/src/stark_rp.rs
@@ -21,6 +21,7 @@ use twenty_first::shared_math::other::random_elements_array;
 use twenty_first::shared_math::other::roundup_npo2;
 use twenty_first::shared_math::polynomial::Polynomial;
 use twenty_first::shared_math::rescue_prime_digest::Digest;
+use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
 use twenty_first::shared_math::rescue_prime_regular::*;
 use twenty_first::shared_math::traits::CyclicGroupGenerator;
 use twenty_first::shared_math::traits::PrimitiveRootOfUnity;

--- a/stark-rescue-prime/src/stark_rp.rs
+++ b/stark-rescue-prime/src/stark_rp.rs
@@ -1172,6 +1172,8 @@ impl StarkRp {
 
 #[cfg(test)]
 pub mod test_stark {
+    use crate::rescue_prime_trace;
+
     use super::*;
 
     use rand::Rng;
@@ -1238,7 +1240,7 @@ pub mod test_stark {
 
         // Verify that the AIR constraints evaluation over the trace is zero along the trace
         let input_2 = [BFieldElement::new(42); 10];
-        let trace = RescuePrimeRegular::trace(&input_2);
+        let trace = crate::rescue_prime_trace(&input_2);
         println!("Computing get_air_constraints(omicron)...");
         let now = std::time::Instant::now();
         let air_constraints = StarkRp::get_air_constraints(omicron);
@@ -1275,7 +1277,7 @@ pub mod test_stark {
 
         let mut input = [BFieldElement::zero(); 10];
         input[0] = BFieldElement::one();
-        let trace = RescuePrimeRegular::trace(&input);
+        let trace = rescue_prime_trace(&input);
         let output = &trace[trace.len() - 1][0..DIGEST_LENGTH];
         assert_eq!(9, trace.len());
 
@@ -1337,7 +1339,7 @@ pub mod test_stark {
 
         let mut input = [BFieldElement::zero(); 10];
         input[0] = BFieldElement::one();
-        let trace = RescuePrimeRegular::trace(&input);
+        let trace = rescue_prime_trace(&input);
         let output = &trace[trace.len() - 1][0..DIGEST_LENGTH];
 
         let mut npo2 = trace.len() + num_randomizers as usize;
@@ -1402,7 +1404,7 @@ pub mod test_stark {
         );
         let mut input = [BFieldElement::zero(); 10];
         input[0] = BFieldElement::one();
-        let trace = RescuePrimeRegular::trace(&input);
+        let trace = rescue_prime_trace(&input);
         let output = &trace[trace.len() - 1][0..DIGEST_LENGTH];
 
         assert_eq!(9, trace.len());

--- a/stark-rescue-prime/src/stark_rp.rs
+++ b/stark-rescue-prime/src/stark_rp.rs
@@ -1275,7 +1275,8 @@ pub mod test_stark {
 
         let mut input = [BFieldElement::zero(); 10];
         input[0] = BFieldElement::one();
-        let (output, trace) = RescuePrimeRegular::hash_10_with_trace(&input);
+        let trace = RescuePrimeRegular::trace(&input);
+        let output = &trace[trace.len() - 1][0..DIGEST_LENGTH];
         assert_eq!(9, trace.len());
 
         let mut npo2 = trace.len() + num_randomizers;
@@ -1288,7 +1289,7 @@ pub mod test_stark {
 
         let omicron = BFieldElement::primitive_root_of_unity(npo2 as u64).unwrap();
         let air_constraints = StarkRp::get_air_constraints(omicron);
-        let boundary_constraints = StarkRp::get_boundary_constraints(&output);
+        let boundary_constraints = StarkRp::get_boundary_constraints(output);
         let mut proof_stream = ProofStream::default();
 
         let prove_result = stark.prove(
@@ -1336,7 +1337,8 @@ pub mod test_stark {
 
         let mut input = [BFieldElement::zero(); 10];
         input[0] = BFieldElement::one();
-        let (output, trace) = RescuePrimeRegular::hash_10_with_trace(&input);
+        let trace = RescuePrimeRegular::trace(&input);
+        let output = &trace[trace.len() - 1][0..DIGEST_LENGTH];
 
         let mut npo2 = trace.len() + num_randomizers as usize;
         if npo2 & (npo2 - 1) != 0 {
@@ -1350,7 +1352,7 @@ pub mod test_stark {
         let mut timer = TimingReporter::start();
         let air_constraints = StarkRp::get_air_constraints(omicron);
         timer.elapsed("get_air_constraints(omicron)");
-        let boundary_constraints = StarkRp::get_boundary_constraints(&output);
+        let boundary_constraints = StarkRp::get_boundary_constraints(output);
         timer.elapsed("get_boundary_constraints(output)");
         let report = timer.finish();
         println!("{}", report);
@@ -1400,7 +1402,9 @@ pub mod test_stark {
         );
         let mut input = [BFieldElement::zero(); 10];
         input[0] = BFieldElement::one();
-        let (output, trace) = RescuePrimeRegular::hash_10_with_trace(&input);
+        let trace = RescuePrimeRegular::trace(&input);
+        let output = &trace[trace.len() - 1][0..DIGEST_LENGTH];
+
         assert_eq!(9, trace.len());
 
         let mut npo2 = trace.len() + num_randomizers as usize;
@@ -1413,7 +1417,7 @@ pub mod test_stark {
 
         let omicron = BFieldElement::primitive_root_of_unity(npo2 as u64).unwrap();
         let air_constraints = StarkRp::get_air_constraints(omicron);
-        let boundary_constraints = StarkRp::get_boundary_constraints(&output);
+        let boundary_constraints = StarkRp::get_boundary_constraints(output);
         let mut proof_stream = ProofStream::default();
 
         let prove_result = stark.prove(

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -91,3 +91,7 @@ harness = false
 [[bench]]
 name = "merkle_tree"
 harness = false
+
+[[bench]]
+name = "sponge_hashing"
+harness = false

--- a/twenty-first/benches/rescue_prime_regular.rs
+++ b/twenty-first/benches/rescue_prime_regular.rs
@@ -6,6 +6,7 @@ use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::other::random_elements;
 use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
 use twenty_first::shared_math::rescue_prime_regular::RescuePrimeRegular;
+use twenty_first::util_types::algebraic_hasher::AlgebraicHasherNew;
 
 fn bench_10(c: &mut Criterion) {
     let mut group = c.benchmark_group("rescue_prime_regular/hash_10");

--- a/twenty-first/benches/rescue_prime_regular.rs
+++ b/twenty-first/benches/rescue_prime_regular.rs
@@ -4,7 +4,8 @@ use rand::RngCore;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::other::random_elements;
-use twenty_first::shared_math::rescue_prime_regular::{RescuePrimeRegular, DIGEST_LENGTH};
+use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
+use twenty_first::shared_math::rescue_prime_regular::RescuePrimeRegular;
 
 fn bench_10(c: &mut Criterion) {
     let mut group = c.benchmark_group("rescue_prime_regular/hash_10");

--- a/twenty-first/benches/sponge_hashing.rs
+++ b/twenty-first/benches/sponge_hashing.rs
@@ -1,0 +1,55 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use twenty_first::shared_math::other::random_elements;
+use twenty_first::shared_math::rescue_prime_regular::RescuePrimeRegular;
+use twenty_first::util_types::algebraic_hasher::{AlgebraicHasherNew, SpongeHasher, RATE};
+
+fn hash_varlen_bench<H: AlgebraicHasherNew>(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sponge");
+
+    let input_length = 150;
+
+    group.sample_size(1000);
+    group.bench_function(BenchmarkId::new("hash_varlen", input_length), |bencher| {
+        let input = random_elements(input_length);
+        bencher.iter(|| {
+            H::hash_varlen(&input);
+        });
+    });
+}
+
+fn sample_indices_bench<H: SpongeHasher>(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sponge");
+
+    let num_indices = 50;
+    let upper_bound = 1 << 20;
+
+    group.sample_size(1000);
+    group.bench_function(BenchmarkId::new("sample_indices", num_indices), |bencher| {
+        let seed = random_elements(RATE);
+        let mut sponge = H::absorb_init(&seed);
+        bencher.iter(|| {
+            H::sample_indices(&mut sponge, upper_bound, num_indices);
+        });
+    });
+}
+
+fn sample_weights_bench<H: SpongeHasher>(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sponge");
+
+    let num_weights = 120;
+
+    group.sample_size(1000);
+    group.bench_function(BenchmarkId::new("sample_weights", num_weights), |bencher| {
+        let seed = random_elements(RATE);
+        let mut sponge = H::absorb_init(&seed);
+        bencher.iter(|| H::sample_weights(&mut sponge, num_weights));
+    });
+}
+
+criterion_group!(
+    benches,
+    hash_varlen_bench<RescuePrimeRegular>,
+    sample_indices_bench<RescuePrimeRegular>,
+    sample_weights_bench<RescuePrimeRegular>,
+);
+criterion_main!(benches);

--- a/twenty-first/benches/sponge_hashing.rs
+++ b/twenty-first/benches/sponge_hashing.rs
@@ -1,5 +1,6 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use twenty_first::shared_math::other::random_elements;
+use twenty_first::shared_math::b_field_element::BFieldElement;
+use twenty_first::shared_math::other::{random_elements, random_elements_array};
 use twenty_first::shared_math::rescue_prime_regular::RescuePrimeRegular;
 use twenty_first::util_types::algebraic_hasher::{AlgebraicHasherNew, SpongeHasher, RATE};
 
@@ -25,7 +26,7 @@ fn sample_indices_bench<H: SpongeHasher>(c: &mut Criterion) {
 
     group.sample_size(1000);
     group.bench_function(BenchmarkId::new("sample_indices", num_indices), |bencher| {
-        let seed = random_elements(RATE);
+        let seed = random_elements_array::<BFieldElement, RATE>();
         let mut sponge = H::absorb_init(&seed);
         bencher.iter(|| {
             H::sample_indices(&mut sponge, upper_bound, num_indices);
@@ -40,7 +41,7 @@ fn sample_weights_bench<H: SpongeHasher>(c: &mut Criterion) {
 
     group.sample_size(1000);
     group.bench_function(BenchmarkId::new("sample_weights", num_weights), |bencher| {
-        let seed = random_elements(RATE);
+        let seed = random_elements_array::<BFieldElement, RATE>();
         let mut sponge = H::absorb_init(&seed);
         bencher.iter(|| H::sample_weights(&mut sponge, num_weights));
     });

--- a/twenty-first/benches/tip5.rs
+++ b/twenty-first/benches/tip5.rs
@@ -4,7 +4,7 @@ use rand::RngCore;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::other::random_elements;
-use twenty_first::shared_math::rescue_prime_regular::DIGEST_LENGTH;
+use twenty_first::shared_math::rescue_prime_digest::DIGEST_LENGTH;
 use twenty_first::shared_math::tip5::Tip5;
 
 fn bench_10(c: &mut Criterion) {

--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -1203,16 +1203,20 @@ mod b_prime_field_element_test {
 
     #[test]
     fn test_fixed_mul() {
-        let a = BFieldElement::new(2779336007265862836);
-        let b = BFieldElement::new(8146517303801474933);
-        let c = a * b;
-        let expected = BFieldElement::new(1857758653037316764);
-        assert_eq!(c, expected);
+        {
+            let a = BFieldElement::new(2779336007265862836);
+            let b = BFieldElement::new(8146517303801474933);
+            let c = a * b;
+            let expected = BFieldElement::new(1857758653037316764);
+            assert_eq!(c, expected);
+        }
 
-        let a = BFieldElement::new(9223372036854775808);
-        let b = BFieldElement::new(9223372036854775808);
-        let c = a * b;
-        let expected = BFieldElement::new(18446744068340842497);
-        assert_eq!(c, expected);
+        {
+            let a = BFieldElement::new(9223372036854775808);
+            let b = BFieldElement::new(9223372036854775808);
+            let c = a * b;
+            let expected = BFieldElement::new(18446744068340842497);
+            assert_eq!(c, expected);
+        }
     }
 }

--- a/twenty-first/src/shared_math/other.rs
+++ b/twenty-first/src/shared_math/other.rs
@@ -66,6 +66,13 @@ pub fn roundup_npo2(x: u64) -> u64 {
     1 << log_2_ceil(x as u128)
 }
 
+pub fn roundup_nearest_multiple(mut x: usize, multiple: usize) -> usize {
+    if x % multiple != 0 {
+        x += multiple - (x % multiple);
+    }
+    x
+}
+
 /// Simultaneously perform division and remainder.
 ///
 /// While there is apparently no built-in Rust function for this,
@@ -280,6 +287,15 @@ mod test_other {
                 is_power_of_two(leaf_count),
                 "The leaf count should be a power of two."
             );
+        }
+    }
+
+    #[test]
+    fn roundup_nearest_multiple_test() {
+        let cases = [(0, 10, 0), (1, 10, 10), (10, 10, 10), (11, 10, 20)];
+        for (x, multiple, expected) in cases {
+            let actual = roundup_nearest_multiple(x, multiple);
+            assert_eq!(expected, actual);
         }
     }
 }

--- a/twenty-first/src/shared_math/rescue_prime_digest.rs
+++ b/twenty-first/src/shared_math/rescue_prime_digest.rs
@@ -9,13 +9,13 @@ use rand_distr::{Distribution, Standard};
 use serde::{Deserialize, Serialize};
 
 use crate::shared_math::b_field_element::{BFieldElement, BFIELD_ZERO};
-use crate::shared_math::rescue_prime_regular::DIGEST_LENGTH;
 use crate::shared_math::traits::FromVecu8;
 use crate::util_types::emojihash_trait::Emojihash;
 
+pub const DIGEST_LENGTH: usize = 5;
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Digest([BFieldElement; DIGEST_LENGTH]);
-// FIXME: Make Digest a record instead of a tuple.
 
 impl GetSize for Digest {
     fn get_stack_size() -> usize {

--- a/twenty-first/src/shared_math/rescue_prime_optimized.rs
+++ b/twenty-first/src/shared_math/rescue_prime_optimized.rs
@@ -797,22 +797,6 @@ impl RescuePrimeOptimized {
 
         trace
     }
-
-    /// hash_10_with_trace
-    /// Computes the fixed-length hash digest and returns the trace
-    /// along with it.
-    pub fn hash_10_with_trace(
-        input: &[BFieldElement; 10],
-    ) -> (
-        [BFieldElement; DIGEST_LENGTH],
-        [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS],
-    ) {
-        let trace: [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS] = Self::trace(input);
-        let output: [BFieldElement; DIGEST_LENGTH] =
-            trace[NUM_ROUNDS][0..DIGEST_LENGTH].try_into().unwrap();
-
-        (output, trace)
-    }
 }
 
 impl AlgebraicHasher for RescuePrimeOptimized {
@@ -825,23 +809,5 @@ impl AlgebraicHasher for RescuePrimeOptimized {
         input[..DIGEST_LENGTH].copy_from_slice(&left.values());
         input[DIGEST_LENGTH..].copy_from_slice(&right.values());
         Digest::new(RescuePrimeOptimized::hash_10(&input))
-    }
-}
-
-#[cfg(test)]
-mod rescue_prime_optimized_tests {
-
-    use crate::shared_math::other::random_elements_array;
-
-    use super::*;
-
-    #[test]
-    fn trace_consistent_test() {
-        for _ in 0..10 {
-            let input: [BFieldElement; 10] = random_elements_array();
-            let (output_a, _) = RescuePrimeOptimized::hash_10_with_trace(&input);
-            let output_b = RescuePrimeOptimized::hash_10(&input);
-            assert_eq!(output_a, output_b);
-        }
     }
 }

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -1093,7 +1093,7 @@ impl AlgebraicHasherNew for RescuePrimeRegular {
 impl SpongeHasher for RescuePrimeRegular {
     type SpongeState = RescuePrimeRegularState;
 
-    fn absorb_init(input: &[BFieldElement]) -> Self::SpongeState {
+    fn absorb_init(input: &[BFieldElement; RATE]) -> Self::SpongeState {
         let mut sponge = RescuePrimeRegularState::new(algebraic_hasher::Domain::VariableLength);
 
         Self::absorb(&mut sponge, input);
@@ -1101,7 +1101,7 @@ impl SpongeHasher for RescuePrimeRegular {
         sponge
     }
 
-    fn absorb(sponge: &mut Self::SpongeState, input: &[BFieldElement]) {
+    fn absorb(sponge: &mut Self::SpongeState, input: &[BFieldElement; RATE]) {
         // absorb
         sponge.state[..RATE]
             .iter_mut()

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -983,7 +983,7 @@ impl RescuePrimeRegular {
     /// hash_10
     /// Hash 10 elements, or two digests. There is no padding because
     /// the input length is fixed.
-    pub fn hash_10(input: &[BFieldElement; 10]) -> [BFieldElement; 5] {
+    pub fn hash_10(input: &[BFieldElement; 10]) -> [BFieldElement; DIGEST_LENGTH] {
         let mut sponge = RescuePrimeRegularState::new();
 
         // absorb once
@@ -1063,7 +1063,7 @@ impl AlgebraicHasher for RescuePrimeRegular {
     }
 
     fn hash_pair(left: &Digest, right: &Digest) -> Digest {
-        let mut input = [BFIELD_ZERO; 10];
+        let mut input = [BFIELD_ZERO; 2 * DIGEST_LENGTH];
         input[..DIGEST_LENGTH].copy_from_slice(&left.values());
         input[DIGEST_LENGTH..].copy_from_slice(&right.values());
         Digest::new(RescuePrimeRegular::hash_10(&input))

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -802,7 +802,16 @@ pub struct RescuePrimeRegularState {
 
 impl RescuePrimeRegularState {
     #[inline]
-    const fn new() -> RescuePrimeRegularState {
+    pub const fn new(domain: algebraic_hasher::Domain) -> RescuePrimeRegularState {
+        use algebraic_hasher::Domain::*;
+
+        let mut state = [BFIELD_ZERO; STATE_SIZE];
+
+        match domain {
+            VariableLength => (),
+            FixedLength => state[RATE] = BFIELD_ONE,
+        }
+
         RescuePrimeRegularState {
             state: [BFIELD_ZERO; STATE_SIZE],
         }
@@ -986,7 +995,7 @@ impl RescuePrimeRegular {
     /// Hash 10 elements, or two digests. There is no padding because
     /// the input length is fixed.
     pub fn hash_10(input: &[BFieldElement; 10]) -> [BFieldElement; DIGEST_LENGTH] {
-        let mut sponge = RescuePrimeRegularState::new();
+        let mut sponge = RescuePrimeRegularState::new(algebraic_hasher::Domain::FixedLength);
 
         // absorb once
         sponge.state[..10].copy_from_slice(input);
@@ -1007,7 +1016,7 @@ impl RescuePrimeRegular {
     /// and as many 0 ∈ Fp elements as required to make the number of input elements
     /// a multiple of `RATE`.
     pub fn hash_varlen(input: &[BFieldElement]) -> [BFieldElement; 5] {
-        let mut sponge = RescuePrimeRegularState::new();
+        let mut sponge = RescuePrimeRegularState::new(algebraic_hasher::Domain::VariableLength);
 
         // pad input
         let mut padded_input = input.to_vec();
@@ -1085,7 +1094,7 @@ impl SpongeHasher for RescuePrimeRegular {
     type SpongeState = RescuePrimeRegularState;
 
     fn absorb_init(input: &[BFieldElement]) -> Self::SpongeState {
-        let mut sponge = RescuePrimeRegularState::new();
+        let mut sponge = RescuePrimeRegularState::new(algebraic_hasher::Domain::VariableLength);
 
         Self::absorb(&mut sponge, input);
 

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::shared_math::b_field_element::{BFieldElement, BFIELD_ONE, BFIELD_ZERO};
 use crate::shared_math::traits::FiniteField;
-use crate::util_types::algebraic_hasher::{AlgebraicHasher, AlgebraicHasherNew, SpongeHasher};
+use crate::util_types::algebraic_hasher::{
+    self, AlgebraicHasher, AlgebraicHasherNew, SpongeHasher,
+};
 
 use super::rescue_prime_digest::{Digest, DIGEST_LENGTH};
 

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -1058,6 +1058,29 @@ impl RescuePrimeRegular {
 
         trace
     }
+
+    /// full_trace
+    /// Produces the execution trace for one invocation of XLIX
+    pub fn full_trace(
+        state: [BFieldElement; STATE_SIZE],
+    ) -> [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS] {
+        let mut trace = [[BFIELD_ZERO; STATE_SIZE]; 1 + NUM_ROUNDS];
+        let mut state = RescuePrimeRegularState { state };
+
+        // record trace
+        trace[0] = state.state;
+
+        // apply N rounds
+        for round_index in 0..NUM_ROUNDS {
+            // apply round function to state
+            Self::xlix_round(&mut state, round_index);
+
+            // record trace
+            trace[1 + round_index] = state.state;
+        }
+
+        trace
+    }
 }
 
 impl AlgebraicHasher for RescuePrimeRegular {

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -1058,22 +1058,6 @@ impl RescuePrimeRegular {
 
         trace
     }
-
-    /// hash_10_with_trace
-    /// Computes the fixed-length hash digest and returns the trace
-    /// along with it.
-    pub fn hash_10_with_trace(
-        input: &[BFieldElement; 10],
-    ) -> (
-        [BFieldElement; DIGEST_LENGTH],
-        [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS],
-    ) {
-        let trace: [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS] = Self::trace(input);
-        let output: [BFieldElement; DIGEST_LENGTH] =
-            trace[NUM_ROUNDS][0..DIGEST_LENGTH].try_into().unwrap();
-
-        (output, trace)
-    }
 }
 
 impl AlgebraicHasher for RescuePrimeRegular {
@@ -1093,8 +1077,6 @@ impl AlgebraicHasher for RescuePrimeRegular {
 mod rescue_prime_regular_tests {
     use itertools::Itertools;
     use num_traits::Zero;
-
-    use crate::shared_math::other::random_elements_array;
 
     use super::*;
 
@@ -1411,16 +1393,6 @@ mod rescue_prime_regular_tests {
             let input = (0..i as u64).map(BFieldElement::new).collect_vec();
             let actual = RescuePrimeRegular::hash_varlen(&input);
             assert_eq!(expected, actual);
-        }
-    }
-
-    #[test]
-    fn trace_consistent_test() {
-        for _ in 0..10 {
-            let input: [BFieldElement; 10] = random_elements_array();
-            let (output_a, _) = RescuePrimeRegular::hash_10_with_trace(&input);
-            let output_b = RescuePrimeRegular::hash_10(&input);
-            assert_eq!(output_a, output_b);
         }
     }
 }

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -1092,7 +1092,10 @@ impl SpongeHasher for RescuePrimeRegular {
 
     fn absorb(sponge: &mut Self::SpongeState, input: &[BFieldElement]) {
         // absorb
-        sponge.state[..RATE].copy_from_slice(input);
+        sponge.state[..RATE]
+            .iter_mut()
+            .zip_eq(input.iter())
+            .for_each(|(a, &b)| *a += b);
 
         // xlix
         Self::xlix(sponge);

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::shared_math::b_field_element::{BFieldElement, BFIELD_ONE, BFIELD_ZERO};
 use crate::shared_math::traits::FiniteField;
-use crate::util_types::algebraic_hasher::AlgebraicHasher;
+use crate::util_types::algebraic_hasher::{AlgebraicHasher, AlgebraicHasherNew, SpongeHasher};
 
 use super::rescue_prime_digest::{Digest, DIGEST_LENGTH};
 
@@ -1083,6 +1083,7 @@ impl RescuePrimeRegular {
     }
 }
 
+// TODO: Remove old AlgebraicHasher in favor of AlgebraicHasherNew + SpongeHasher
 impl AlgebraicHasher for RescuePrimeRegular {
     fn hash_slice(elements: &[BFieldElement]) -> Digest {
         Digest::new(RescuePrimeRegular::hash_varlen(elements))
@@ -1093,6 +1094,45 @@ impl AlgebraicHasher for RescuePrimeRegular {
         input[..DIGEST_LENGTH].copy_from_slice(&left.values());
         input[DIGEST_LENGTH..].copy_from_slice(&right.values());
         Digest::new(RescuePrimeRegular::hash_10(&input))
+    }
+}
+
+impl AlgebraicHasherNew for RescuePrimeRegular {
+    fn hash_pair(left: &Digest, right: &Digest) -> Digest {
+        let mut input = [BFIELD_ZERO; 10];
+        input[..DIGEST_LENGTH].copy_from_slice(&left.values());
+        input[DIGEST_LENGTH..].copy_from_slice(&right.values());
+        Digest::new(RescuePrimeRegular::hash_10(&input))
+    }
+}
+
+impl SpongeHasher for RescuePrimeRegular {
+    type SpongeState = RescuePrimeRegularState;
+
+    fn absorb_init(input: &[BFieldElement]) -> Self::SpongeState {
+        let mut sponge = RescuePrimeRegularState::new();
+
+        Self::absorb(&mut sponge, input);
+
+        sponge
+    }
+
+    fn absorb(sponge: &mut Self::SpongeState, input: &[BFieldElement]) {
+        // absorb
+        sponge.state[..RATE].copy_from_slice(input);
+
+        // xlix
+        Self::xlix(sponge);
+    }
+
+    fn squeeze(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE] {
+        // squeeze
+        let produce: [BFieldElement; RATE] = (&sponge.state[..RATE]).try_into().unwrap();
+
+        // xlix
+        Self::xlix(sponge);
+
+        produce
     }
 }
 

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -6,9 +6,8 @@ use crate::shared_math::b_field_element::{BFieldElement, BFIELD_ONE, BFIELD_ZERO
 use crate::shared_math::traits::FiniteField;
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
 
-use super::rescue_prime_digest::Digest;
+use super::rescue_prime_digest::{Digest, DIGEST_LENGTH};
 
-pub const DIGEST_LENGTH: usize = 5;
 pub const STATE_SIZE: usize = 16;
 pub const CAPACITY: usize = 6;
 pub const RATE: usize = 10;

--- a/twenty-first/src/shared_math/rescue_prime_regular.rs
+++ b/twenty-first/src/shared_math/rescue_prime_regular.rs
@@ -1034,34 +1034,7 @@ impl RescuePrimeRegular {
 
     /// trace
     /// Produces the execution trace for one invocation of XLIX
-    pub fn trace(input: &[BFieldElement; 10]) -> [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS] {
-        let mut trace = [[BFIELD_ZERO; STATE_SIZE]; 1 + NUM_ROUNDS];
-        let mut sponge = RescuePrimeRegularState::new();
-
-        // absorb
-        sponge.state[0..RATE].copy_from_slice(input);
-
-        // domain separation
-        sponge.state[RATE] = BFIELD_ONE;
-
-        // record trace
-        trace[0] = sponge.state;
-
-        // apply N rounds
-        for round_index in 0..NUM_ROUNDS {
-            // apply round function to state
-            Self::xlix_round(&mut sponge, round_index);
-
-            // record trace
-            trace[1 + round_index] = sponge.state;
-        }
-
-        trace
-    }
-
-    /// full_trace
-    /// Produces the execution trace for one invocation of XLIX
-    pub fn full_trace(
+    pub fn trace(
         state: [BFieldElement; STATE_SIZE],
     ) -> [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS] {
         let mut trace = [[BFIELD_ZERO; STATE_SIZE]; 1 + NUM_ROUNDS];

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -30,7 +30,7 @@ pub trait SpongeHasher: Clone + Send + Sync {
         num_indices: usize,
     ) -> Vec<usize> {
         assert!(upper_bound <= BFieldElement::MAX as usize);
-        let num_squeezes = num_indices / RATE;
+        let num_squeezes = (num_indices + RATE) / RATE;
         (0..num_squeezes)
             .flat_map(|_| Self::squeeze(state))
             .take(num_indices)
@@ -134,7 +134,7 @@ pub trait AlgebraicHasher: Clone + Send + Sync {
     ///
     /// - `seed`: A hash `Digest`
     /// - `upper_bound`: The (non-inclusive) upper bound (a power of two)
-    /// - `num_indices`: The number of sample indices
+    /// - `num_indices`: The number of indices to sample
     fn sample_indices(seed: &Digest, upper_bound: usize, num_indices: usize) -> Vec<usize> {
         Self::get_n_hash_rounds(seed, num_indices)
             .iter()

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -29,6 +29,7 @@ pub trait SpongeHasher: Clone + Send + Sync {
         upper_bound: usize,
         num_indices: usize,
     ) -> Vec<usize> {
+        assert!(is_power_of_two(upper_bound));
         assert!(upper_bound <= BFieldElement::MAX as usize);
         let num_squeezes = roundup_nearest_multiple(num_indices, RATE) / RATE;
         (0..num_squeezes)
@@ -72,12 +73,12 @@ pub trait AlgebraicHasherNew: SpongeHasher {
             .into_iter()
             .map(|chunk| chunk.into_iter().copied().collect::<Vec<_>>());
 
-        // absorb_init once
+        // absorb_init
         let absorb_init_elems: Vec<BFieldElement> =
             padded_input_iter.next().expect("at least one absorb");
         let mut sponge = Self::absorb_init(&absorb_init_elems);
 
-        // absorb variably
+        // absorb
         for absorb_elems in padded_input_iter {
             Self::absorb(&mut sponge, &absorb_elems);
         }

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -30,7 +30,7 @@ pub trait SpongeHasher: Clone + Send + Sync {
         num_indices: usize,
     ) -> Vec<usize> {
         assert!(upper_bound <= BFieldElement::MAX as usize);
-        let num_squeezes = (num_indices + RATE) / RATE;
+        let num_squeezes = roundup_nearest_multiple(num_indices, RATE) / RATE;
         (0..num_squeezes)
             .flat_map(|_| Self::squeeze(state))
             .take(num_indices)
@@ -39,7 +39,7 @@ pub trait SpongeHasher: Clone + Send + Sync {
     }
 
     fn sample_weights(state: &mut Self::SpongeState, num_weights: usize) -> Vec<XFieldElement> {
-        let num_squeezes = (num_weights * EXTENSION_DEGREE) / RATE;
+        let num_squeezes = roundup_nearest_multiple(num_weights * EXTENSION_DEGREE, RATE) / RATE;
         (0..num_squeezes)
             .map(|_| Self::squeeze(state))
             .flat_map(|elems| {

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -14,8 +14,8 @@ pub trait SpongeHasher: Clone + Send + Sync {
     type SpongeState;
 
     fn absorb_init(input: &[BFieldElement]) -> Self::SpongeState;
-    fn absorb(state: &mut Self::SpongeState, input: &[BFieldElement]);
-    fn squeeze(state: &mut Self::SpongeState) -> [BFieldElement; RATE];
+    fn absorb(sponge: &mut Self::SpongeState, input: &[BFieldElement]);
+    fn squeeze(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE];
 
     /// Given a sponge state and an `upper_bound` that is a power of two,
     /// produce `num_indices` uniform random numbers (sample indices) in

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -4,11 +4,17 @@ use itertools::Itertools;
 use rayon::prelude::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
 use crate::shared_math::b_field_element::{BFieldElement, BFIELD_ONE, BFIELD_ZERO};
-use crate::shared_math::other::{self, roundup_nearest_multiple};
+use crate::shared_math::other::{self, is_power_of_two, roundup_nearest_multiple};
 use crate::shared_math::rescue_prime_digest::{Digest, DIGEST_LENGTH};
 use crate::shared_math::x_field_element::{XFieldElement, EXTENSION_DEGREE};
 
 pub const RATE: usize = 10;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Domain {
+    VariableLength,
+    FixedLength,
+}
 
 pub trait SpongeHasher: Clone + Send + Sync {
     type SpongeState;

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -64,6 +64,10 @@ pub trait SpongeHasher: Clone + Send + Sync {
 pub trait AlgebraicHasherNew: SpongeHasher {
     fn hash_pair(left: &Digest, right: &Digest) -> Digest;
 
+    fn hash<T: Hashable>(value: &T) -> Digest {
+        Self::hash_varlen(&value.to_sequence())
+    }
+
     fn hash_varlen(input: &[BFieldElement]) -> Digest {
         // calculate padded length
         let padded_length = roundup_nearest_multiple(input.len() + 1, RATE);

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -192,7 +192,7 @@ mod algebraic_hasher_tests {
     use num_traits::Zero;
     use rand::Rng;
 
-    use crate::shared_math::rescue_prime_regular::DIGEST_LENGTH;
+    use crate::shared_math::rescue_prime_digest::DIGEST_LENGTH;
     use crate::shared_math::x_field_element::EXTENSION_DEGREE;
 
     use super::*;


### PR DESCRIPTION
In order to hash things equivalently in the Rust/tasm implementations of the STARK verifier, it is necessary to expose the same hashing primitives in both environments. For Merkle-tree hashing, this was already fixed using `RescuePrimeRegular::hash_10()` in both `AlgebraicHasher::hash_pair()` and in Triton VM's `hash` instruction.

Other cases of hashing in the STARK verifier includes Fiat-Shamir challenges / sampling indices / sampling weights.

The proposed solution (which also affects how variable-length hashing works in general) is to expose sponge instructions (`absorb_init`, `absorb`, `squeeze`) in the VM (TritonVM/triton-vm#166, TritonVM/triton-vm#168), for which the primitives are ported back to a trait in twenty-first, `SpongeHasher`.

A `hash_varlen()` is also made with `SpongeHasher`'s primitives. Now

- Triton VM can depend on these primitives so that eventually an equivalence test between two `.verify()`s can pass.
- Any dependence on variable-length hashing can also pass such equivalence tests.