### PR TITLE
Abstract Storage Schema

### DIFF
--- a/twenty-first/benches/poseidon.rs
+++ b/twenty-first/benches/poseidon.rs
@@ -21,7 +21,6 @@ fn bench_10(c: &mut Criterion) {
 
     let mut rng = rand::thread_rng();
     let single_element: [BFieldElement; STATE_SIZE] = (0..STATE_SIZE)
-        .into_iter()
         .map(|_| BFieldElement::new(rng.next_u64()))
         .collect_vec()
         .try_into()

--- a/twenty-first/benches/poseidon_naive.rs
+++ b/twenty-first/benches/poseidon_naive.rs
@@ -20,7 +20,6 @@ fn bench_10(c: &mut Criterion) {
 
     let mut rng = rand::thread_rng();
     let single_element: [BFieldElement; STATE_SIZE] = (0..STATE_SIZE)
-        .into_iter()
         .map(|_| BFieldElement::new(rng.next_u64()))
         .collect_vec()
         .try_into()

--- a/twenty-first/benches/rescue_prime_optimized.rs
+++ b/twenty-first/benches/rescue_prime_optimized.rs
@@ -15,7 +15,6 @@ fn bench_10(c: &mut Criterion) {
 
     let mut rng = rand::thread_rng();
     let single_element: [BFieldElement; 10] = (0..10)
-        .into_iter()
         .map(|_| BFieldElement::new(rng.next_u64()))
         .collect_vec()
         .try_into()

--- a/twenty-first/benches/rescue_prime_regular.rs
+++ b/twenty-first/benches/rescue_prime_regular.rs
@@ -16,7 +16,6 @@ fn bench_10(c: &mut Criterion) {
 
     let mut rng = rand::thread_rng();
     let single_element: [BFieldElement; 10] = (0..10)
-        .into_iter()
         .map(|_| BFieldElement::new(rng.next_u64()))
         .collect_vec()
         .try_into()

--- a/twenty-first/benches/tip5.rs
+++ b/twenty-first/benches/tip5.rs
@@ -16,7 +16,6 @@ fn bench_10(c: &mut Criterion) {
 
     let mut rng = rand::thread_rng();
     let single_element: [BFieldElement; 10] = (0..10)
-        .into_iter()
         .map(|_| BFieldElement::new(rng.next_u64()))
         .collect_vec()
         .try_into()

--- a/twenty-first/src/shared_math/lattice.rs
+++ b/twenty-first/src/shared_math/lattice.rs
@@ -736,7 +736,6 @@ mod lattice_test {
     fn test_embedding() {
         let mut rng = thread_rng();
         let msg: [u8; 32] = (0..32)
-            .into_iter()
             .map(|_| (rng.next_u32() % 256) as u8)
             .collect_vec()
             .try_into()
@@ -751,7 +750,6 @@ mod lattice_test {
     fn test_module_distributivity() {
         let mut rng = thread_rng();
         let randomness = (0..(2 * 3 + 2 * 3 + 3) * 64 * 9)
-            .into_iter()
             .map(|_| (rng.next_u32() % 256) as u8)
             .collect_vec();
         let mut start = 0;
@@ -775,7 +773,6 @@ mod lattice_test {
     fn test_module_multiply() {
         let mut rng = thread_rng();
         let randomness = (0..(2 * 3 + 2 * 3 + 3) * 64 * 9)
-            .into_iter()
             .map(|_| (rng.next_u32() % 256) as u8)
             .collect_vec();
         let mut start = 0;

--- a/twenty-first/src/shared_math/mpolynomial.rs
+++ b/twenty-first/src/shared_math/mpolynomial.rs
@@ -1968,18 +1968,8 @@ mod test_mpolynomials {
         let mut exponents: Vec<Vec<u8>> =
             MPolynomial::extract_exponents_list(&[a.clone(), b.clone()]).unwrap();
         exponents.sort();
-        let exponents_a: Vec<Vec<u8>> = a
-            .coefficients
-            .keys()
-            .into_iter()
-            .map(|x| x.to_owned())
-            .collect();
-        let exponents_b: Vec<Vec<u8>> = b
-            .coefficients
-            .keys()
-            .into_iter()
-            .map(|x| x.to_owned())
-            .collect();
+        let exponents_a: Vec<Vec<u8>> = a.coefficients.keys().map(|x| x.to_owned()).collect();
+        let exponents_b: Vec<Vec<u8>> = b.coefficients.keys().map(|x| x.to_owned()).collect();
         let mut expected_exponents_set: HashSet<Vec<u8>> = [exponents_a, exponents_b]
             .iter()
             .flat_map(|mpol| mpol.iter().map(|x| x.to_owned()))

--- a/twenty-first/src/shared_math/tip5.rs
+++ b/twenty-first/src/shared_math/tip5.rs
@@ -725,7 +725,6 @@ mod tip5_tests {
             .into_par_iter()
             .map(|a| {
                 (1..256)
-                    .into_iter()
                     .map(|b| count_satisfiers_fermat(a, b))
                     .max()
                     .unwrap()
@@ -757,7 +756,6 @@ mod tip5_tests {
             .into_par_iter()
             .map(|a| {
                 (1..256)
-                    .into_iter()
                     .map(|b| count_satisfiers_fermat_bitwise(a, b))
                     .max()
                     .unwrap()
@@ -825,7 +823,7 @@ mod tip5_tests {
     fn hash_varlen_test_vectors() {
         let mut digest_sum = [BFieldElement::zero(); DIGEST_LENGTH];
         for i in 0..20 {
-            let preimage = (0..i).into_iter().map(BFieldElement::new).collect_vec();
+            let preimage = (0..i).map(BFieldElement::new).collect_vec();
             let digest = Tip5::hash_varlen(&preimage);
             println!(
                 "{:?} -> {:?}",

--- a/twenty-first/src/test_shared/mmr.rs
+++ b/twenty-first/src/test_shared/mmr.rs
@@ -1,5 +1,4 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use rusty_leveldb::DB;
 
@@ -15,7 +14,7 @@ pub fn get_empty_rustyleveldb_ammr<H: AlgebraicHasher>() -> ArchivalMmr<H, Rusty
 {
     let opt = rusty_leveldb::in_memory();
     let db = DB::open("mydatabase", opt).unwrap();
-    let db = Rc::new(RefCell::new(db));
+    let db = Arc::new(Mutex::new(db));
     let pv = RustyLevelDbVec::new(db, 0, "in-memory AMMR for unit tests");
     ArchivalMmr::new(pv)
 }

--- a/twenty-first/src/util_types.rs
+++ b/twenty-first/src/util_types.rs
@@ -8,5 +8,6 @@ pub mod merkle_tree_maker;
 pub mod mmr;
 pub mod proof_stream_typed;
 pub mod shared;
+pub mod storage_schema;
 pub mod storage_vec;
 pub mod tree_m_ary;

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -1044,19 +1044,19 @@ mod mmr_test {
         ammr0.persist(&mut write_batch);
 
         // Verify that DB is still empty, as the write batch hasn't been applied yet
-        let mut db_iter = db.lock().unwrap().new_iter().unwrap();
+        db_iter = db.lock().unwrap().new_iter().unwrap();
         assert!(db_iter.next().is_none());
 
         ammr1.persist(&mut write_batch);
 
         // Verify that DB is still empty, as the write batch hasn't been applied yet
-        let mut db_iter = db.lock().unwrap().new_iter().unwrap();
+        db_iter = db.lock().unwrap().new_iter().unwrap();
         assert!(db_iter.next().is_none());
 
         db.lock().unwrap().write(write_batch, true).unwrap();
 
         // Verify that DB is not empty
-        let mut db_iter = db.lock().unwrap().new_iter().unwrap();
+        db_iter = db.lock().unwrap().new_iter().unwrap();
         assert!(db_iter.next().is_some());
 
         assert_eq!(digest0, ammr0.get_leaf(0));

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -141,7 +141,6 @@ impl<H: AlgebraicHasher, Storage: StorageVec<Digest>> ArchivalMmr<H, Storage> {
     /// is the empty vector. This method fixes that.
     pub fn fix_dummy(&mut self) {
         if self.digests.len() == 0 {
-            println!("Inserting dummy");
             self.digests.push(Digest::default());
         }
     }

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -309,8 +309,7 @@ impl<H: AlgebraicHasher> ArchivalMmr<H, RustyLevelDbVec<Digest>> {
 
 #[cfg(test)]
 mod mmr_test {
-    use std::cell::RefCell;
-    use std::rc::Rc;
+    use std::sync::{Arc, Mutex};
 
     use super::*;
     use crate::shared_math::other::random_elements;
@@ -1024,7 +1023,7 @@ mod mmr_test {
 
         let opt = rusty_leveldb::in_memory();
         let db = DB::open("mydatabase", opt).unwrap();
-        let db = Rc::new(RefCell::new(db));
+        let db = Arc::new(Mutex::new(db));
         let persistent_vec_0 = RustyLevelDbVec::new(db.clone(), 0, "archival MMR for unit tests");
         let mut ammr0: ArchivalMmr<H, RustyLevelDbVec<Digest>> = ArchivalMmr::new(persistent_vec_0);
 
@@ -1038,26 +1037,26 @@ mod mmr_test {
         ammr1.append(digest1);
 
         // Verify that DB is still empty
-        let mut db_iter = db.borrow_mut().new_iter().unwrap();
+        let mut db_iter = db.lock().unwrap().new_iter().unwrap();
         assert!(db_iter.next().is_none());
 
         let mut write_batch = WriteBatch::new();
         ammr0.persist(&mut write_batch);
 
         // Verify that DB is still empty, as the write batch hasn't been applied yet
-        let mut db_iter = db.borrow_mut().new_iter().unwrap();
+        let mut db_iter = db.lock().unwrap().new_iter().unwrap();
         assert!(db_iter.next().is_none());
 
         ammr1.persist(&mut write_batch);
 
         // Verify that DB is still empty, as the write batch hasn't been applied yet
-        let mut db_iter = db.borrow_mut().new_iter().unwrap();
+        let mut db_iter = db.lock().unwrap().new_iter().unwrap();
         assert!(db_iter.next().is_none());
 
-        db.borrow_mut().write(write_batch, true).unwrap();
+        db.lock().unwrap().write(write_batch, true).unwrap();
 
         // Verify that DB is not empty
-        let mut db_iter = db.borrow_mut().new_iter().unwrap();
+        let mut db_iter = db.lock().unwrap().new_iter().unwrap();
         assert!(db_iter.next().is_some());
 
         assert_eq!(digest0, ammr0.get_leaf(0));

--- a/twenty-first/src/util_types/storage_schema.rs
+++ b/twenty-first/src/util_types/storage_schema.rs
@@ -1,0 +1,565 @@
+use std::{
+    cell::RefCell,
+    collections::{HashMap, VecDeque},
+    fmt::Debug,
+    sync::Arc,
+};
+
+use rusty_leveldb::{WriteBatch, DB};
+
+use super::storage_vec::{IndexType, StorageVec};
+
+pub enum WriteOperation<ParentKey, ParentValue> {
+    Write(ParentKey, ParentValue),
+    Delete(ParentKey),
+}
+
+pub trait DbTable<ParentKey, ParentValue> {
+    fn pull_queue(&mut self) -> Vec<WriteOperation<ParentKey, ParentValue>>;
+    fn restore_or_new(&mut self);
+}
+
+pub trait StorageReader<ParentKey, ParentValue> {
+    fn get(&mut self, key: ParentKey) -> Option<ParentValue>;
+}
+
+pub enum VecWriteOperation<Index, T> {
+    OverWrite((Index, T)),
+    Push(T),
+    Pop,
+}
+
+pub struct DbtVec<ParentKey, ParentValue, Index, T> {
+    reader: Arc<RefCell<dyn StorageReader<ParentKey, ParentValue>>>,
+    current_length: Index,
+    key_prefix: u8,
+    write_queue: VecDeque<VecWriteOperation<Index, T>>,
+    cache: HashMap<Index, T>,
+    name: String,
+}
+
+impl<ParentKey, ParentValue, Index, T> DbtVec<ParentKey, ParentValue, Index, T>
+where
+    ParentKey: From<(ParentKey, ParentKey)>,
+    ParentKey: From<u8>,
+    ParentKey: From<Index>,
+    Index: From<ParentValue> + From<u64> + Clone,
+{
+    // Return the key of ParentKey type used to store the length of the vector
+    fn get_length_key(key_prefix: u8) -> ParentKey {
+        let const_length_key: ParentKey = 0u8.into();
+        let key_prefix_key: ParentKey = key_prefix.into();
+        (key_prefix_key, const_length_key).into()
+    }
+
+    /// Return the length at the last write to disk
+    fn persisted_length(&self) -> Option<Index> {
+        self.reader
+            .as_ref()
+            .borrow_mut()
+            .get(Self::get_length_key(self.key_prefix))
+            .map(|v| v.into())
+    }
+
+    /// Return the key of ParentKey type used to store the element at a given index of Index type
+    fn get_index_key(&self, index: Index) -> ParentKey {
+        let key_prefix_key: ParentKey = self.key_prefix.into();
+        let index_key: ParentKey = index.into();
+        (key_prefix_key, index_key).into()
+    }
+
+    pub fn new(
+        reader: Arc<RefCell<dyn StorageReader<ParentKey, ParentValue>>>,
+        key_prefix: u8,
+        name: &str,
+    ) -> Self {
+        let length: Index = 0.into();
+        let cache = HashMap::new();
+        Self {
+            key_prefix,
+            reader,
+            write_queue: VecDeque::default(),
+            current_length: length,
+            cache,
+            name: name.to_string(),
+        }
+    }
+}
+
+impl<ParentKey, ParentValue, T> StorageVec<T> for DbtVec<ParentKey, ParentValue, IndexType, T>
+where
+    ParentKey: From<IndexType>,
+    ParentValue: From<T>,
+    T: Clone,
+    T: From<ParentValue>,
+    ParentKey: From<(ParentKey, ParentKey)>,
+    ParentKey: From<u8>,
+    IndexType: From<ParentValue>,
+{
+    fn is_empty(&self) -> bool {
+        self.current_length == 0
+    }
+
+    fn len(&self) -> IndexType {
+        self.current_length
+    }
+
+    fn get(&self, index: IndexType) -> T {
+        // Disallow getting values out-of-bounds
+        assert!(
+            index < self.len(),
+            "Out-of-bounds. Got {index} but length was {}. persisted vector name: {}",
+            self.current_length,
+            self.name
+        );
+
+        // try cache first
+        if self.cache.contains_key(&index) {
+            return self.cache.get(&index).unwrap().clone();
+        }
+
+        // then try persistent storage
+        let key: ParentKey = self.get_index_key(index);
+        let val = self
+            .reader
+            .as_ref()
+            .borrow_mut()
+            .get(key)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Element with index {index} does not exist in {}. This should not happen",
+                    self.name
+                )
+            });
+        val.into()
+    }
+
+    fn set(&mut self, index: IndexType, value: T) {
+        // Disallow setting values out-of-bounds
+        assert!(
+            index < self.len(),
+            "Out-of-bounds. Got {index} but length was {}. persisted vector name: {}",
+            self.current_length,
+            self.name
+        );
+
+        let _old_value = self.cache.insert(index, value.clone());
+
+        // TODO: If `old_value` is Some(*) use it to remove the corresponding
+        // element in the `write_queue` to reduce disk IO.
+
+        self.write_queue
+            .push_back(VecWriteOperation::OverWrite((index, value)));
+    }
+
+    fn pop(&mut self) -> Option<T> {
+        // add to write queue
+        self.write_queue.push_back(VecWriteOperation::Pop);
+
+        // If vector is empty, return None
+        if self.current_length == 0 {
+            return None;
+        }
+
+        // Update length
+        self.current_length -= 1;
+
+        // try cache first
+        if self.cache.contains_key(&self.current_length) {
+            self.cache.remove(&self.current_length)
+        } else {
+            // then try persistent storage
+            let key = self.get_index_key(self.current_length);
+            self.reader
+                .as_ref()
+                .borrow_mut()
+                .get(key)
+                .map(|value| value.into())
+        }
+    }
+
+    fn push(&mut self, value: T) {
+        // add to write queue
+        self.write_queue
+            .push_back(VecWriteOperation::Push(value.clone()));
+
+        // record in cache
+        let _old_value = self.cache.insert(self.current_length, value);
+
+        // TODO: if `old_value` is Some(_) then use it to remove the corresponding
+        // element from the `write_queue` to reduce disk operations
+
+        // update length
+        self.current_length += 1;
+    }
+}
+
+impl<ParentKey, ParentValue, T> DbTable<ParentKey, ParentValue>
+    for DbtVec<ParentKey, ParentValue, IndexType, T>
+where
+    ParentKey: From<IndexType>,
+    ParentValue: From<T>,
+    T: Clone,
+    T: From<ParentValue>,
+    ParentKey: From<(ParentKey, ParentKey)>,
+    ParentKey: From<u8>,
+    IndexType: From<ParentValue>,
+    ParentValue: From<IndexType>,
+{
+    /// Collect all added elements that have not yet bit persisted
+    fn pull_queue(&mut self) -> Vec<WriteOperation<ParentKey, ParentValue>> {
+        let maybe_original_length = self.persisted_length();
+        // necessary because we need maybe_original_length.is_none() later
+        #[allow(clippy::unnecessary_unwrap)]
+        let original_length = if maybe_original_length.is_some() {
+            maybe_original_length.unwrap()
+        } else {
+            0
+        };
+        let mut length = original_length;
+        let mut queue = vec![];
+        while let Some(write_element) = self.write_queue.pop_front() {
+            match write_element {
+                VecWriteOperation::OverWrite((i, t)) => {
+                    let key = self.get_index_key(i);
+                    queue.push(WriteOperation::Write(key, Into::<ParentValue>::into(t)));
+                }
+                VecWriteOperation::Push(t) => {
+                    let key = self.get_index_key(length);
+                    length += 1;
+                    queue.push(WriteOperation::Write(key, Into::<ParentValue>::into(t)));
+                }
+                VecWriteOperation::Pop => {
+                    let key = self.get_index_key(length - 1);
+                    length -= 1;
+                    queue.push(WriteOperation::Delete(key));
+                }
+            };
+        }
+
+        if original_length != length || maybe_original_length.is_none() {
+            let key = Self::get_length_key(self.key_prefix);
+            queue.push(WriteOperation::Write(
+                key,
+                Into::<ParentValue>::into(length),
+            ));
+        }
+
+        self.cache.clear();
+
+        queue
+    }
+
+    fn restore_or_new(&mut self) {
+        if let Some(length) = self
+            .reader
+            .as_ref()
+            .borrow_mut()
+            .get(Self::get_length_key(self.key_prefix))
+        {
+            self.current_length = length.into();
+        } else {
+            self.current_length = 0;
+        }
+    }
+}
+
+// possible future extension
+// pub struct DbtHashMap<Key, Value, K, V> {
+//     parent: Arc<Mutex<DbtSchema<Key, Value>>>,
+// }
+
+pub trait StorageSingleton<T>
+where
+    T: Clone,
+{
+    fn get(&self) -> T;
+    fn set(&mut self, t: T);
+}
+
+pub struct DbtSingleton<ParentKey, ParentValue, T> {
+    current_value: T,
+    old_value: T,
+    key: ParentKey,
+    reader: Arc<RefCell<dyn StorageReader<ParentKey, ParentValue>>>,
+}
+
+impl<ParentKey, ParentValue, T> StorageSingleton<T> for DbtSingleton<ParentKey, ParentValue, T>
+where
+    T: Clone + From<ParentValue>,
+{
+    fn get(&self) -> T {
+        self.current_value.clone()
+    }
+
+    fn set(&mut self, t: T) {
+        self.current_value = t;
+    }
+}
+
+impl<ParentKey, ParentValue, T> DbTable<ParentKey, ParentValue>
+    for DbtSingleton<ParentKey, ParentValue, T>
+where
+    T: Eq + Clone + Default + From<ParentValue>,
+    ParentValue: From<T> + Debug,
+    ParentKey: Clone,
+{
+    fn pull_queue(&mut self) -> Vec<WriteOperation<ParentKey, ParentValue>> {
+        if self.current_value == self.old_value {
+            vec![]
+        } else {
+            self.old_value = self.current_value.clone();
+            vec![WriteOperation::Write(
+                self.key.clone(),
+                self.current_value.clone().into(),
+            )]
+        }
+    }
+
+    fn restore_or_new(&mut self) {
+        self.current_value = match self.reader.as_ref().borrow_mut().get(self.key.clone()) {
+            Some(value) => value.into(),
+            None => T::default(),
+        }
+    }
+}
+
+pub struct DbtSchema<ParentKey, ParentValue, Reader: StorageReader<ParentKey, ParentValue>> {
+    tables: Vec<Arc<RefCell<dyn DbTable<ParentKey, ParentValue>>>>,
+    reader: Arc<RefCell<Reader>>,
+}
+
+impl<ParentKey, ParentValue, Reader: StorageReader<ParentKey, ParentValue> + 'static>
+    DbtSchema<ParentKey, ParentValue, Reader>
+{
+    pub fn new_vec<Index, T>(
+        &mut self,
+        name: &str,
+    ) -> Arc<RefCell<DbtVec<ParentKey, ParentValue, Index, T>>>
+    where
+        ParentKey: From<IndexType> + 'static,
+        ParentValue: From<T> + 'static,
+        T: Clone + From<ParentValue> + 'static,
+        ParentKey: From<(ParentKey, ParentKey)>,
+        ParentKey: From<u8>,
+        Index: From<ParentValue>,
+        ParentValue: From<IndexType>,
+        Index: From<u64> + 'static,
+        DbtVec<ParentKey, ParentValue, Index, T>: DbTable<ParentKey, ParentValue>,
+    {
+        assert!(self.tables.len() < 255);
+        let reader = self.reader.clone();
+        let vector = DbtVec::<ParentKey, ParentValue, Index, T> {
+            reader,
+            current_length: 0.into(),
+            key_prefix: self.tables.len() as u8,
+            write_queue: VecDeque::new(),
+            cache: HashMap::new(),
+            name: name.to_string(),
+        };
+        let arc_refcell_vector = Arc::new(RefCell::new(vector));
+        self.tables.push(arc_refcell_vector.clone());
+        arc_refcell_vector
+    }
+
+    // possible future extension
+    // fn new_hashmap<K, V>(&self) -> Arc<RefCell<DbtHashMap<K, V>>> { }
+
+    pub fn new_singleton<S>(
+        &mut self,
+        key: ParentKey,
+    ) -> Arc<RefCell<DbtSingleton<ParentKey, ParentValue, S>>>
+    where
+        S: Default + Eq + Clone + 'static,
+        ParentKey: 'static,
+        ParentValue: From<S> + 'static,
+        ParentKey: From<(ParentKey, ParentKey)> + From<u8>,
+        DbtSingleton<ParentKey, ParentValue, S>: DbTable<ParentKey, ParentValue>,
+    {
+        let reader = self.reader.clone();
+        let singleton = DbtSingleton::<ParentKey, ParentValue, S> {
+            current_value: S::default(),
+            old_value: S::default(),
+            key,
+            reader,
+        };
+        let arc_refcell_singleton = Arc::new(RefCell::new(singleton));
+        self.tables.push(arc_refcell_singleton.clone());
+        arc_refcell_singleton
+    }
+}
+
+pub trait StorageWriter<ParentKey, ParentValue> {
+    fn persist(&mut self);
+    fn restore_or_new(&mut self);
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct RustyKey(Vec<u8>);
+impl From<u8> for RustyKey {
+    fn from(value: u8) -> Self {
+        Self([value].to_vec())
+    }
+}
+impl From<(RustyKey, RustyKey)> for RustyKey {
+    fn from(value: (RustyKey, RustyKey)) -> Self {
+        let v0 = value.0 .0;
+        let v1 = value.1 .0;
+        RustyKey([v0, v1].concat())
+    }
+}
+#[derive(Debug)]
+struct RustyValue(Vec<u8>);
+
+/// Database schema and tables logic for RustyLevelDB. You probably
+/// want to implement your own storage class after this example so
+/// that you can hardcode the schema in new(). But it is nevertheless
+/// possible to use this struct and add to the scheme after calling
+/// new() (that's what the tests do).
+pub struct SimpleRustyStorage {
+    db: Arc<RefCell<DB>>,
+    schema: DbtSchema<RustyKey, RustyValue, SimpleRustyReader>,
+}
+
+impl StorageWriter<RustyKey, RustyValue> for SimpleRustyStorage {
+    fn persist(&mut self) {
+        let mut write_batch = WriteBatch::new();
+        for table in &self.schema.tables {
+            let operations = table.as_ref().borrow_mut().pull_queue();
+            for op in operations {
+                match op {
+                    WriteOperation::Write(key, value) => write_batch.put(&key.0, &value.0),
+                    WriteOperation::Delete(key) => write_batch.delete(&key.0),
+                }
+            }
+        }
+
+        self.db
+            .as_ref()
+            .borrow_mut()
+            .write(write_batch, true)
+            .expect("Could not persist to database.");
+    }
+
+    fn restore_or_new(&mut self) {
+        for table in &self.schema.tables {
+            table.as_ref().borrow_mut().restore_or_new();
+        }
+    }
+}
+
+impl SimpleRustyStorage {
+    pub fn new(db: DB) -> Self {
+        let db_pointer = Arc::new(RefCell::new(db));
+        let reader = SimpleRustyReader {
+            db: db_pointer.clone(),
+        };
+        let schema = DbtSchema::<RustyKey, RustyValue, SimpleRustyReader> {
+            tables: Vec::new(),
+            reader: Arc::new(RefCell::new(reader)),
+        };
+        Self {
+            db: db_pointer,
+            schema,
+        }
+    }
+
+    pub fn close(&mut self) {
+        self.db
+            .as_ref()
+            .borrow_mut()
+            .close()
+            .expect("Could not close database.");
+    }
+}
+
+struct SimpleRustyReader {
+    db: Arc<RefCell<DB>>,
+}
+
+impl StorageReader<RustyKey, RustyValue> for SimpleRustyReader {
+    fn get(&mut self, key: RustyKey) -> Option<RustyValue> {
+        self.db.as_ref().borrow_mut().get(&key.0).map(RustyValue)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[derive(Default, PartialEq, Eq, Clone, Debug)]
+    struct S(Vec<u8>);
+    impl From<Vec<u8>> for S {
+        fn from(value: Vec<u8>) -> Self {
+            S(value)
+        }
+    }
+    impl From<S> for Vec<u8> {
+        fn from(value: S) -> Self {
+            value.0
+        }
+    }
+    impl From<(S, S)> for S {
+        fn from(value: (S, S)) -> Self {
+            let vector0: Vec<u8> = value.0.into();
+            let vector1: Vec<u8> = value.1.into();
+            S([vector0, vector1].concat())
+        }
+    }
+    impl From<RustyValue> for S {
+        fn from(value: RustyValue) -> Self {
+            Self(value.0)
+        }
+    }
+    impl From<S> for RustyValue {
+        fn from(value: S) -> Self {
+            Self(value.0)
+        }
+    }
+
+    #[test]
+    fn test_simple_singleton() {
+        let singleton_value = S([1u8, 3u8, 3u8, 7u8].to_vec());
+        // let opt = rusty_leveldb::Options::default();
+        let opt = rusty_leveldb::in_memory();
+        let db = DB::open("test-database", opt.clone()).unwrap();
+
+        let mut rusty_storage = SimpleRustyStorage::new(db);
+        let singleton = rusty_storage
+            .schema
+            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+
+        // initialize
+        rusty_storage.restore_or_new();
+
+        // test
+        assert_eq!(singleton.as_ref().borrow_mut().get(), S([].to_vec()));
+
+        // set
+        singleton.as_ref().borrow_mut().set(singleton_value.clone());
+
+        // test
+        assert_eq!(singleton.as_ref().borrow_mut().get(), singleton_value);
+
+        // persist
+        rusty_storage.persist();
+
+        // test
+        assert_eq!(singleton.as_ref().borrow_mut().get(), singleton_value);
+
+        // drop
+        rusty_storage.close();
+
+        // restore
+        let new_db = DB::open("test-database", opt).unwrap();
+        let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
+        let new_singleton = new_rusty_storage
+            .schema
+            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+        new_rusty_storage.restore_or_new();
+
+        // test
+        assert_eq!(new_singleton.as_ref().borrow_mut().get(), singleton_value);
+    }
+}

--- a/twenty-first/src/util_types/storage_vec.rs
+++ b/twenty-first/src/util_types/storage_vec.rs
@@ -394,8 +394,8 @@ mod tests {
 
         // Check equality after above loop
         assert_eq!(normal_vector.len(), persisted_vector.len() as usize);
-        for i in 0..normal_vector.len() {
-            assert_eq!(normal_vector[i], persisted_vector.get(i as u64));
+        for (i, nvi) in normal_vector.iter().enumerate() {
+            assert_eq!(*nvi, persisted_vector.get(i as u64));
         }
 
         // Check equality after persisting updates
@@ -408,8 +408,11 @@ mod tests {
             normal_vector.len(),
             persisted_vector.persisted_length() as usize
         );
-        for i in 0..normal_vector.len() {
-            assert_eq!(normal_vector[i], persisted_vector.get(i as u64));
+
+        // Check equality after write
+        assert_eq!(normal_vector.len(), persisted_vector.len() as usize);
+        for (i, nvi) in normal_vector.iter().enumerate() {
+            assert_eq!(*nvi, persisted_vector.get(i as u64));
         }
     }
 

--- a/twenty-first/src/util_types/storage_vec.rs
+++ b/twenty-first/src/util_types/storage_vec.rs
@@ -6,7 +6,7 @@ use std::{
 use rusty_leveldb::{WriteBatch, DB};
 use serde::{de::DeserializeOwned, Serialize};
 
-type IndexType = u64;
+pub type IndexType = u64;
 
 pub trait StorageVec<T> {
     fn is_empty(&self) -> bool;

--- a/twenty-first/src/util_types/storage_vec.rs
+++ b/twenty-first/src/util_types/storage_vec.rs
@@ -1,7 +1,6 @@
 use std::{
-    cell::RefCell,
     collections::{HashMap, VecDeque},
-    rc::Rc,
+    sync::{Arc, Mutex},
 };
 
 use rusty_leveldb::{WriteBatch, DB};
@@ -22,6 +21,15 @@ pub enum WriteElement<T: Serialize + DeserializeOwned> {
     OverWrite((IndexType, T)),
     Push(T),
     Pop,
+}
+
+pub struct RustyLevelDbVec<T: Serialize + DeserializeOwned> {
+    key_prefix: u8,
+    db: Arc<Mutex<DB>>,
+    write_queue: VecDeque<WriteElement<T>>,
+    length: IndexType,
+    cache: HashMap<IndexType, T>,
+    name: String,
 }
 
 impl<T: Serialize + DeserializeOwned + Clone> StorageVec<T> for RustyLevelDbVec<T> {
@@ -49,7 +57,7 @@ impl<T: Serialize + DeserializeOwned + Clone> StorageVec<T> for RustyLevelDbVec<
 
         // then try persistent storage
         let db_key = self.get_index_key(index);
-        let db_val = self.db.borrow_mut().get(&db_key).unwrap_or_else(|| {
+        let db_val = self.db.lock().unwrap().get(&db_key).unwrap_or_else(|| {
             panic!(
                 "Element with index {index} does not exist in {}. This should not happen",
                 self.name
@@ -95,7 +103,8 @@ impl<T: Serialize + DeserializeOwned + Clone> StorageVec<T> for RustyLevelDbVec<
             // then try persistent storage
             let db_key = self.get_index_key(self.length);
             self.db
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .get(&db_key)
                 .map(|bytes| bincode::deserialize(&bytes).unwrap())
         }
@@ -117,15 +126,6 @@ impl<T: Serialize + DeserializeOwned + Clone> StorageVec<T> for RustyLevelDbVec<
     }
 }
 
-pub struct RustyLevelDbVec<T: Serialize + DeserializeOwned> {
-    key_prefix: u8,
-    db: Rc<RefCell<DB>>,
-    write_queue: VecDeque<WriteElement<T>>,
-    length: IndexType,
-    cache: HashMap<IndexType, T>,
-    name: String,
-}
-
 impl<T: Serialize + DeserializeOwned> RustyLevelDbVec<T> {
     // Return the key used to store the length of the persisted vector
     fn get_length_key(key_prefix: u8) -> [u8; 2] {
@@ -136,7 +136,7 @@ impl<T: Serialize + DeserializeOwned> RustyLevelDbVec<T> {
     /// Return the length at the last write to disk
     fn persisted_length(&self) -> IndexType {
         let key = Self::get_length_key(self.key_prefix);
-        match self.db.borrow_mut().get(&key) {
+        match self.db.lock().unwrap().get(&key) {
             Some(value) => bincode::deserialize(&value).unwrap(),
             None => 0,
         }
@@ -150,9 +150,9 @@ impl<T: Serialize + DeserializeOwned> RustyLevelDbVec<T> {
             .unwrap()
     }
 
-    pub fn new(db: Rc<RefCell<DB>>, key_prefix: u8, name: &str) -> Self {
+    pub fn new(db: Arc<Mutex<DB>>, key_prefix: u8, name: &str) -> Self {
         let length_key = Self::get_length_key(key_prefix);
-        let length = match db.borrow_mut().get(&length_key) {
+        let length = match db.lock().unwrap().get(&length_key) {
             Some(length_bytes) => bincode::deserialize(&length_bytes).unwrap(),
             None => 0,
         };
@@ -240,17 +240,17 @@ mod tests {
     use rand::{Rng, RngCore};
     use rusty_leveldb::DB;
 
-    fn get_test_db() -> Rc<RefCell<DB>> {
+    fn get_test_db() -> Arc<Mutex<DB>> {
         let opt = rusty_leveldb::in_memory();
         let db = DB::open("mydatabase", opt).unwrap();
-        Rc::new(RefCell::new(db))
+        Arc::new(Mutex::new(db))
     }
 
     /// Return a persisted vector and a regular in-memory vector with the same elements
     fn get_persisted_vec_with_length(
         length: IndexType,
         name: &str,
-    ) -> (RustyLevelDbVec<u64>, Vec<u64>, Rc<RefCell<DB>>) {
+    ) -> (RustyLevelDbVec<u64>, Vec<u64>, Arc<Mutex<DB>>) {
         let db = get_test_db();
         let mut persisted_vec = RustyLevelDbVec::new(db.clone(), 0, name);
         let mut regular_vec = vec![];
@@ -264,7 +264,7 @@ mod tests {
 
         let mut write_batch = WriteBatch::new();
         persisted_vec.pull_queue(&mut write_batch);
-        assert!(db.borrow_mut().write(write_batch, true).is_ok());
+        assert!(db.lock().unwrap().write(write_batch, true).is_ok());
 
         // Sanity checks
         assert!(persisted_vec.cache.is_empty());
@@ -349,7 +349,7 @@ mod tests {
         assert_eq!(0, delegated_db_vec_b.len());
 
         assert!(
-            db.borrow_mut().write(write_batch, true).is_ok(),
+            db.lock().unwrap().write(write_batch, true).is_ok(),
             "DB write must succeed"
         );
         assert_eq!(3, delegated_db_vec_a.persisted_length());
@@ -401,7 +401,7 @@ mod tests {
         // Check equality after persisting updates
         let mut write_batch = WriteBatch::new();
         persisted_vector.pull_queue(&mut write_batch);
-        db.borrow_mut().write(write_batch, true).unwrap();
+        db.lock().unwrap().write(write_batch, true).unwrap();
 
         assert_eq!(normal_vector.len(), persisted_vector.len() as usize);
         assert_eq!(


### PR DESCRIPTION
The file `storage_schema.rs` introduces a bunch of structs and traits (and implementations!) that abstract out the database-specific logic of containers-with-persistence. This allows the user to write logic relative to standard rust containers (such as `Vec`) and then switch to a container-with-persistance (such as `DbtVec`, defined in this PR) which has the same interface but also provides an interface for the host application to restore from or persist to database.