### PR TITLE
make `BFieldCodec` derive macro more stable and feature complete

### DIFF
--- a/bfieldcodec_derive/src/lib.rs
+++ b/bfieldcodec_derive/src/lib.rs
@@ -117,7 +117,7 @@ fn impl_bfieldcodec_macro(ast: syn::DeriveInput) -> TokenStream {
 
     let gen = quote! {
         impl #impl_generics BFieldCodec for #name #ty_generics #where_clause{
-            fn decode(sequence: &[BFieldElement]) -> anyhow::Result<Box<Self>> {
+            fn decode(sequence: &[crate::shared_math::b_field_element::BFieldElement]) -> anyhow::Result<Box<Self>> {
                 let mut sequence = sequence.to_vec();
                 #(#decode_statements)*
 
@@ -128,7 +128,7 @@ fn impl_bfieldcodec_macro(ast: syn::DeriveInput) -> TokenStream {
                 Ok(Box::new(#value_constructor))
             }
 
-            fn encode(&self) -> Vec<BFieldElement> {
+            fn encode(&self) -> Vec<crate::shared_math::b_field_element::BFieldElement> {
                 let mut elements = Vec::new();
                 #(#encode_statements)*
                 elements
@@ -172,8 +172,8 @@ fn struct_with_named_fields(
         .iter()
         .map(|fname| {
             quote! {
-                let mut #fname: Vec<BFieldElement> = self.#fname.encode();
-                elements.push(BFieldElement::new(#fname.len() as u64));
+                let mut #fname: Vec<crate::shared_math::b_field_element::BFieldElement> = self.#fname.encode();
+                elements.push(crate::shared_math::b_field_element::BFieldElement::new(#fname.len() as u64));
                 elements.append(&mut #fname);
             }
         })
@@ -227,8 +227,8 @@ fn struct_with_unnamed_fields(
         .iter()
         .map(|idx| {
             quote! {
-                    let mut field_value: Vec<BFieldElement> = self.#idx.encode();
-                    elements.push(BFieldElement::new(field_value.len() as u64));
+                    let mut field_value: Vec<crate::shared_math::b_field_element::BFieldElement> = self.#idx.encode();
+                    elements.push(crate::shared_math::b_field_element::BFieldElement::new(field_value.len() as u64));
                     elements.append(&mut field_value);
             }
         })
@@ -250,11 +250,11 @@ fn generate_decode_statement(
 ) -> quote::__private::TokenStream {
     quote! {
         let (field_value, sequence) = {if sequence.is_empty() {
-            bail!("Cannot decode field: sequence is empty.");
+            anyhow::bail!("Cannot decode field: sequence is empty.");
         }
         let len = sequence[0].value() as usize;
         if sequence.len() < 1 + len {
-            bail!("Cannot decode field: sequence too short.");
+            anyhow::bail!("Cannot decode field: sequence too short.");
         }
         let decoded = *<#field_type as BFieldCodec>::decode(&sequence[1..1 + len])?;
         (decoded, sequence[1 + len..].to_vec())};

--- a/bfieldcodec_derive/src/lib.rs
+++ b/bfieldcodec_derive/src/lib.rs
@@ -113,13 +113,10 @@ fn impl_bfieldcodec_macro(ast: syn::DeriveInput) -> TokenStream {
             fn decode(
                 sequence: &[::twenty_first::shared_math::b_field_element::BFieldElement],
             ) -> anyhow::Result<Box<Self>> {
-                let mut sequence = sequence.to_vec();
                 #(#decode_statements)*
-
                 if !sequence.is_empty() {
                     anyhow::bail!("Failed to decode {}", stringify!(#name));
                 }
-
                 Ok(Box::new(#value_constructor))
             }
 
@@ -310,7 +307,7 @@ fn generate_decode_statement(
                 as ::twenty_first::shared_math::bfield_codec::BFieldCodec>::decode(
                     &sequence[1..1 + len]
                 )?;
-            (decoded, sequence[1 + len..].to_vec())
+            (decoded, &sequence[1 + len..])
         };
         let #field_name = field_value;
     }

--- a/bfieldcodec_derive/src/lib.rs
+++ b/bfieldcodec_derive/src/lib.rs
@@ -7,6 +7,39 @@ use quote::quote;
 use syn::spanned::Spanned;
 use syn::Ident;
 
+/// Derives `BFieldCodec` for structs.
+///
+/// Fields that should not be serialized can be ignored by annotating them with
+/// `#[bfield_codec(ignore)]`.
+/// Ignored fields must implement [`Default`].
+///
+/// ### Example
+///
+/// ```ignore
+/// #[derive(BFieldCodec)]
+/// struct Foo {
+///    bar: u64,
+///    #[bfield_codec(ignore)]
+///    ignored: usize,
+/// }
+/// let foo = Foo { bar: 42, ignored: 7 };
+/// let encoded = foo.encode();
+/// let decoded = Foo::decode(&encoded).unwrap();
+/// assert_eq!(foo.bar, decoded.bar);
+/// ```
+///
+/// ### Known limitations
+/// Structs with tuples as fields are not supported.
+/// More specifically, deriving the trait will succeed, and the resulting implementations of
+/// `encode` and `decode` will compile.
+/// However, the derived methods `encode` and `decode` won't be each others duals.
+/// For example, the following code will panic:
+/// ```ignore
+/// #[derive(BFieldCodec)]
+/// struct Foo((u8, u8));
+/// let encoded = Foo((1, 2)).encode();
+/// let decoded = Foo::decode(&encoded).unwrap();
+/// ```
 #[proc_macro_derive(BFieldCodec, attributes(bfield_codec))]
 pub fn bfieldcodec_derive(input: TokenStream) -> TokenStream {
     // ...

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -29,7 +29,8 @@ features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-bfieldcodec_derive = "0.2.0"
+# bfieldcodec_derive = "0.2.0"
+bfieldcodec_derive = { path = "../bfieldcodec_derive" }
 blake3 = "1.3.3"
 byteorder = "1.4"
 console = "0.15"

--- a/twenty-first/src/lib.rs
+++ b/twenty-first/src/lib.rs
@@ -5,3 +5,13 @@ pub mod test_shared;
 pub mod timing_reporter;
 pub mod util_types;
 pub mod utils;
+
+// This is needed for `#[derive(BFieldCodec)]` macro to work consistently across crates.
+// Specifically:
+// From inside the `twenty-first` crate, we need to refer to `twenty-first` by `crate`.
+// However, from outside the `twenty-first` crate, we need to refer to it by `twenty_first`.
+// The re-export below allows using identifier `twenty_first` even from inside `twenty-first`.
+//
+// See also:
+// https://github.com/bkchr/proc-macro-crate/issues/2#issuecomment-572914520
+extern crate self as twenty_first;

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -2,10 +2,13 @@ use std::marker::PhantomData;
 
 use anyhow::bail;
 use anyhow::Result;
-use bfieldcodec_derive::BFieldCodec;
 use itertools::Itertools;
 use num_traits::One;
 use num_traits::Zero;
+
+// Re-export the derive macro so that it can be used in other crates without having to add
+// an explicit dependency on `bfieldcodec_derive` to their Cargo.toml.
+pub use bfieldcodec_derive::BFieldCodec;
 
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
 
@@ -26,7 +29,8 @@ pub trait BFieldCodec {
     fn decode(sequence: &[BFieldElement]) -> Result<Box<Self>>;
     fn encode(&self) -> Vec<BFieldElement>;
 
-    /// Returns the length in number of BFieldElements if it is known at compile-time. Otherwise, None.
+    /// Returns the length in number of BFieldElements if it is known at compile-time.
+    /// Otherwise, None.
     fn static_length() -> Option<usize>;
 }
 
@@ -326,7 +330,12 @@ impl<T: BFieldCodec> BFieldCodec for Vec<T> {
                 }
 
                 if sequence.len() != vector_length_indication * element_length + 1 {
-                    bail!("Length indication plus one must match actual sequence length. Indication was {}. Sequence length was {}.", vector_length_indication, sequence.len());
+                    bail!(
+                        "Length indication plus one must match actual sequence length. \
+                        Indication was {}. Sequence length was {}.",
+                        vector_length_indication,
+                        sequence.len()
+                    );
                 }
 
                 let mut ret: Vec<T> = Vec::with_capacity(vector_length_indication);
@@ -343,7 +352,12 @@ impl<T: BFieldCodec> BFieldCodec for Vec<T> {
                 let total_length_indication = sequence[0].value() as usize;
 
                 if sequence.len() != total_length_indication + 1 {
-                    bail!("Length indication plus one must match actual sequence length. Indication was {}. Sequence length was {}.", total_length_indication, sequence.len());
+                    bail!(
+                        "Length indication plus one must match actual sequence length. \
+                        Indication was {}. Sequence length was {}.",
+                        total_length_indication,
+                        sequence.len()
+                    );
                 }
 
                 let mut ret = vec![];

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -1038,4 +1038,21 @@ pub mod derive_tests {
             prop(random_struct());
         }
     }
+
+    #[test]
+    fn unsupported_fields_can_be_ignored_test() {
+        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+        struct UnsupportedFields {
+            a: u64,
+            #[bfield_codec(ignore)]
+            b: usize,
+        }
+        let my_struct = UnsupportedFields {
+            a: random(),
+            b: random(),
+        };
+        let encoded = my_struct.encode();
+        let decoded = UnsupportedFields::decode(&encoded).unwrap();
+        assert_eq!(my_struct.a, decoded.a);
+    }
 }

--- a/twenty-first/src/shared_math/tip5.rs
+++ b/twenty-first/src/shared_math/tip5.rs
@@ -9,11 +9,9 @@ pub use crate::shared_math::digest::{Digest, DIGEST_LENGTH};
 
 use crate::util_types::algebraic_hasher::{AlgebraicHasher, Domain, SpongeHasher};
 
-use super::{
-    bfield_codec::BFieldCodec,
-    mds::generated_function,
-    x_field_element::{XFieldElement, EXTENSION_DEGREE},
-};
+use crate::shared_math::mds::generated_function;
+use crate::shared_math::x_field_element::XFieldElement;
+use crate::shared_math::x_field_element::EXTENSION_DEGREE;
 
 pub const STATE_SIZE: usize = 16;
 pub const NUM_SPLIT_AND_LOOKUP: usize = 4;

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -1,4 +1,3 @@
-use bfieldcodec_derive::BFieldCodec;
 use itertools::izip;
 use itertools::Itertools;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -1,3 +1,4 @@
+use bfieldcodec_derive::BFieldCodec;
 use itertools::izip;
 use itertools::Itertools;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
@@ -8,6 +9,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
+use crate::shared_math::bfield_codec::BFieldCodec;
 use crate::shared_math::digest::Digest;
 use crate::shared_math::other::{bit_representation, is_power_of_two, log_2_floor};
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
@@ -44,7 +46,7 @@ where
 /// A single partial authentication path probably does not make a lot of sense. However, if you
 /// have multiple authentication paths that overlap, using multiple partial authentication paths
 /// is more space efficient.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, BFieldCodec)]
 pub struct PartialAuthenticationPath<Digest>(pub Vec<Option<Digest>>);
 
 impl Deref for PartialAuthenticationPath<Digest> {

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -1,4 +1,3 @@
-use bfieldcodec_derive::BFieldCodec;
 use get_size::GetSize;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -1,4 +1,3 @@
-use anyhow::bail;
 use bfieldcodec_derive::BFieldCodec;
 use get_size::GetSize;
 use serde::{Deserialize, Serialize};
@@ -9,7 +8,6 @@ use super::archival_mmr::ArchivalMmr;
 use super::mmr_membership_proof::MmrMembershipProof;
 use super::mmr_trait::Mmr;
 use super::shared_basic;
-use crate::shared_math::b_field_element::BFieldElement;
 use crate::shared_math::bfield_codec::BFieldCodec;
 use crate::shared_math::digest::Digest;
 use crate::util_types::algebraic_hasher::AlgebraicHasher;


### PR DESCRIPTION
- Use the new macro in more places.
- Add documentation, including example and known limitations.
- Allow ignoring fields via attribute `#[bfield_codec(ignore)]`. Ignored fields must implement `Default`.
- Make usage of the macro more stable through fully qualified names.
- Slight code cleanup.