### PR TITLE
improve on Merkle tree's de-duplicated authentication structure generation & verification

### DIFF
--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -101,3 +101,7 @@ harness = false
 [[bench]]
 name = "merkle_tree"
 harness = false
+
+[[bench]]
+name = "merkle_tree_authenticate"
+harness = false

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -19,7 +19,7 @@ fn merkle_tree_authenticate(c: &mut Criterion) {
     let log_2_size = 16;
     let size = usize::pow(2, log_2_size);
     let leaves = (0..size).map(|_| rng.next_u64()).collect::<Vec<_>>();
-    let leaf_digests = leaves.iter().map(|x| Tip5::hash(x)).collect::<Vec<_>>();
+    let leaf_digests = leaves.iter().map(Tip5::hash).collect::<Vec<_>>();
     let mt: MerkleTree<Tip5, _> = CpuParallel::from_digests(&leaf_digests);
     let mt_root = mt.get_root();
 

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -1,0 +1,53 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use rand::rngs::StdRng;
+use rand::Rng;
+use rand::RngCore;
+use rand::SeedableRng;
+
+use twenty_first::shared_math::tip5::Tip5;
+use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
+use twenty_first::util_types::merkle_tree::CpuParallel;
+use twenty_first::util_types::merkle_tree::MerkleTree;
+use twenty_first::util_types::merkle_tree_maker::MerkleTreeMaker;
+
+fn merkle_tree_authenticate(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(0);
+
+    let log_2_size = 16;
+    let size = usize::pow(2, log_2_size);
+    let leaves = (0..size).map(|_| rng.next_u64()).collect::<Vec<_>>();
+    let leaf_digests = leaves.iter().map(|x| Tip5::hash(x)).collect::<Vec<_>>();
+    let mt: MerkleTree<Tip5, _> = CpuParallel::from_digests(&leaf_digests);
+    let mt_root = mt.get_root();
+
+    let num_opened_indices = usize::pow(2, log_2_size - 2);
+    let opened_indices = (0..num_opened_indices)
+        .map(|_| rng.gen_range(0..size))
+        .collect::<Vec<_>>();
+    let authentication_structure = mt.get_authentication_structure(&opened_indices);
+    let opened_leaves = opened_indices
+        .iter()
+        .map(|&i| leaf_digests[i])
+        .collect::<Vec<_>>();
+
+    let mut group = c.benchmark_group("merkle_tree_authenticate");
+    group.bench_function(
+        BenchmarkId::new("merkle_tree_authenticate", size),
+        |bencher| {
+            bencher.iter(|| {
+                MerkleTree::<Tip5, CpuParallel>::verify_authentication_structure_from_leaves(
+                    mt_root,
+                    &opened_indices,
+                    &opened_leaves,
+                    &authentication_structure,
+                )
+            });
+        },
+    );
+}
+
+criterion_group!(benches, merkle_tree_authenticate);
+criterion_main!(benches);

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -2,6 +2,7 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
+use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand::Rng;
 use rand::RngCore;
@@ -16,30 +17,31 @@ use twenty_first::util_types::merkle_tree_maker::MerkleTreeMaker;
 fn merkle_tree_authenticate(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0);
 
-    let log_2_size = 16;
-    let size = usize::pow(2, log_2_size);
-    let leaves = (0..size).map(|_| rng.next_u64()).collect::<Vec<_>>();
-    let leaf_digests = leaves.iter().map(Tip5::hash).collect::<Vec<_>>();
+    let tree_height = 16;
+    let num_leaves = 1 << tree_height;
+    let leaves = (0..num_leaves).map(|_| rng.next_u64()).collect_vec();
+    let leaf_digests = leaves.iter().map(Tip5::hash).collect_vec();
     let mt: MerkleTree<Tip5, _> = CpuParallel::from_digests(&leaf_digests);
     let mt_root = mt.get_root();
 
-    let num_opened_indices = usize::pow(2, log_2_size - 2);
+    let num_opened_indices = num_leaves / 4;
     let opened_indices = (0..num_opened_indices)
-        .map(|_| rng.gen_range(0..size))
-        .collect::<Vec<_>>();
+        .map(|_| rng.gen_range(0..num_leaves))
+        .collect_vec();
     let authentication_structure = mt.get_authentication_structure(&opened_indices);
     let opened_leaves = opened_indices
         .iter()
         .map(|&i| leaf_digests[i])
-        .collect::<Vec<_>>();
+        .collect_vec();
 
     let mut group = c.benchmark_group("merkle_tree_authenticate");
     group.bench_function(
-        BenchmarkId::new("merkle_tree_authenticate", size),
+        BenchmarkId::new("merkle_tree_authenticate", num_leaves),
         |bencher| {
             bencher.iter(|| {
                 MerkleTree::<Tip5, CpuParallel>::verify_authentication_structure_from_leaves(
                     mt_root,
+                    tree_height,
                     &opened_indices,
                     &opened_leaves,
                     &authentication_structure,

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -219,7 +219,7 @@ where
                 // the list (node_index, node_index / 2, node_index / 4, …). Hence, all the tests
                 // performed here exclusively deal with the current node_index's sibling.
                 let sibling_node_index = node_index ^ 1;
-                let siblings_calculability_is_known = scanned.contains(&sibling_node_index);
+                let sibling_already_covered = scanned.contains(&sibling_node_index);
 
                 let siblings_left_child_node_index = sibling_node_index * 2;
                 let siblings_right_child_node_index = siblings_left_child_node_index + 1;
@@ -227,10 +227,13 @@ where
                     .contains(&siblings_left_child_node_index)
                     && calculable_indices.contains(&siblings_right_child_node_index);
 
-                let sibling_leaf_index = sibling_node_index - num_leaves;
-                let sibling_is_explicitly_requested = leaf_indices.contains(&sibling_leaf_index);
+                // In the leaf layer, check if sibling is explicitly provided
+                let potential_sibling_leaf_index = sibling_node_index as i128 - num_leaves as i128;
+                let sibling_is_in_leaf_layer = potential_sibling_leaf_index >= 0;
+                let sibling_is_explicitly_requested = sibling_is_in_leaf_layer
+                    && leaf_indices.contains(&(potential_sibling_leaf_index as usize));
 
-                let authentication_path_element_is_redundant = siblings_calculability_is_known
+                let authentication_path_element_is_redundant = sibling_already_covered
                     || both_sibling_children_can_be_calculated
                     || sibling_is_explicitly_requested;
                 if authentication_path_element_is_redundant {

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -91,17 +91,16 @@ where
     /// return the hashes, not the tree nodes (and potential leaf values), and instead
     /// of referring to this as a `proof', we call it the `authentication path'.
     ///
+    /// ```markdown
     ///              root
     ///             /    \
     /// H(H(a)+H(b))      H(H(c)+H(d))
     ///   /      \        /      \
     /// H(a)    H(b)    H(c)    H(d)
+    /// ```
     ///
-    /// The authentication path for `c' (index: 2) would be
-    ///
-    ///   vec![ H(d), H(H(a)+H(b)) ]
-    ///
-    /// ... so a criss-cross of siblings upwards.
+    /// The authentication path for `c` (index: 2) would be `vec![ H(d), H(H(a)+H(b)) ]`, i.e.,
+    /// a criss-cross of siblings upwards.
     pub fn get_authentication_path(&self, leaf_index: usize) -> Vec<Digest> {
         let height = self.get_height();
         let mut auth_path: Vec<Digest> = Vec::with_capacity(height);


### PR DESCRIPTION
This PR brings multiple goodies.

- A benchmark for verifying partial Merkle authentication paths.
- A tremendous speedup when verifying partial authentication paths: what used to take ~500ms now takes ~650μs. Yes, you've read that right, the new code for verifying the particular de-duplicated Merkle tree authentication structure from the new benchmark shaves off ~99.87%[^2] of the runtime. This is achieved by performing as little hashing as possible.[^1]
- The expected height of the Merkle tree for the which the authentication structure is claimed to be valid is now an obligatory parameter. If any partial authentication path does not conform to this expected height, validation will fail.
- A bug fix in the logic of generating partial authentication paths.
- Big code readability improvements for both generation and verification of partial authentication paths.
- Implementations of traits `Deref` and `DerefMut` for partial authentication paths. This allows easier access to the underlying vector. For example, `auth_path.0.len()` can now be `auth_path.len()`.

[^1]: In contrast to the old logic, the new code for verifying partial authentication paths is completely sequential. It is possible that additional speedups can be achieved by introducing parallelization.
[^2]: On the beefy machine known as “mjolnir”, the respective times are 170ms and ~80μs, translating to 99.95%.