### PR TITLE
Awareness of Static Sizes in BFieldCodec

### DIFF
--- a/bfieldcodec_derive/src/lib.rs
+++ b/bfieldcodec_derive/src/lib.rs
@@ -105,16 +105,17 @@ fn extract_ignored_generics(attr: &syn::Attribute) -> Vec<Ident> {
 }
 
 fn impl_bfieldcodec_macro(ast: syn::DeriveInput) -> TokenStream {
-    let (decode_statements, encode_statements, value_constructor, field_types) = match &ast.data {
+    let (encode_statements, decode_function_body, static_length_body) = match &ast.data {
         syn::Data::Struct(syn::DataStruct {
             fields: syn::Fields::Named(fields),
             ..
-        }) => struct_with_named_fields(fields),
+        }) => generate_tokens_for_struct_with_named_fields(fields),
         syn::Data::Struct(syn::DataStruct {
             fields: syn::Fields::Unnamed(fields),
             ..
-        }) => struct_with_unnamed_fields(fields),
-        _ => panic!("expected a struct with named fields"),
+        }) => generate_tokens_for_struct_with_unnamed_fields(fields),
+        syn::Data::Enum(data_enum) => generate_tokens_for_enum_with_variants(&data_enum.variants),
+        _ => panic!("expected a struct with named fields, with unnamed fields, or an enum"),
     };
 
     let name = &ast.ident;
@@ -128,19 +129,13 @@ fn impl_bfieldcodec_macro(ast: syn::DeriveInput) -> TokenStream {
     // Extract the generics of the struct/enum.
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let num_fields = field_types.len();
-
     let gen = quote! {
         impl #impl_generics ::twenty_first::shared_math::bfield_codec::BFieldCodec
         for #name #ty_generics #where_clause{
             fn decode(
                 sequence: &[::twenty_first::shared_math::b_field_element::BFieldElement],
             ) -> anyhow::Result<Box<Self>> {
-                #(#decode_statements)*
-                if !sequence.is_empty() {
-                    anyhow::bail!("Failed to decode {}", stringify!(#name));
-                }
-                Ok(Box::new(#value_constructor))
+                #decode_function_body
             }
 
             fn encode(&self) -> Vec<::twenty_first::shared_math::b_field_element::BFieldElement> {
@@ -150,18 +145,7 @@ fn impl_bfieldcodec_macro(ast: syn::DeriveInput) -> TokenStream {
             }
 
             fn static_length() -> Option<usize> {
-                let field_lengths : [Option<usize>; #num_fields] = [
-                    #(
-                        <#field_types as
-                        ::twenty_first::shared_math::bfield_codec::BFieldCodec>::static_length(),
-                    )*
-                ];
-                if field_lengths.iter().all(|fl| fl.is_some() ) {
-                    Some(field_lengths.iter().map(|fl| fl.unwrap()).sum())
-                }
-                else {
-                    None
-                }
+                #static_length_body
             }
         }
     };
@@ -202,13 +186,12 @@ fn field_is_ignored(field: &syn::Field) -> bool {
     false
 }
 
-fn struct_with_named_fields(
+fn generate_tokens_for_struct_with_named_fields(
     fields: &syn::FieldsNamed,
 ) -> (
     Vec<quote::__private::TokenStream>,
-    Vec<quote::__private::TokenStream>,
     quote::__private::TokenStream,
-    Vec<syn::Type>,
+    quote::__private::TokenStream,
 ) {
     let fields = fields.named.iter();
     let included_fields = fields.clone().filter(|field| !field_is_ignored(field));
@@ -243,11 +226,11 @@ fn struct_with_named_fields(
         })
         .collect();
 
-    let decode_statements: Vec<_> = included_field_types
+    let decode_statements = included_field_types
         .clone()
         .zip(included_field_names.clone())
-        .map(|(ftype, fname)| generate_decode_statement(&fname, &ftype))
-        .collect();
+        .map(|(ftype, fname)| generate_decode_statement_for_field(&fname, &ftype))
+        .collect::<Vec<_>>();
 
     let value_constructor = quote! {
         Self {
@@ -256,21 +239,49 @@ fn struct_with_named_fields(
         }
     };
 
+    let decode_constructor = quote! {
+        #(#decode_statements)*
+        if !sequence.is_empty() {
+            anyhow::bail!("Could not decode struct: sequence too long. ({} elements remaining)", sequence.len());
+        }
+
+        Ok(Box::new(#value_constructor))
+    };
+
     (
-        decode_statements,
         encode_statements,
-        value_constructor,
-        included_field_types.collect(),
+        decode_constructor,
+        generate_static_length_function_body_for_struct(included_field_types.collect()),
     )
 }
 
-fn struct_with_unnamed_fields(
+fn generate_static_length_function_body_for_struct(
+    field_types: Vec<syn::Type>,
+) -> quote::__private::TokenStream {
+    let num_fields = field_types.len();
+    quote! {
+
+        let field_lengths : [Option<usize>; #num_fields] = [
+            #(
+                <#field_types as
+                ::twenty_first::shared_math::bfield_codec::BFieldCodec>::static_length(),
+            )*
+        ];
+        if field_lengths.iter().all(|fl| fl.is_some() ) {
+            Some(field_lengths.iter().map(|fl| fl.unwrap()).sum())
+        }
+        else {
+            None
+        }
+    }
+}
+
+fn generate_tokens_for_struct_with_unnamed_fields(
     fields: &syn::FieldsUnnamed,
 ) -> (
     Vec<quote::__private::TokenStream>,
-    Vec<quote::__private::TokenStream>,
     quote::__private::TokenStream,
-    Vec<syn::Type>,
+    quote::__private::TokenStream,
 ) {
     let indices: Vec<_> = (0..fields.unnamed.len()).map(syn::Index::from).collect();
     let field_types = fields
@@ -289,7 +300,7 @@ fn struct_with_unnamed_fields(
     let decode_statements: Vec<_> = field_types
         .iter()
         .zip(&field_names)
-        .map(|(ty, var)| generate_decode_statement(var, ty))
+        .map(|(ty, var)| generate_decode_statement_for_field(var, ty))
         .collect();
 
     let encode_statements: Vec<_> = indices
@@ -313,22 +324,121 @@ fn struct_with_unnamed_fields(
 
     let value_constructor = quote! { Self ( #(#field_names,)* ) };
 
+    let decode_constructor = quote! {
+        #(#decode_statements)*
+        if !sequence.is_empty() {
+            anyhow::bail!("Could not decode struct: sequence too long. ({} elements remaining)", sequence.len());
+        }
+        Ok(Box::new(#value_constructor))
+    };
+
     (
-        decode_statements,
         encode_statements,
-        value_constructor,
-        field_types,
+        decode_constructor,
+        generate_static_length_function_body_for_struct(field_types),
     )
 }
 
-fn generate_decode_statement(
+fn generate_tokens_for_enum_with_variants(
+    variants: &syn::punctuated::Punctuated<syn::Variant, syn::token::Comma>,
+) -> (
+    Vec<quote::__private::TokenStream>,
+    quote::__private::TokenStream,
+    quote::__private::TokenStream,
+) {
+    let decode_clauses = variants
+        .iter()
+        .enumerate()
+        .map(|(i, v)| generate_decode_clause_for_variant(i, &v.ident, &v.fields));
+    let match_clauses = decode_clauses
+        .enumerate()
+        .map(|(i, c)| quote! { #i => { #c } });
+    let decode_constructor = quote! {
+
+        if sequence.is_empty() {
+            anyhow::bail!("Cannot decode variant: sequence is empty");
+        }
+        else
+        {
+            let (variant_index, sequence) = (sequence[0].value() as usize, &sequence[1..]);
+            match variant_index {
+                #(#match_clauses ,)*
+                other_index => anyhow::bail!("Cannot decode variant: invalid variant index: {other_index}"),
+            }
+        }
+
+    };
+
+    let encode_clauses = variants
+        .iter()
+        .enumerate()
+        .map(|(i, v)| generate_encode_clause_for_variant(i, &v.ident, &v.fields));
+    let encode_match_statement = quote! {
+        match self {
+            #( #encode_clauses , )*
+        }
+    };
+
+    let num_variants = variants.len();
+    let static_field_length_function_body = if variants.iter().all(|v| v.fields.is_empty()) {
+        // no variants have associated data
+        quote! {Some(1)}
+    } else if num_variants == 0 {
+        // there are no variants
+        quote! {Some(0)}
+    } else {
+        // some variants have associated data
+        // if all variants encode to the same length anyway, the length is still statically known
+        let variant_lengths = variants
+            .iter()
+            .map(|variant| {
+                let num_fields = variant.fields.len();
+                let fields = variant.fields.clone();
+                let field_lengths = fields
+                    .iter()
+                    .map(|f| quote!{
+                        < #f as ::twenty_first::shared_math::bfield_codec::BFieldCodec>::static_length()
+                    });
+                quote!{
+                    {
+                        let field_lengths : [Option<usize>; #num_fields] = [ #( #field_lengths , )* ];
+                        if field_lengths.iter().all(|fl| fl.is_some()) { Some(field_lengths.iter().map(|fl|fl.unwrap()).sum()) } else { None }
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        quote! {
+
+            let variant_lengths : [Option<usize>; #num_variants] = [
+                #(
+                    #variant_lengths ,
+                )*
+            ];
+            if variant_lengths.iter().all(|fl| fl.is_some() ) && variant_lengths.iter().tuple_windows().all(|(l, r)| l.unwrap() == r.unwrap()) {
+                variant_lengths[0]
+            }
+            else {
+                None
+            }
+        }
+    };
+
+    (
+        vec![encode_match_statement],
+        decode_constructor,
+        static_field_length_function_body,
+    )
+}
+
+fn generate_decode_statement_for_field(
     field_name: &syn::Ident,
     field_type: &syn::Type,
 ) -> quote::__private::TokenStream {
+    let field_name_as_string_literal = field_name.to_string();
     quote! {
-        let (field_value, sequence) = {
+        let (#field_name, sequence) = {
             if sequence.is_empty() {
-                anyhow::bail!("Cannot decode field: sequence is empty.");
+                anyhow::bail!("Cannot decode field {}: sequence is empty.", #field_name_as_string_literal);
             }
             let (len, sequence) = match <#field_type
                 as ::twenty_first::shared_math::bfield_codec::BFieldCodec>::static_length() {
@@ -336,7 +446,7 @@ fn generate_decode_statement(
                 None => (sequence[0].value() as usize, &sequence[1..]),
             };
             if sequence.len() < len {
-                anyhow::bail!("Cannot decode field: sequence too short.");
+                anyhow::bail!("Cannot decode field {}: sequence too short.", #field_name_as_string_literal);
             }
             let decoded = *<#field_type
                 as ::twenty_first::shared_math::bfield_codec::BFieldCodec>::decode(
@@ -344,6 +454,98 @@ fn generate_decode_statement(
                 )?;
             (decoded, &sequence[len..])
         };
-        let #field_name = field_value;
+    }
+}
+
+fn enum_variant_field_name(variant_index: usize, field_index: usize) -> syn::Ident {
+    quote::format_ident!("variant_{}_field_{}", variant_index, field_index)
+}
+
+fn generate_decode_clause_for_variant(
+    variant_index: usize,
+    name: &syn::Ident,
+    associated_data: &syn::Fields,
+) -> quote::__private::TokenStream {
+    if associated_data.is_empty() {
+        quote! {
+            Ok(Box::new(Self::#name))
+        }
+    } else {
+        let field_decoders = associated_data.iter().enumerate().map(|(field_index, field)| {
+            let field_type = field.ty.clone();
+            let field_name = enum_variant_field_name(variant_index, field_index);
+            let field_value = quote::format_ident!("variant_{}_field_{}_value", variant_index, field_index);
+            quote! {
+                let (#field_value, sequence) = {
+                    if sequence.is_empty() {
+                        anyhow::bail!("Cannot decode field {}: sequence is empty.", #field_index);
+                    }
+                    let (len, sequence) = match <#field_type
+                        as ::twenty_first::shared_math::bfield_codec::BFieldCodec>::static_length() {
+                        Some(len) => (len, sequence),
+                        None => (sequence[0].value() as usize, &sequence[1..]),
+                    };
+                    if sequence.len() < len {
+                        anyhow::bail!("Cannot decode field {}: sequence too short.", #field_index);
+                    }
+                    let decoded = *<#field_type
+                        as ::twenty_first::shared_math::bfield_codec::BFieldCodec>::decode(
+                            &sequence[..len]
+                        )?;
+                    (decoded, &sequence[len..])
+                };
+                let #field_name = #field_value;
+            }
+        }).fold(quote!{}, |l, r| quote!{#l #r});
+        let field_names = associated_data
+            .iter()
+            .enumerate()
+            .map(|(field_index, _field)| enum_variant_field_name(variant_index, field_index));
+        quote! { #field_decoders Ok(Box::new(Self::#name ( #( #field_names , )* ))) }
+    }
+}
+
+fn generate_encode_clause_for_variant(
+    variant_index: usize,
+    variant_name: &syn::Ident,
+    associated_data: &syn::Fields,
+) -> quote::__private::TokenStream {
+    if associated_data.is_empty() {
+        quote! {
+            Self::#variant_name => { elements.push(::twenty_first::shared_math::b_field_element::BFieldElement::new( #variant_index as u64)); }
+        }
+    } else {
+        let field_encoders = associated_data.iter().enumerate().map(|(field_index, ad)| {
+            let field_name = enum_variant_field_name(variant_index, field_index);
+            let field_type = ad.ty.clone();
+            let field_encoding =
+                quote::format_ident!("variant_{}_field_{}_encoding", variant_index, field_index);
+            quote! {
+                let mut #field_encoding :
+                    Vec<::twenty_first::shared_math::b_field_element::BFieldElement>
+                    = #field_name.encode();
+                if <#field_type as ::twenty_first::shared_math::bfield_codec::BFieldCodec>
+                    ::static_length().is_none() {
+                    elements.push(::twenty_first::shared_math::b_field_element::BFieldElement::new(
+                        #field_encoding.len() as u64)
+                    );
+                }
+                elements.append(&mut #field_encoding);
+            }
+        });
+
+        let field_names = associated_data
+            .iter()
+            .enumerate()
+            .map(|(field_index, _field)| enum_variant_field_name(variant_index, field_index));
+
+        let ret = quote! {
+            Self::#variant_name ( #( #field_names , )* ) => {
+                elements.push(::twenty_first::shared_math::b_field_element::BFieldElement::new( #variant_index as u64));
+                #( #field_encoders )*
+            }
+        };
+
+        ret
     }
 }

--- a/bfieldcodec_derive/src/lib.rs
+++ b/bfieldcodec_derive/src/lib.rs
@@ -29,16 +29,6 @@ use syn::Ident;
 /// ```
 ///
 /// ### Known limitations
-/// Structs with tuples as fields are not supported.
-/// More specifically, deriving the trait will succeed, and the resulting implementations of
-/// `encode` and `decode` will compile.
-/// However, the derived methods `encode` and `decode` won't be each others duals.
-/// For example, the following code will panic:
-/// ```ignore
-/// #[derive(BFieldCodec)]
-/// struct Foo((u8, u8));
-/// let encoded = Foo((1, 2)).encode();
-/// let decoded = Foo::decode(&encoded).unwrap();
 /// ```
 #[proc_macro_derive(BFieldCodec, attributes(bfield_codec))]
 pub fn bfieldcodec_derive(input: TokenStream) -> TokenStream {

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -29,7 +29,8 @@ features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-bfieldcodec_derive = "0.3.0"
+bfieldcodec_derive = { path = "../bfieldcodec_derive" }
+#bfieldcodec_derive = "0.3.0"
 blake3 = "1.3.3"
 colored = "2.0"
 hashbrown = "0.14"

--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -68,10 +68,6 @@ impl GetSize for BFieldElement {
     fn get_heap_size(&self) -> usize {
         0
     }
-
-    fn get_size(&self) -> usize {
-        Self::get_stack_size() + GetSize::get_heap_size(self)
-    }
 }
 
 pub const BFIELD_ZERO: BFieldElement = BFieldElement::new(0);

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -461,7 +461,9 @@ mod tests {
                 assert!(
                     decoded_mutated.is_err()
                         || *decoded_mutated.unwrap() != original_decoded
-                        || mutated_encoding[i] == original_value
+                        || mutated_encoding[i] == original_value,
+                    "Error: Mutated encoding was: {}",
+                    mutated_encoding.iter().join(",")
                 );
             }
 
@@ -473,7 +475,9 @@ mod tests {
                 assert!(
                     decoded_mutated.is_err()
                         || *decoded_mutated.unwrap() != original_decoded
-                        || mutated_encoding[i] == original_value
+                        || mutated_encoding[i] == original_value,
+                    "Error: Mutated encoding was: {}",
+                    mutated_encoding.iter().join(",")
                 );
             }
 

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -979,7 +979,9 @@ pub mod derive_tests {
         #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
         struct MuchNesting {
             a: Vec<Vec<Vec<Vec<BFieldElement>>>>,
+            #[bfield_codec(ignore)]
             b: PhantomData<Tip5>,
+            #[bfield_codec(ignore)]
             c: PhantomData<Tip5>,
         }
 
@@ -1167,6 +1169,7 @@ pub mod derive_tests {
         struct MmrAccumulator<H: BFieldCodec> {
             leaf_count: u64,
             peaks: Vec<Digest>,
+            #[bfield_codec(ignore)]
             _hasher: PhantomData<H>,
         }
 
@@ -1201,5 +1204,131 @@ pub mod derive_tests {
         let encoded = my_struct.encode();
         let decoded = UnsupportedFields::decode(&encoded).unwrap();
         assert_eq!(my_struct.a, decoded.a);
+    }
+
+    #[test]
+    fn vec_of_struct_with_one_fix_len_field_test() {
+        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+        pub struct OneFixedLenField {
+            pub some_digest: Digest,
+        }
+
+        let rand_struct = || OneFixedLenField {
+            some_digest: random(),
+        };
+
+        for num_elements in 0..5 {
+            dbg!(num_elements);
+            prop(vec![rand_struct(); num_elements]);
+        }
+    }
+
+    #[test]
+    fn vec_of_struct_with_two_fix_len_fields_test() {
+        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+        pub struct TwoFixedLenFields {
+            pub some_digest: Digest,
+            pub some_u64: u64,
+        }
+
+        let rand_struct = || TwoFixedLenFields {
+            some_digest: random(),
+            some_u64: random(),
+        };
+
+        for num_elements in 0..5 {
+            dbg!(num_elements);
+            prop(vec![rand_struct(); num_elements]);
+        }
+    }
+
+    #[test]
+    fn vec_of_struct_with_two_fix_len_unnamed_fields_test() {
+        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+        pub struct TwoFixedLenUnnamedFields(Digest, u64);
+
+        let rand_struct = || TwoFixedLenUnnamedFields(random(), random());
+
+        for num_elements in 0..5 {
+            dbg!(num_elements);
+            prop(vec![rand_struct(); num_elements]);
+        }
+    }
+
+    #[test]
+    fn vec_of_struct_with_fix_and_var_len_fields_test() {
+        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+        pub struct FixAndVarLenFields {
+            pub some_digest: Digest,
+            pub some_vec: Vec<u64>,
+        }
+
+        let rand_struct = || {
+            let num_elements: usize = thread_rng().gen_range(0..42);
+            FixAndVarLenFields {
+                some_digest: random(),
+                some_vec: random_elements(num_elements),
+            }
+        };
+
+        for num_elements in 0..5 {
+            dbg!(num_elements);
+            prop(vec![rand_struct(); num_elements]);
+        }
+    }
+
+    #[test]
+    fn vec_of_struct_with_fix_and_var_len_unnamed_fields_test() {
+        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+        pub struct FixAndVarLenUnnamedFields(Digest, Vec<u64>);
+
+        let rand_struct = || {
+            let num_elements: usize = thread_rng().gen_range(0..42);
+            FixAndVarLenUnnamedFields(random(), random_elements(num_elements))
+        };
+
+        for num_elements in 0..5 {
+            dbg!(num_elements);
+            prop(vec![rand_struct(); num_elements]);
+        }
+    }
+
+    #[test]
+    fn vec_of_struct_with_quite_a_few_fix_and_var_len_fields_test() {
+        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+        pub struct QuiteAFewFixAndVarLenFields {
+            pub some_digest: Digest,
+            pub some_vec: Vec<u64>,
+            pub some_u64: u64,
+            pub other_vec: Vec<u32>,
+            pub other_digest: Digest,
+            pub yet_another_vec: Vec<u32>,
+            pub and_another_vec: Vec<u64>,
+            pub more_fixed_len: u64,
+            pub even_more_fixed_len: u64,
+        }
+
+        let rand_struct = || {
+            let num_elements_0: usize = thread_rng().gen_range(0..42);
+            let num_elements_1: usize = thread_rng().gen_range(0..42);
+            let num_elements_2: usize = thread_rng().gen_range(0..42);
+            let num_elements_3: usize = thread_rng().gen_range(0..42);
+            QuiteAFewFixAndVarLenFields {
+                some_digest: random(),
+                some_vec: random_elements(num_elements_0),
+                some_u64: random(),
+                other_vec: random_elements(num_elements_1),
+                other_digest: random(),
+                yet_another_vec: random_elements(num_elements_2),
+                and_another_vec: random_elements(num_elements_3),
+                more_fixed_len: random(),
+                even_more_fixed_len: random(),
+            }
+        };
+
+        for num_elements in 0..5 {
+            dbg!(num_elements);
+            prop(vec![rand_struct(); num_elements]);
+        }
     }
 }

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -524,249 +524,11 @@ impl<T> BFieldCodec for PhantomData<T> {
 }
 
 #[cfg(test)]
-mod bfield_codec_tests {
-
-    use itertools::Itertools;
-    use rand::thread_rng;
-    use rand::Rng;
-    use rand::RngCore;
-
+mod tests {
     use crate::shared_math::other::random_elements;
-    use crate::shared_math::tip5::Tip5;
 
     use super::*;
-
-    fn random_length(max: usize) -> usize {
-        let mut rng = thread_rng();
-        rng.next_u32() as usize % max
-    }
-
-    fn random_bfieldelement() -> BFieldElement {
-        let mut rng = thread_rng();
-        BFieldElement::new(rng.next_u64())
-    }
-
-    fn random_xfieldelement() -> XFieldElement {
-        XFieldElement {
-            coefficients: [
-                random_bfieldelement(),
-                random_bfieldelement(),
-                random_bfieldelement(),
-            ],
-        }
-    }
-
-    fn random_digest() -> Digest {
-        Digest::new([
-            random_bfieldelement(),
-            random_bfieldelement(),
-            random_bfieldelement(),
-            random_bfieldelement(),
-            random_bfieldelement(),
-        ])
-    }
-
-    #[test]
-    fn test_encode_decode_random_bfieldelement() {
-        for _ in 1..=10 {
-            let bfe = random_bfieldelement();
-            let str = bfe.encode();
-            let bfe_ = *BFieldElement::decode(&str).unwrap();
-            assert_eq!(bfe, bfe_);
-        }
-    }
-
-    #[test]
-    fn test_encode_decode_random_xfieldelement() {
-        for _ in 1..=10 {
-            let xfe = random_xfieldelement();
-            let str = xfe.encode();
-            let xfe_ = *XFieldElement::decode(&str).unwrap();
-            assert_eq!(xfe, xfe_);
-        }
-    }
-
-    #[test]
-    fn test_encode_decode_random_digest() {
-        for _ in 1..=10 {
-            let dig = random_digest();
-            let str = dig.encode();
-            let dig_ = *Digest::decode(&str).unwrap();
-            assert_eq!(dig, dig_);
-        }
-    }
-
-    #[test]
-    fn test_encode_decode_random_vec_of_bfieldelement() {
-        for _ in 1..=10 {
-            let len = random_length(100);
-            let bfe_vec = (0..len).map(|_| random_bfieldelement()).collect_vec();
-            let str = bfe_vec.encode();
-            let bfe_vec_ = *Vec::<BFieldElement>::decode(&str).unwrap();
-            assert_eq!(bfe_vec, bfe_vec_);
-        }
-    }
-
-    #[test]
-    fn test_encode_decode_random_vec_of_xfieldelement() {
-        for _ in 1..=10 {
-            let len = random_length(100);
-            let xfe_vec = (0..len).map(|_| random_xfieldelement()).collect_vec();
-            let str = xfe_vec.encode();
-            let xfe_vec_ = *Vec::<XFieldElement>::decode(&str).unwrap();
-            assert_eq!(xfe_vec, xfe_vec_);
-        }
-    }
-
-    #[test]
-    fn test_encode_decode_random_vec_of_digest() {
-        for _ in 1..=10 {
-            let len = random_length(100);
-            let digest_vec = (0..len).map(|_| random_digest()).collect_vec();
-            let str = digest_vec.encode();
-            let digest_vec_ = *Vec::<Digest>::decode(&str).unwrap();
-            assert_eq!(digest_vec, digest_vec_);
-        }
-    }
-
-    #[test]
-    fn test_encode_decode_random_vec_of_vec_of_bfieldelement() {
-        for _ in 1..=10 {
-            let len = random_length(10);
-            let bfe_vec_vec = (0..len)
-                .map(|_| {
-                    let inner_len = random_length(20);
-                    (0..inner_len).map(|_| random_bfieldelement()).collect_vec()
-                })
-                .collect_vec();
-            let str = bfe_vec_vec.encode();
-            let bfe_vec_vec_ = *Vec::<Vec<BFieldElement>>::decode(&str).unwrap();
-            assert_eq!(bfe_vec_vec, bfe_vec_vec_);
-        }
-    }
-
-    #[test]
-    fn test_encode_decode_random_vec_of_vec_of_xfieldelement() {
-        for _ in 1..=10 {
-            let len = random_length(10);
-            let xfe_vec_vec = (0..len)
-                .map(|_| {
-                    let inner_len = random_length(20);
-                    (0..inner_len).map(|_| random_xfieldelement()).collect_vec()
-                })
-                .collect_vec();
-            let str = xfe_vec_vec.encode();
-            let xfe_vec_vec_ = *Vec::<Vec<XFieldElement>>::decode(&str).unwrap();
-            assert_eq!(xfe_vec_vec, xfe_vec_vec_);
-        }
-    }
-
-    #[test]
-    fn test_decode_random_negative() {
-        for _ in 1..=10000 {
-            let len = random_length(100);
-            let str: Vec<BFieldElement> = random_elements(len);
-
-            // Some of the following cases can be triggered by false
-            // positives. This should occur with probability roughly
-            // 2^-60.
-
-            if let Ok(sth) = Vec::<BFieldElement>::decode(&str) {
-                panic!("{sth:?}");
-            }
-
-            if str.len() % EXTENSION_DEGREE != 1 {
-                if let Ok(sth) = Vec::<XFieldElement>::decode(&str) {
-                    panic!("{sth:?}");
-                }
-            }
-
-            if str.len() % DIGEST_LENGTH != 1 {
-                if let Ok(sth) = Vec::<Digest>::decode(&str) {
-                    panic!("{sth:?}");
-                }
-            }
-
-            if let Ok(sth) = Vec::<Vec<BFieldElement>>::decode(&str) {
-                if !sth.is_empty() {
-                    panic!("{sth:?}");
-                }
-            }
-
-            if let Ok(sth) = Vec::<Vec<XFieldElement>>::decode(&str) {
-                if !sth.is_empty() {
-                    panic!("{sth:?}");
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_encode_decode_random_vec_option_xfieldelement() {
-        let mut rng = thread_rng();
-        let n = 10 + (rng.next_u32() % 50);
-        let mut vector: Vec<Option<XFieldElement>> = vec![];
-        for _ in 0..n {
-            if rng.next_u32() % 2 == 0 {
-                vector.push(None);
-            } else {
-                vector.push(Some(rng.gen()));
-            }
-        }
-
-        let encoded = vector.encode();
-        let decoded = *Vec::<Option<XFieldElement>>::decode(&encoded).unwrap();
-
-        assert_eq!(vector, decoded);
-    }
-
-    #[test]
-    fn test_phantom_data() {
-        let pd = PhantomData::<Tip5>;
-        let encoded = pd.encode();
-        let decoded = *PhantomData::decode(&encoded).unwrap();
-        assert_eq!(decoded, pd);
-
-        assert!(encoded.is_empty());
-    }
-
-    #[test]
-    fn decode_encode_array_with_static_element_size() {
-        const N: usize = 14;
-        type Array = [u64; N];
-
-        let an_array: Array = [14u64; N];
-        prop(&an_array);
-
-        assert_eq!(
-            Some(N * 2),
-            <Array>::static_length(),
-            "Static length must be set and correct for array with static element lengths"
-        );
-    }
-
-    #[test]
-    fn decode_encode_array_with_dynamic_element_size() {
-        const N: usize = 19;
-        type Array = [Vec<Digest>; N];
-
-        // Initialize an array with empty vectors in all elements
-        let mut an_array: Array = Default::default();
-        prop(&an_array);
-
-        // Should also work if the elements are not just the empty vectors
-        let mut rng = thread_rng();
-        for elem in an_array.iter_mut() {
-            *elem = random_elements(rng.gen_range(0..7));
-        }
-
-        prop(&an_array);
-
-        assert!(
-            <Array>::static_length().is_none(),
-            "Static length must be none for array with dynamic element lengths"
-        );
-    }
+    use rand::{random, thread_rng};
 
     fn prop<T: BFieldCodec + PartialEq + Eq + std::fmt::Debug>(value: &T) {
         let encoded = value.encode();
@@ -780,620 +542,866 @@ mod bfield_codec_tests {
         let encoded_too_short = encoded_too_long[..encoded_too_long.len() - 2].to_vec();
         assert!(T::decode(&encoded_too_short).is_err());
     }
-}
 
-#[derive(BFieldCodec, PartialEq, Eq, Debug)]
-struct DeriveTestStructA {
-    field_a: u64,
-    field_b: u64,
-    field_c: u64,
-}
+    mod bfield_codec_tests {
 
-#[derive(BFieldCodec, PartialEq, Eq, Debug)]
-struct DeriveTestStructB(u128);
+        use rand::{Rng, RngCore};
 
-#[derive(BFieldCodec, PartialEq, Eq, Debug)]
-struct DeriveTestStructC(u128, u64, u32);
+        use crate::{
+            shared_math::{other::random_elements, tip5::Tip5},
+            util_types::merkle_tree::PartialAuthenticationPath,
+        };
 
-// Struct containing Vec<T> where T is BFieldCodec
-#[derive(BFieldCodec, PartialEq, Eq, Debug)]
-struct DeriveTestStructD(Vec<u128>);
+        use super::*;
 
-#[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
-struct DeriveTestStructE(Vec<u128>, u128, u64, Vec<bool>, u32, Vec<u128>);
-
-#[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
-struct DeriveTestStructF {
-    field_a: Vec<u64>,
-    field_b: bool,
-    field_c: u32,
-    field_d: Vec<bool>,
-    field_e: Vec<BFieldElement>,
-    field_f: Vec<BFieldElement>,
-}
-
-#[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
-struct WithPhantomData<H: AlgebraicHasher> {
-    a_field: u128,
-    #[bfield_codec(ignore)]
-    _phantom_data: PhantomData<H>,
-    another_field: Vec<u64>,
-}
-
-#[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
-struct WithNestedPhantomData<H: AlgebraicHasher> {
-    a_field: u128,
-    #[bfield_codec(ignore)]
-    _phantom_data: PhantomData<H>,
-    another_field: Vec<u64>,
-    a_third_field: Vec<WithPhantomData<H>>,
-    a_fourth_field: WithPhantomData<Tip5>,
-}
-
-#[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
-struct WithNestedVec {
-    a_field: Vec<Vec<u64>>,
-}
-
-#[cfg(test)]
-pub mod derive_tests {
-    // Since we cannot use the derive macro in the same crate where it is defined,
-    // we test the macro here instead.
-
-    use rand::{random, thread_rng, Rng, RngCore};
-
-    use crate::{
-        shared_math::{other::random_elements, tip5::Tip5},
-        util_types::mmr::mmr_membership_proof::MmrMembershipProof,
-    };
-
-    use super::*;
-
-    fn prop<T: BFieldCodec + PartialEq + Eq + std::fmt::Debug>(value: T) {
-        let encoded = value.encode();
-        let decoded = T::decode(&encoded);
-        let decoded = decoded.unwrap();
-        assert_eq!(value, *decoded);
-
-        let encoded_too_long = vec![encoded, vec![BFieldElement::new(5)]].concat();
-        assert!(T::decode(&encoded_too_long).is_err());
-
-        let encoded_too_short = encoded_too_long[..encoded_too_long.len() - 2].to_vec();
-        assert!(T::decode(&encoded_too_short).is_err());
-    }
-
-    #[test]
-    fn simple_struct_with_named_fields() {
-        prop(DeriveTestStructA {
-            field_a: 14,
-            field_b: 555558,
-            field_c: 1337,
-        });
-
-        assert_eq!(Some(6), DeriveTestStructA::static_length());
-    }
-
-    #[test]
-    fn simple_struct_with_one_unnamed_field() {
-        prop(DeriveTestStructB(127));
-
-        assert_eq!(Some(4), DeriveTestStructB::static_length());
-    }
-
-    #[test]
-    fn simple_struct_with_unnamed_fields() {
-        prop(DeriveTestStructC(127 << 100, 14, 1000));
-
-        assert_eq!(Some(7), DeriveTestStructC::static_length());
-    }
-
-    #[test]
-    fn struct_with_unnamed_vec_field() {
-        prop(DeriveTestStructD(vec![
-            1 << 99,
-            99,
-            1 << 120,
-            120,
-            u64::MAX as u128,
-        ]));
-
-        // Test the empty struct
-        prop(DeriveTestStructD(vec![]));
-
-        assert!(DeriveTestStructD::static_length().is_none());
-    }
-
-    #[test]
-    fn struct_with_unnamed_vec_fields() {
-        fn random_struct() -> DeriveTestStructE {
+        fn random_bool() -> bool {
             let mut rng = thread_rng();
-            let length_0: usize = rng.gen_range(0..10);
-            let length_3: usize = rng.gen_range(0..20);
-            let length_5: usize = rng.gen_range(0..20);
-            DeriveTestStructE(
-                random_elements(length_0),
-                random(),
-                random(),
-                random_elements(length_3),
-                random(),
-                random_elements(length_5),
-            )
-        }
-        for _ in 0..20 {
-            prop(random_struct());
+            rng.next_u32() % 2 == 0
         }
 
-        // Also test the Default/empty struct
-        prop(DeriveTestStructE::default());
-
-        assert!(DeriveTestStructE::static_length().is_none());
-    }
-
-    #[test]
-    fn struct_with_named_vec_fields() {
-        fn random_struct() -> DeriveTestStructF {
+        fn random_length(max: usize) -> usize {
             let mut rng = thread_rng();
-            let length_a: usize = rng.gen_range(0..10);
-            let length_d: usize = rng.gen_range(0..20);
-            let length_e: usize = rng.gen_range(0..20);
-            let length_f: usize = rng.gen_range(0..20);
-            DeriveTestStructF {
-                field_a: random_elements(length_a),
-                field_b: random(),
-                field_c: random(),
-                field_d: random_elements(length_d),
-                field_e: random_elements(length_e),
-                field_f: random_elements(length_f),
-            }
-        }
-        for _ in 0..20 {
-            prop(random_struct());
+            rng.next_u32() as usize % max
         }
 
-        // Also test the Default/empty struct
-        prop(DeriveTestStructF::default());
+        fn random_partial_authentication_paths(
+            inner_length: usize,
+            count: usize,
+        ) -> Vec<PartialAuthenticationPath<Digest>> {
+            let mut ret = vec![];
 
-        assert!(DeriveTestStructF::static_length().is_none());
-    }
-
-    fn random_with_phantomdata_struct() -> WithPhantomData<Tip5> {
-        let mut rng = thread_rng();
-        let length_another_field: usize = rng.gen_range(0..10);
-        WithPhantomData {
-            a_field: random(),
-            _phantom_data: PhantomData,
-            another_field: random_elements(length_another_field),
-        }
-    }
-
-    #[test]
-    fn struct_with_phantom_data() {
-        for _ in 0..20 {
-            prop(random_with_phantomdata_struct());
-        }
-
-        // Also test the Default/empty struct
-        prop(WithPhantomData::<Tip5>::default());
-    }
-
-    #[test]
-    fn struct_with_nested_phantom_data() {
-        fn random_struct() -> WithNestedPhantomData<Tip5> {
-            let mut rng = thread_rng();
-            let length_a_fourth_field: usize = rng.gen_range(0..20);
-            let a_third_field = (0..length_a_fourth_field)
-                .map(|_| random_with_phantomdata_struct())
-                .collect_vec();
-            WithNestedPhantomData {
-                _phantom_data: PhantomData,
-                a_field: random(),
-                another_field: random_elements(rng.gen_range(0..30)),
-                a_fourth_field: random_with_phantomdata_struct(),
-                a_third_field,
-            }
-        }
-
-        for _ in 0..20 {
-            prop(random_struct());
-        }
-
-        // Also test the Default/empty struct
-        prop(WithNestedPhantomData::<Tip5>::default());
-    }
-
-    #[test]
-    fn struct_with_nested_vec() {
-        fn random_struct() -> WithNestedVec {
-            let mut rng = thread_rng();
-            let outer_length = rng.gen_range(0..30);
-            let mut ret = WithNestedVec {
-                a_field: Vec::with_capacity(outer_length),
-            };
-            for _ in 0..outer_length {
-                let inner_length = rng.gen_range(0..20);
-                let inner_vec: Vec<u64> = random_elements(inner_length);
-                ret.a_field.push(inner_vec);
+            for _ in 0..count {
+                ret.push(
+                    (0..inner_length)
+                        .map(|_| if random_bool() { Some(random()) } else { None })
+                        .collect_vec(),
+                )
             }
 
             ret
         }
 
-        for _ in 0..20 {
-            prop(random_struct());
+        #[test]
+        fn test_encode_decode_random_bfieldelement() {
+            for _ in 1..=10 {
+                let bfe: BFieldElement = random();
+                let str = bfe.encode();
+                let bfe_ = *BFieldElement::decode(&str).unwrap();
+                assert_eq!(bfe, bfe_);
+            }
         }
 
-        // Also test the Default/empty struct
-        prop(WithNestedVec::default());
-
-        assert!(WithNestedVec::static_length().is_none());
-    }
-
-    #[test]
-    fn deeply_nested_vec() {
-        #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
-        struct MuchNesting {
-            a: Vec<Vec<Vec<Vec<BFieldElement>>>>,
-            #[bfield_codec(ignore)]
-            b: PhantomData<Tip5>,
-            #[bfield_codec(ignore)]
-            c: PhantomData<Tip5>,
+        #[test]
+        fn test_encode_decode_random_xfieldelement() {
+            for _ in 1..=10 {
+                let xfe: XFieldElement = random();
+                let str = xfe.encode();
+                let xfe_ = *XFieldElement::decode(&str).unwrap();
+                assert_eq!(xfe, xfe_);
+            }
         }
 
-        fn random_struct() -> MuchNesting {
-            let mut rng = thread_rng();
-            let outer_length = rng.gen_range(0..10);
-            let mut ret = MuchNesting {
-                a: Vec::with_capacity(outer_length),
-                b: PhantomData,
-                c: PhantomData,
-            };
-            for i in 0..outer_length {
-                ret.a.push(vec![]);
-                let second_length = rng.gen_range(0..10);
-                for j in 0..second_length {
-                    ret.a[i].push(vec![]);
-                    let third_length = rng.gen_range(0..10);
-                    for k in 0..third_length {
-                        ret.a[i][j].push(vec![]);
-                        ret.a[i][j][k] = random_elements(rng.gen_range(0..15));
+        #[test]
+        fn test_encode_decode_random_digest() {
+            for _ in 1..=10 {
+                let dig: Digest = random();
+                let str = dig.encode();
+                let dig_ = *Digest::decode(&str).unwrap();
+                assert_eq!(dig, dig_);
+            }
+        }
+
+        #[test]
+        fn test_encode_decode_random_vec_of_bfieldelement() {
+            for _ in 1..=10 {
+                let len = random_length(100);
+                let bfe_vec: Vec<BFieldElement> = (0..len).map(|_| random()).collect_vec();
+                let str = bfe_vec.encode();
+                let bfe_vec_ = *Vec::<BFieldElement>::decode(&str).unwrap();
+                assert_eq!(bfe_vec, bfe_vec_);
+            }
+        }
+
+        #[test]
+        fn test_encode_decode_random_vec_of_xfieldelement() {
+            for _ in 1..=10 {
+                let len = random_length(100);
+                let xfe_vec: Vec<XFieldElement> = (0..len).map(|_| random()).collect_vec();
+                let str = xfe_vec.encode();
+                let xfe_vec_ = *Vec::<XFieldElement>::decode(&str).unwrap();
+                assert_eq!(xfe_vec, xfe_vec_);
+            }
+        }
+
+        #[test]
+        fn test_encode_decode_random_vec_of_digest() {
+            for _ in 1..=10 {
+                let len = random_length(100);
+                let digest_vec: Vec<Digest> = (0..len).map(|_| random()).collect_vec();
+                let str = digest_vec.encode();
+                let digest_vec_ = *Vec::<Digest>::decode(&str).unwrap();
+                assert_eq!(digest_vec, digest_vec_);
+            }
+        }
+
+        #[test]
+        fn test_encode_decode_random_vec_of_vec_of_bfieldelement() {
+            for _ in 1..=10 {
+                let len = random_length(10);
+                let bfe_vec_vec: Vec<Vec<BFieldElement>> = (0..len)
+                    .map(|_| {
+                        let inner_len = random_length(20);
+                        (0..inner_len).map(|_| random()).collect_vec()
+                    })
+                    .collect_vec();
+                let str = bfe_vec_vec.encode();
+                let bfe_vec_vec_ = *Vec::<Vec<BFieldElement>>::decode(&str).unwrap();
+                assert_eq!(bfe_vec_vec, bfe_vec_vec_);
+            }
+        }
+
+        #[test]
+        fn test_encode_decode_random_vec_of_vec_of_xfieldelement() {
+            for _ in 1..=10 {
+                let len = random_length(10);
+                let xfe_vec_vec: Vec<Vec<XFieldElement>> = (0..len)
+                    .map(|_| {
+                        let inner_len = random_length(20);
+                        (0..inner_len).map(|_| random()).collect_vec()
+                    })
+                    .collect_vec();
+                let str = xfe_vec_vec.encode();
+                let xfe_vec_vec_ = *Vec::<Vec<XFieldElement>>::decode(&str).unwrap();
+                assert_eq!(xfe_vec_vec, xfe_vec_vec_);
+            }
+        }
+
+        #[test]
+        fn test_encode_decode_random_partial_authentication_path() {
+            for _ in 1..=10 {
+                let len = 1 + random_length(10);
+                let count = random_length(10);
+                let pap = random_partial_authentication_paths(len, count);
+                let str = pap.encode();
+                let pap_ = *Vec::<PartialAuthenticationPath<Digest>>::decode(&str).unwrap();
+                assert_eq!(pap, pap_);
+            }
+        }
+
+        #[test]
+        fn test_decode_random_negative() {
+            for _ in 1..=10000 {
+                let len = random_length(100);
+                let str: Vec<BFieldElement> = random_elements(len);
+
+                // Some of the following cases can be triggered by false
+                // positives. This should occur with probability roughly
+                // 2^-60.
+
+                if let Ok(sth) = Vec::<BFieldElement>::decode(&str) {
+                    panic!("{sth:?}");
+                }
+
+                if str.len() % EXTENSION_DEGREE != 1 {
+                    if let Ok(sth) = Vec::<XFieldElement>::decode(&str) {
+                        panic!("{sth:?}");
                     }
+                }
+
+                if str.len() % DIGEST_LENGTH != 1 {
+                    if let Ok(sth) = Vec::<Digest>::decode(&str) {
+                        panic!("{sth:?}");
+                    }
+                }
+
+                if let Ok(sth) = Vec::<Vec<BFieldElement>>::decode(&str) {
+                    if !sth.is_empty() {
+                        panic!("{sth:?}");
+                    }
+                }
+
+                if let Ok(sth) = Vec::<Vec<XFieldElement>>::decode(&str) {
+                    if !sth.is_empty() {
+                        panic!("{sth:?}");
+                    }
+                }
+
+                // if let Ok(_sth) = Vec::<PartialAuthenticationPath<Digest>>::decode(&str) {
+                //     (will work quite often)
+                // }
+            }
+        }
+
+        #[test]
+        fn test_encode_decode_random_vec_option_xfieldelement() {
+            let mut rng = thread_rng();
+            let n = 10 + (rng.next_u32() % 50);
+            let mut vector: Vec<Option<XFieldElement>> = vec![];
+            for _ in 0..n {
+                if rng.next_u32() % 2 == 0 {
+                    vector.push(None);
+                } else {
+                    vector.push(Some(rng.gen()));
                 }
             }
 
-            ret
+            let encoded = vector.encode();
+            let decoded = *Vec::<Option<XFieldElement>>::decode(&encoded).unwrap();
+
+            assert_eq!(vector, decoded);
         }
 
-        for _ in 0..5 {
-            prop(random_struct());
+        #[test]
+        fn test_phantom_data() {
+            let pd = PhantomData::<Tip5>;
+            let encoded = pd.encode();
+            let decoded = *PhantomData::decode(&encoded).unwrap();
+            assert_eq!(decoded, pd);
+
+            assert!(encoded.is_empty());
         }
 
-        assert!(MuchNesting::static_length().is_none());
+        #[test]
+        fn decode_encode_array_with_static_element_size() {
+            const N: usize = 14;
+            type Array = [u64; N];
+
+            let an_array: Array = [14u64; N];
+            prop(&an_array);
+
+            assert_eq!(
+                Some(N * 2),
+                <Array>::static_length(),
+                "Static length must be set and correct for array with static element lengths"
+            );
+        }
+
+        #[test]
+        fn decode_encode_array_with_dynamic_element_size() {
+            const N: usize = 19;
+            type Array = [Vec<Digest>; N];
+
+            // Initialize an array with empty vectors in all elements
+            let mut an_array: Array = Default::default();
+            prop(&an_array);
+
+            // Should also work if the elements are not just the empty vectors
+            let mut rng = thread_rng();
+            for elem in an_array.iter_mut() {
+                *elem = random_elements(rng.gen_range(0..7));
+            }
+
+            prop(&an_array);
+
+            assert!(
+                <Array>::static_length().is_none(),
+                "Static length must be none for array with dynamic element lengths"
+            );
+        }
     }
 
-    #[test]
-    fn struct_with_small_array() {
-        #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
-        struct SmallArrayStructUnnamedFields([u128; 1]);
+    #[cfg(test)]
+    pub mod derive_tests {
+        // Since we cannot use the derive macro in the same crate where it is defined,
+        // we test the macro here instead.
 
-        #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
-        struct SmallArrayStructNamedFields {
-            a: [u128; 1],
-        }
+        use rand::{random, thread_rng, Rng, RngCore};
 
-        fn random_struct_unnamed_fields() -> SmallArrayStructUnnamedFields {
-            SmallArrayStructUnnamedFields([random(); 1])
-        }
+        use crate::{
+            shared_math::{other::random_elements, tip5::Tip5},
+            util_types::{
+                algebraic_hasher::AlgebraicHasher, mmr::mmr_membership_proof::MmrMembershipProof,
+            },
+        };
 
-        fn random_struct_named_fields() -> SmallArrayStructNamedFields {
-            SmallArrayStructNamedFields { a: [random(); 1] }
-        }
-
-        for _ in 0..5 {
-            prop(random_struct_unnamed_fields());
-            prop(random_struct_named_fields());
-        }
-
-        assert_eq!(Some(4), SmallArrayStructUnnamedFields::static_length());
-        assert_eq!(Some(4), SmallArrayStructNamedFields::static_length());
-    }
-
-    #[test]
-    fn struct_with_big_array() {
-        const BIG_ARRAY_LENGTH: usize = 600;
+        use super::*;
 
         #[derive(BFieldCodec, PartialEq, Eq, Debug)]
-        struct BigArrayStructUnnamedFields([u128; BIG_ARRAY_LENGTH]);
-
-        #[derive(BFieldCodec, PartialEq, Eq, Debug)]
-        struct BigArrayStructNamedFields {
-            a: [XFieldElement; BIG_ARRAY_LENGTH],
-            b: XFieldElement,
-            c: u64,
+        struct DeriveTestStructA {
+            field_a: u64,
+            field_b: u64,
+            field_c: u64,
         }
 
-        fn random_struct_unnamed_fields() -> BigArrayStructUnnamedFields {
-            BigArrayStructUnnamedFields(
-                random_elements::<u128>(BIG_ARRAY_LENGTH)
-                    .try_into()
-                    .unwrap(),
+        #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+        struct DeriveTestStructB(u128);
+
+        #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+        struct DeriveTestStructC(u128, u64, u32);
+
+        // Struct containing Vec<T> where T is BFieldCodec
+        #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+        struct DeriveTestStructD(Vec<u128>);
+
+        #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+        struct DeriveTestStructE(Vec<u128>, u128, u64, Vec<bool>, u32, Vec<u128>);
+
+        #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+        struct DeriveTestStructF {
+            field_a: Vec<u64>,
+            field_b: bool,
+            field_c: u32,
+            field_d: Vec<bool>,
+            field_e: Vec<BFieldElement>,
+            field_f: Vec<BFieldElement>,
+        }
+
+        #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+        struct WithPhantomData<H: AlgebraicHasher> {
+            a_field: u128,
+            #[bfield_codec(ignore)]
+            _phantom_data: PhantomData<H>,
+            another_field: Vec<u64>,
+        }
+
+        #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+        struct WithNestedPhantomData<H: AlgebraicHasher> {
+            a_field: u128,
+            #[bfield_codec(ignore)]
+            _phantom_data: PhantomData<H>,
+            another_field: Vec<u64>,
+            a_third_field: Vec<WithPhantomData<H>>,
+            a_fourth_field: WithPhantomData<Tip5>,
+        }
+
+        #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+        struct WithNestedVec {
+            a_field: Vec<Vec<u64>>,
+        }
+
+        #[test]
+        fn simple_struct_with_named_fields() {
+            prop(&DeriveTestStructA {
+                field_a: 14,
+                field_b: 555558,
+                field_c: 1337,
+            });
+
+            assert_eq!(Some(6), DeriveTestStructA::static_length());
+        }
+
+        #[test]
+        fn simple_struct_with_one_unnamed_field() {
+            prop(&DeriveTestStructB(127));
+
+            assert_eq!(Some(4), DeriveTestStructB::static_length());
+        }
+
+        #[test]
+        fn simple_struct_with_unnamed_fields() {
+            prop(&DeriveTestStructC(127 << 100, 14, 1000));
+
+            assert_eq!(Some(7), DeriveTestStructC::static_length());
+        }
+
+        #[test]
+        fn struct_with_unnamed_vec_field() {
+            prop(&DeriveTestStructD(vec![
+                1 << 99,
+                99,
+                1 << 120,
+                120,
+                u64::MAX as u128,
+            ]));
+
+            // Test the empty struct
+            prop(&DeriveTestStructD(vec![]));
+
+            assert!(DeriveTestStructD::static_length().is_none());
+        }
+
+        #[test]
+        fn struct_with_unnamed_vec_fields() {
+            fn random_struct() -> DeriveTestStructE {
+                let mut rng = thread_rng();
+                let length_0: usize = rng.gen_range(0..10);
+                let length_3: usize = rng.gen_range(0..20);
+                let length_5: usize = rng.gen_range(0..20);
+                DeriveTestStructE(
+                    random_elements(length_0),
+                    random(),
+                    random(),
+                    random_elements(length_3),
+                    random(),
+                    random_elements(length_5),
+                )
+            }
+            for _ in 0..20 {
+                prop(&random_struct());
+            }
+
+            // Also test the Default/empty struct
+            prop(&DeriveTestStructE::default());
+
+            assert!(DeriveTestStructE::static_length().is_none());
+        }
+
+        #[test]
+        fn struct_with_named_vec_fields() {
+            fn random_struct() -> DeriveTestStructF {
+                let mut rng = thread_rng();
+                let length_a: usize = rng.gen_range(0..10);
+                let length_d: usize = rng.gen_range(0..20);
+                let length_e: usize = rng.gen_range(0..20);
+                let length_f: usize = rng.gen_range(0..20);
+                DeriveTestStructF {
+                    field_a: random_elements(length_a),
+                    field_b: random(),
+                    field_c: random(),
+                    field_d: random_elements(length_d),
+                    field_e: random_elements(length_e),
+                    field_f: random_elements(length_f),
+                }
+            }
+            for _ in 0..20 {
+                prop(&random_struct());
+            }
+
+            // Also test the Default/empty struct
+            prop(&DeriveTestStructF::default());
+
+            assert!(DeriveTestStructF::static_length().is_none());
+        }
+
+        fn random_with_phantomdata_struct() -> WithPhantomData<Tip5> {
+            let mut rng = thread_rng();
+            let length_another_field: usize = rng.gen_range(0..10);
+            WithPhantomData {
+                a_field: random(),
+                _phantom_data: PhantomData,
+                another_field: random_elements(length_another_field),
+            }
+        }
+
+        #[test]
+        fn struct_with_phantom_data() {
+            for _ in 0..20 {
+                prop(&random_with_phantomdata_struct());
+            }
+
+            // Also test the Default/empty struct
+            prop(&WithPhantomData::<Tip5>::default());
+        }
+
+        #[test]
+        fn struct_with_nested_phantom_data() {
+            fn random_struct() -> WithNestedPhantomData<Tip5> {
+                let mut rng = thread_rng();
+                let length_a_fourth_field: usize = rng.gen_range(0..10);
+                let a_third_field = (0..length_a_fourth_field)
+                    .map(|_| random_with_phantomdata_struct())
+                    .collect_vec();
+                WithNestedPhantomData {
+                    _phantom_data: PhantomData,
+                    a_field: random(),
+                    another_field: random_elements(rng.gen_range(0..15)),
+                    a_fourth_field: random_with_phantomdata_struct(),
+                    a_third_field,
+                }
+            }
+
+            for _ in 0..10 {
+                prop(&random_struct());
+            }
+
+            // Also test the Default/empty struct
+            prop(&WithNestedPhantomData::<Tip5>::default());
+        }
+
+        #[test]
+        fn struct_with_nested_vec() {
+            fn random_struct() -> WithNestedVec {
+                let mut rng = thread_rng();
+                let outer_length = rng.gen_range(0..10);
+                let mut ret = WithNestedVec {
+                    a_field: Vec::with_capacity(outer_length),
+                };
+                for _ in 0..outer_length {
+                    let inner_length = rng.gen_range(0..12);
+                    let inner_vec: Vec<u64> = random_elements(inner_length);
+                    ret.a_field.push(inner_vec);
+                }
+
+                ret
+            }
+
+            for _ in 0..10 {
+                prop(&random_struct());
+            }
+
+            // Also test the Default/empty struct
+            prop(&WithNestedVec::default());
+
+            assert!(WithNestedVec::static_length().is_none());
+        }
+
+        #[test]
+        fn deeply_nested_vec() {
+            #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+            struct MuchNesting {
+                a: Vec<Vec<Vec<Vec<BFieldElement>>>>,
+                #[bfield_codec(ignore)]
+                b: PhantomData<Tip5>,
+                #[bfield_codec(ignore)]
+                c: PhantomData<Tip5>,
+            }
+
+            fn random_struct() -> MuchNesting {
+                let mut rng = thread_rng();
+                let outer_length = rng.gen_range(0..10);
+                let mut ret = MuchNesting {
+                    a: Vec::with_capacity(outer_length),
+                    b: PhantomData,
+                    c: PhantomData,
+                };
+                for i in 0..outer_length {
+                    ret.a.push(vec![]);
+                    let second_length = rng.gen_range(0..10);
+                    for j in 0..second_length {
+                        ret.a[i].push(vec![]);
+                        let third_length = rng.gen_range(0..10);
+                        for k in 0..third_length {
+                            ret.a[i][j].push(vec![]);
+                            ret.a[i][j][k] = random_elements(rng.gen_range(0..15));
+                        }
+                    }
+                }
+
+                ret
+            }
+
+            for _ in 0..5 {
+                prop(&random_struct());
+            }
+
+            assert!(MuchNesting::static_length().is_none());
+        }
+
+        #[test]
+        fn struct_with_small_array() {
+            #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+            struct SmallArrayStructUnnamedFields([u128; 1]);
+
+            #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+            struct SmallArrayStructNamedFields {
+                a: [u128; 1],
+            }
+
+            fn random_struct_unnamed_fields() -> SmallArrayStructUnnamedFields {
+                SmallArrayStructUnnamedFields([random(); 1])
+            }
+
+            fn random_struct_named_fields() -> SmallArrayStructNamedFields {
+                SmallArrayStructNamedFields { a: [random(); 1] }
+            }
+
+            for _ in 0..5 {
+                prop(&random_struct_unnamed_fields());
+                prop(&random_struct_named_fields());
+            }
+
+            assert_eq!(Some(4), SmallArrayStructUnnamedFields::static_length());
+            assert_eq!(Some(4), SmallArrayStructNamedFields::static_length());
+        }
+
+        #[test]
+        fn struct_with_big_array() {
+            const BIG_ARRAY_LENGTH: usize = 300;
+
+            #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+            struct BigArrayStructUnnamedFields([u128; BIG_ARRAY_LENGTH]);
+
+            #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+            struct BigArrayStructNamedFields {
+                a: [XFieldElement; BIG_ARRAY_LENGTH],
+                b: XFieldElement,
+                c: u64,
+            }
+
+            fn random_struct_unnamed_fields() -> BigArrayStructUnnamedFields {
+                BigArrayStructUnnamedFields(
+                    random_elements::<u128>(BIG_ARRAY_LENGTH)
+                        .try_into()
+                        .unwrap(),
+                )
+            }
+
+            fn random_struct_named_fields() -> BigArrayStructNamedFields {
+                BigArrayStructNamedFields {
+                    a: random_elements::<XFieldElement>(BIG_ARRAY_LENGTH)
+                        .try_into()
+                        .unwrap(),
+                    b: random(),
+                    c: random(),
+                }
+            }
+
+            for _ in 0..3 {
+                prop(&random_struct_unnamed_fields());
+                prop(&random_struct_named_fields());
+            }
+
+            assert_eq!(
+                Some(BIG_ARRAY_LENGTH * 4),
+                BigArrayStructUnnamedFields::static_length()
+            );
+            assert_eq!(
+                Some(BIG_ARRAY_LENGTH * 3 + 3 + 2),
+                BigArrayStructNamedFields::static_length()
+            );
+        }
+
+        #[test]
+        fn struct_with_array_with_dynamically_sized_elements() {
+            const ARRAY_LENGTH: usize = 7;
+
+            #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+            struct ArrayStructDynamicallySizedElementsUnnamedFields([Vec<u128>; ARRAY_LENGTH]);
+
+            #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+            struct ArrayStructDynamicallySizedElementsNamedFields {
+                a: [Vec<u128>; ARRAY_LENGTH],
+            }
+
+            fn random_struct_unnamed_fields() -> ArrayStructDynamicallySizedElementsUnnamedFields {
+                let mut rng = thread_rng();
+                ArrayStructDynamicallySizedElementsUnnamedFields(std::array::from_fn(|_| {
+                    random_elements(rng.gen_range(0..10))
+                }))
+            }
+
+            fn random_struct_named_fields() -> ArrayStructDynamicallySizedElementsNamedFields {
+                let mut rng = thread_rng();
+                ArrayStructDynamicallySizedElementsNamedFields {
+                    a: std::array::from_fn(|_| random_elements(rng.gen_range(0..10))),
+                }
+            }
+
+            for _ in 0..5 {
+                prop(&random_struct_unnamed_fields());
+                prop(&random_struct_named_fields());
+            }
+
+            assert!(ArrayStructDynamicallySizedElementsUnnamedFields::static_length().is_none());
+            assert!(ArrayStructDynamicallySizedElementsNamedFields::static_length().is_none());
+        }
+
+        #[test]
+        fn ms_membership_proof_derive_test() {
+            #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+            struct MsMembershipProof<H: AlgebraicHasher> {
+                sender_randomness: Digest,
+                receiver_preimage: Digest,
+                auth_path_aocl: MmrMembershipProof<H>,
+            }
+
+            fn random_mmr_membership_proof<H: AlgebraicHasher>() -> MmrMembershipProof<H> {
+                let leaf_index: u64 = random();
+                let authentication_path: Vec<Digest> =
+                    random_elements((thread_rng().next_u32() % 15) as usize);
+                MmrMembershipProof {
+                    leaf_index,
+                    authentication_path,
+                    _hasher: PhantomData,
+                }
+            }
+
+            fn random_struct() -> MsMembershipProof<Tip5> {
+                let sender_randomness: Digest = random();
+                let receiver_preimage: Digest = random();
+                let auth_path_aocl: MmrMembershipProof<Tip5> = random_mmr_membership_proof();
+                MsMembershipProof {
+                    sender_randomness,
+                    receiver_preimage,
+                    auth_path_aocl,
+                }
+            }
+
+            for _ in 0..5 {
+                prop(&random_struct());
+            }
+
+            assert!(MsMembershipProof::<Tip5>::static_length().is_none());
+        }
+
+        #[test]
+        fn mmr_bfieldcodec_derive_test() {
+            #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+            struct MmrAccumulator<H: BFieldCodec> {
+                leaf_count: u64,
+                peaks: Vec<Digest>,
+                #[bfield_codec(ignore)]
+                _hasher: PhantomData<H>,
+            }
+
+            fn random_struct() -> MmrAccumulator<Tip5> {
+                let leaf_count: u64 = random();
+                let mut rng = thread_rng();
+                let peaks = random_elements(rng.gen_range(0..63));
+                MmrAccumulator {
+                    leaf_count,
+                    peaks,
+                    _hasher: PhantomData,
+                }
+            }
+
+            for _ in 0..5 {
+                prop(&random_struct());
+            }
+        }
+
+        #[test]
+        fn unsupported_fields_can_be_ignored_test() {
+            #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+            struct UnsupportedFields {
+                a: u64,
+                #[bfield_codec(ignore)]
+                b: usize,
+            }
+            let my_struct = UnsupportedFields {
+                a: random(),
+                b: random(),
+            };
+            let encoded = my_struct.encode();
+            let decoded = UnsupportedFields::decode(&encoded).unwrap();
+            assert_eq!(
+                my_struct.a, decoded.a,
+                "Non-ignored fields must be preserved under encoding"
+            );
+            assert_eq!(
+                usize::default(),
+                decoded.b,
+                "Ignored field must decode to default value"
             )
         }
 
-        fn random_struct_named_fields() -> BigArrayStructNamedFields {
-            BigArrayStructNamedFields {
-                a: random_elements::<XFieldElement>(BIG_ARRAY_LENGTH)
-                    .try_into()
-                    .unwrap(),
-                b: random(),
-                c: random(),
+        #[test]
+        fn vec_of_struct_with_one_fix_len_field_test() {
+            // This is a regression test addressing #124.
+            // https://github.com/Neptune-Crypto/twenty-first/issues/124
+
+            #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+            struct OneFixedLenField {
+                some_digest: Digest,
             }
-        }
 
-        for _ in 0..5 {
-            prop(random_struct_unnamed_fields());
-            prop(random_struct_named_fields());
-        }
-
-        assert_eq!(
-            Some(BIG_ARRAY_LENGTH * 4),
-            BigArrayStructUnnamedFields::static_length()
-        );
-        assert_eq!(
-            Some(BIG_ARRAY_LENGTH * 3 + 3 + 2),
-            BigArrayStructNamedFields::static_length()
-        );
-    }
-
-    #[test]
-    fn struct_with_array_with_dynamically_sized_elements() {
-        const ARRAY_LENGTH: usize = 7;
-
-        #[derive(BFieldCodec, PartialEq, Eq, Debug)]
-        struct ArrayStructDynamicallySizedElementsUnnamedFields([Vec<u128>; ARRAY_LENGTH]);
-
-        #[derive(BFieldCodec, PartialEq, Eq, Debug)]
-        struct ArrayStructDynamicallySizedElementsNamedFields {
-            a: [Vec<u128>; ARRAY_LENGTH],
-        }
-
-        fn random_struct_unnamed_fields() -> ArrayStructDynamicallySizedElementsUnnamedFields {
-            let mut rng = thread_rng();
-            ArrayStructDynamicallySizedElementsUnnamedFields(std::array::from_fn(|_| {
-                random_elements(rng.gen_range(0..100))
-            }))
-        }
-
-        fn random_struct_named_fields() -> ArrayStructDynamicallySizedElementsNamedFields {
-            let mut rng = thread_rng();
-            ArrayStructDynamicallySizedElementsNamedFields {
-                a: std::array::from_fn(|_| random_elements(rng.gen_range(0..100))),
-            }
-        }
-
-        for _ in 0..5 {
-            prop(random_struct_unnamed_fields());
-            prop(random_struct_named_fields());
-        }
-
-        assert!(ArrayStructDynamicallySizedElementsUnnamedFields::static_length().is_none());
-        assert!(ArrayStructDynamicallySizedElementsNamedFields::static_length().is_none());
-    }
-
-    #[test]
-    fn ms_membership_proof_derive_test() {
-        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        struct MsMembershipProof<H: AlgebraicHasher> {
-            sender_randomness: Digest,
-            receiver_preimage: Digest,
-            auth_path_aocl: MmrMembershipProof<H>,
-        }
-
-        fn random_mmr_membership_proof<H: AlgebraicHasher>() -> MmrMembershipProof<H> {
-            let leaf_index: u64 = random();
-            let authentication_path: Vec<Digest> =
-                random_elements((thread_rng().next_u32() % 15) as usize);
-            MmrMembershipProof {
-                leaf_index,
-                authentication_path,
-                _hasher: PhantomData,
-            }
-        }
-
-        fn random_struct() -> MsMembershipProof<Tip5> {
-            let sender_randomness: Digest = random();
-            let receiver_preimage: Digest = random();
-            let auth_path_aocl: MmrMembershipProof<Tip5> = random_mmr_membership_proof();
-            MsMembershipProof {
-                sender_randomness,
-                receiver_preimage,
-                auth_path_aocl,
-            }
-        }
-
-        for _ in 0..5 {
-            prop(random_struct());
-        }
-
-        assert!(MsMembershipProof::<Tip5>::static_length().is_none());
-    }
-
-    #[test]
-    fn mmr_bfieldcodec_derive_test() {
-        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        struct MmrAccumulator<H: BFieldCodec> {
-            leaf_count: u64,
-            peaks: Vec<Digest>,
-            #[bfield_codec(ignore)]
-            _hasher: PhantomData<H>,
-        }
-
-        fn random_struct() -> MmrAccumulator<Tip5> {
-            let leaf_count: u64 = random();
-            let mut rng = thread_rng();
-            let peaks = random_elements(rng.gen_range(0..63));
-            MmrAccumulator {
-                leaf_count,
-                peaks,
-                _hasher: PhantomData,
-            }
-        }
-
-        for _ in 0..5 {
-            prop(random_struct());
-        }
-    }
-
-    #[test]
-    fn unsupported_fields_can_be_ignored_test() {
-        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        struct UnsupportedFields {
-            a: u64,
-            #[bfield_codec(ignore)]
-            b: usize,
-        }
-        let my_struct = UnsupportedFields {
-            a: random(),
-            b: random(),
-        };
-        let encoded = my_struct.encode();
-        let decoded = UnsupportedFields::decode(&encoded).unwrap();
-        assert_eq!(
-            my_struct.a, decoded.a,
-            "Non-ignored fields must be preserved under encoding"
-        );
-        assert_eq!(
-            usize::default(),
-            decoded.b,
-            "Ignored field must decode to default value"
-        )
-    }
-
-    #[test]
-    fn vec_of_struct_with_one_fix_len_field_test() {
-        // This is a regression test addressing #124.
-        // https://github.com/Neptune-Crypto/twenty-first/issues/124
-
-        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        struct OneFixedLenField {
-            some_digest: Digest,
-        }
-
-        let rand_struct = || OneFixedLenField {
-            some_digest: random(),
-        };
-
-        for num_elements in 0..5 {
-            dbg!(num_elements);
-            prop(vec![rand_struct(); num_elements]);
-        }
-    }
-
-    #[test]
-    fn vec_of_struct_with_two_fix_len_fields_test() {
-        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        pub struct TwoFixedLenFields {
-            pub some_digest: Digest,
-            pub some_u64: u64,
-        }
-
-        let rand_struct = || TwoFixedLenFields {
-            some_digest: random(),
-            some_u64: random(),
-        };
-
-        for num_elements in 0..5 {
-            dbg!(num_elements);
-            prop(vec![rand_struct(); num_elements]);
-        }
-    }
-
-    #[test]
-    fn vec_of_struct_with_two_fix_len_unnamed_fields_test() {
-        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        pub struct TwoFixedLenUnnamedFields(Digest, u64);
-
-        let rand_struct = || TwoFixedLenUnnamedFields(random(), random());
-
-        for num_elements in 0..5 {
-            dbg!(num_elements);
-            prop(vec![rand_struct(); num_elements]);
-        }
-    }
-
-    #[test]
-    fn vec_of_struct_with_fix_and_var_len_fields_test() {
-        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        pub struct FixAndVarLenFields {
-            pub some_digest: Digest,
-            pub some_vec: Vec<u64>,
-        }
-
-        let rand_struct = || {
-            let num_elements: usize = thread_rng().gen_range(0..42);
-            FixAndVarLenFields {
+            let rand_struct = || OneFixedLenField {
                 some_digest: random(),
-                some_vec: random_elements(num_elements),
+            };
+
+            for num_elements in 0..5 {
+                dbg!(num_elements);
+                prop(&vec![rand_struct(); num_elements]);
             }
-        };
-
-        for num_elements in 0..5 {
-            dbg!(num_elements);
-            prop(vec![rand_struct(); num_elements]);
-        }
-    }
-
-    #[test]
-    fn vec_of_struct_with_fix_and_var_len_unnamed_fields_test() {
-        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        struct FixAndVarLenUnnamedFields(Digest, Vec<u64>);
-
-        let rand_struct = || {
-            let num_elements: usize = thread_rng().gen_range(0..42);
-            FixAndVarLenUnnamedFields(random(), random_elements(num_elements))
-        };
-
-        for num_elements in 0..5 {
-            dbg!(num_elements);
-            prop(vec![rand_struct(); num_elements]);
-        }
-    }
-
-    #[test]
-    fn vec_of_struct_with_quite_a_few_fix_and_var_len_fields_test() {
-        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        struct QuiteAFewFixAndVarLenFields {
-            some_digest: Digest,
-            some_vec: Vec<u64>,
-            some_u64: u64,
-            other_vec: Vec<u32>,
-            other_digest: Digest,
-            yet_another_vec: Vec<u32>,
-            and_another_vec: Vec<u64>,
-            more_fixed_len: u64,
-            even_more_fixed_len: u64,
         }
 
-        let rand_struct = || {
-            let num_elements_0: usize = thread_rng().gen_range(0..42);
-            let num_elements_1: usize = thread_rng().gen_range(0..42);
-            let num_elements_2: usize = thread_rng().gen_range(0..42);
-            let num_elements_3: usize = thread_rng().gen_range(0..42);
-            QuiteAFewFixAndVarLenFields {
+        #[test]
+        fn vec_of_struct_with_two_fix_len_fields_test() {
+            #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+            pub struct TwoFixedLenFields {
+                pub some_digest: Digest,
+                pub some_u64: u64,
+            }
+
+            let rand_struct = || TwoFixedLenFields {
                 some_digest: random(),
-                some_vec: random_elements(num_elements_0),
                 some_u64: random(),
-                other_vec: random_elements(num_elements_1),
-                other_digest: random(),
-                yet_another_vec: random_elements(num_elements_2),
-                and_another_vec: random_elements(num_elements_3),
-                more_fixed_len: random(),
-                even_more_fixed_len: random(),
-            }
-        };
+            };
 
-        for num_elements in 0..5 {
-            dbg!(num_elements);
-            prop(vec![rand_struct(); num_elements]);
+            for num_elements in 0..5 {
+                dbg!(num_elements);
+                prop(&vec![rand_struct(); num_elements]);
+            }
+        }
+
+        #[test]
+        fn vec_of_struct_with_two_fix_len_unnamed_fields_test() {
+            #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+            pub struct TwoFixedLenUnnamedFields(Digest, u64);
+
+            let rand_struct = || TwoFixedLenUnnamedFields(random(), random());
+
+            for num_elements in 0..5 {
+                dbg!(num_elements);
+                prop(&vec![rand_struct(); num_elements]);
+            }
+        }
+
+        #[test]
+        fn vec_of_struct_with_fix_and_var_len_fields_test() {
+            #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+            pub struct FixAndVarLenFields {
+                pub some_digest: Digest,
+                pub some_vec: Vec<u64>,
+            }
+
+            let rand_struct = || {
+                let num_elements: usize = thread_rng().gen_range(0..7);
+                FixAndVarLenFields {
+                    some_digest: random(),
+                    some_vec: random_elements(num_elements),
+                }
+            };
+
+            for num_elements in 0..5 {
+                dbg!(num_elements);
+                prop(&vec![rand_struct(); num_elements]);
+            }
+        }
+
+        #[test]
+        fn vec_of_struct_with_fix_and_var_len_unnamed_fields_test() {
+            #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+            struct FixAndVarLenUnnamedFields(Digest, Vec<u64>);
+
+            let rand_struct = || {
+                let num_elements: usize = thread_rng().gen_range(0..7);
+                FixAndVarLenUnnamedFields(random(), random_elements(num_elements))
+            };
+
+            for num_elements in 0..5 {
+                dbg!(num_elements);
+                prop(&vec![rand_struct(); num_elements]);
+            }
+        }
+
+        #[test]
+        fn vec_of_struct_with_quite_a_few_fix_and_var_len_fields_test() {
+            #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+            struct QuiteAFewFixAndVarLenFields {
+                some_digest: Digest,
+                some_vec: Vec<u64>,
+                some_u64: u64,
+                other_vec: Vec<u32>,
+                other_digest: Digest,
+                yet_another_vec: Vec<u32>,
+                and_another_vec: Vec<u64>,
+                more_fixed_len: u64,
+                even_more_fixed_len: u64,
+            }
+
+            let rand_struct = || {
+                let num_elements_0: usize = thread_rng().gen_range(0..7);
+                let num_elements_1: usize = thread_rng().gen_range(0..7);
+                let num_elements_2: usize = thread_rng().gen_range(0..7);
+                let num_elements_3: usize = thread_rng().gen_range(0..7);
+                QuiteAFewFixAndVarLenFields {
+                    some_digest: random(),
+                    some_vec: random_elements(num_elements_0),
+                    some_u64: random(),
+                    other_vec: random_elements(num_elements_1),
+                    other_digest: random(),
+                    yet_another_vec: random_elements(num_elements_2),
+                    and_another_vec: random_elements(num_elements_3),
+                    more_fixed_len: random(),
+                    even_more_fixed_len: random(),
+                }
+            };
+
+            for num_elements in 0..5 {
+                dbg!(num_elements);
+                prop(&vec![rand_struct(); num_elements]);
+            }
         }
     }
 }

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -583,30 +583,16 @@ mod tests {
 
         use super::*;
 
-        fn random_bool() -> bool {
-            let mut rng = thread_rng();
-            rng.next_u32() % 2 == 0
-        }
-
-        fn random_length(max: usize) -> usize {
-            let mut rng = thread_rng();
-            rng.next_u32() as usize % max
-        }
-
         fn random_partial_authentication_paths(
-            inner_length: usize,
-            count: usize,
+            path_len: usize,
+            num_paths: usize,
         ) -> Vec<PartialAuthenticationPath<Digest>> {
+            let maybe_elem = || if random() { Some(random()) } else { None };
             let mut ret = vec![];
-
-            for _ in 0..count {
-                ret.push(
-                    (0..inner_length)
-                        .map(|_| if random_bool() { Some(random()) } else { None })
-                        .collect_vec(),
-                )
+            for _ in 0..num_paths {
+                let path = (0..path_len).map(|_| maybe_elem()).collect();
+                ret.push(path);
             }
-
             ret
         }
 
@@ -637,7 +623,7 @@ mod tests {
         #[test]
         fn test_encode_decode_random_vec_of_bfieldelement() {
             for _ in 1..=10 {
-                let len = random_length(100);
+                let len = thread_rng().gen_range(0..100);
                 let bfe_vec: Vec<BFieldElement> = (0..len).map(|_| random()).collect_vec();
                 prop(&bfe_vec);
             }
@@ -646,7 +632,7 @@ mod tests {
         #[test]
         fn test_encode_decode_random_vec_of_xfieldelement() {
             for _ in 1..=10 {
-                let len = random_length(100);
+                let len = thread_rng().gen_range(0..100);
                 let xfe_vec: Vec<XFieldElement> = (0..len).map(|_| random()).collect_vec();
                 prop(&xfe_vec);
             }
@@ -655,7 +641,7 @@ mod tests {
         #[test]
         fn test_encode_decode_random_vec_of_digest() {
             for _ in 1..=10 {
-                let len = random_length(100);
+                let len = thread_rng().gen_range(0..100);
                 let digest_vec: Vec<Digest> = (0..len).map(|_| random()).collect_vec();
                 prop(&digest_vec);
             }
@@ -664,10 +650,10 @@ mod tests {
         #[test]
         fn test_encode_decode_random_vec_of_vec_of_bfieldelement() {
             for _ in 1..=10 {
-                let len = random_length(10);
+                let len = thread_rng().gen_range(0..10);
                 let bfe_vec_vec: Vec<Vec<BFieldElement>> = (0..len)
                     .map(|_| {
-                        let inner_len = random_length(20);
+                        let inner_len = thread_rng().gen_range(0..20);
                         (0..inner_len).map(|_| random()).collect_vec()
                     })
                     .collect_vec();
@@ -678,10 +664,10 @@ mod tests {
         #[test]
         fn test_encode_decode_random_vec_of_vec_of_xfieldelement() {
             for _ in 1..=10 {
-                let len = random_length(10);
+                let len = thread_rng().gen_range(0..10);
                 let xfe_vec_vec: Vec<Vec<XFieldElement>> = (0..len)
                     .map(|_| {
-                        let inner_len = random_length(20);
+                        let inner_len = thread_rng().gen_range(0..20);
                         (0..inner_len).map(|_| random()).collect_vec()
                     })
                     .collect_vec();
@@ -692,8 +678,8 @@ mod tests {
         #[test]
         fn test_encode_decode_random_partial_authentication_path() {
             for _ in 1..=10 {
-                let len = 1 + random_length(10);
-                let count = random_length(10);
+                let len = 1 + thread_rng().gen_range(0..10);
+                let count = thread_rng().gen_range(0..10);
                 let pap = random_partial_authentication_paths(len, count);
                 prop(&pap);
             }
@@ -769,7 +755,7 @@ mod tests {
         #[test]
         fn test_decode_random_negative() {
             for _ in 1..=10000 {
-                let len = random_length(100);
+                let len = thread_rng().gen_range(0..100);
                 let str: Vec<BFieldElement> = random_elements(len);
 
                 // Some of the following cases can be triggered by false

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -539,10 +539,85 @@ mod tests {
     use rand::{random, thread_rng};
 
     fn prop<T: BFieldCodec + PartialEq + Eq + std::fmt::Debug>(value: &T) {
+        fn expensive_encoding_pbt<T: BFieldCodec + PartialEq + Eq + std::fmt::Debug>(
+            original_encoded: &[BFieldElement],
+            original_decoded: Box<T>,
+        ) {
+            const PBT_SIZE: usize = 50;
+
+            // Go over every single element in the sequence, to see if mutating anyone
+            // of the elements causes undesired behavior
+            let mut mutated_encoding = original_encoded.to_vec();
+            for i in 0..mutated_encoding.len() {
+                let original_value = mutated_encoding[i];
+
+                // Ensure that random values do not cause problems
+                for _ in 0..PBT_SIZE {
+                    mutated_encoding[i] = random();
+                    let decoded_mutated = T::decode(&mutated_encoding);
+                    assert!(
+                        decoded_mutated.is_err()
+                            || *decoded_mutated.unwrap() != *original_decoded
+                            || mutated_encoding[i] == original_value
+                    );
+                }
+
+                // Ensure that "nearby" values do not cause problems
+                mutated_encoding[i] = original_value - BFieldElement::new((PBT_SIZE / 2) as u64);
+                for _ in 0..PBT_SIZE {
+                    mutated_encoding[i].increment();
+                    let decoded_mutated = T::decode(&mutated_encoding);
+                    assert!(
+                        decoded_mutated.is_err()
+                            || *decoded_mutated.unwrap() != *original_decoded
+                            || mutated_encoding[i] == original_value
+                    );
+                }
+
+                // Reset word
+                mutated_encoding[i] = original_value;
+            }
+
+            // Ensure no crash while decoding very short sequences
+            let upper_length_bound = std::cmp::min(mutated_encoding.len(), PBT_SIZE / 2);
+            for i in 0..upper_length_bound {
+                let random_bfes = random_elements(i);
+
+                // Ensure `decode` does not crash
+                let dec_res = T::decode(&random_bfes);
+                assert!(
+                    dec_res.is_err() || *dec_res.unwrap() != *original_decoded,
+                    "random BFEs of shorter length than original encoding should not decode to the original struct"
+                );
+            }
+
+            // Ensure no crash while decoding a sequence *one* shorter than the original sequence
+            assert_eq!(
+                original_encoded, mutated_encoding,
+                "Sanity check of test integrity"
+            );
+            match mutated_encoding.pop() {
+                Some(_) => {
+                    let dec_res = T::decode(&mutated_encoding);
+                    assert!(
+                        dec_res.is_err() || *dec_res.unwrap() != *original_decoded,
+                        "random BFEs of shorter length than original encoding should not decode to the original struct"
+                    );
+                }
+                None => (),
+            }
+        }
+
         let encoded = value.encode();
         let decoded = T::decode(&encoded);
         let decoded = decoded.unwrap();
         assert_eq!(*value, *decoded);
+
+        // Set this environment variable to run an expensive PBT of encoding/decoding
+        // uniqueness and `decode`'s inability to panic
+        if std::env::var("EXPENSIVE_ENCODING_PBT").is_ok() {
+            expensive_encoding_pbt(&encoded, decoded);
+        }
 
         let encoded_too_long = vec![encoded, vec![BFieldElement::new(5)]].concat();
         assert!(T::decode(&encoded_too_long).is_err());

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -437,7 +437,8 @@ impl<T: BFieldCodec> BFieldCodec for Vec<T> {
             }
             if raw_item_iter.len() != indicated_num_elements {
                 bail!(
-                    "Vector contains wrong number of items. Expected {indicated_num_elements} found {}",
+                    "Vector contains wrong number of items. \
+                    Expected {indicated_num_elements} found {}",
                     raw_item_iter.len()
                 );
             }

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -1561,5 +1561,53 @@ mod tests {
                 assert!(Digest::decode(&too_long).is_err())
             }
         }
+
+        #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
+        enum ComplexEnum {
+            A,
+            B(u32),
+            C(BFieldElement, XFieldElement, u32),
+            D(Vec<BFieldElement>, Digest),
+            E(Option<bool>),
+        }
+
+        #[test]
+        fn test_complex_enum_derive() {
+            let mut rng = thread_rng();
+            match ComplexEnum::A {
+                ComplexEnum::A => {
+                    let object = ComplexEnum::A;
+
+                    assert_bfield_codec_properties(&object);
+                }
+                ComplexEnum::B(_) => {
+                    let object = ComplexEnum::B(rng.next_u32());
+
+                    assert_bfield_codec_properties(&object);
+                }
+                ComplexEnum::C(_, _, _) => {
+                    let object = ComplexEnum::C(rng.gen(), rng.gen(), rng.next_u32());
+
+                    assert_bfield_codec_properties(&object);
+                }
+                ComplexEnum::D(_, _) => {
+                    let d_3 = ComplexEnum::D(rng.gen::<[BFieldElement; 3]>().to_vec(), rng.gen());
+                    assert_bfield_codec_properties(&d_3);
+
+                    let d_0 = ComplexEnum::D(Vec::<BFieldElement>::new(), rng.gen());
+                    assert_bfield_codec_properties(&d_0);
+                }
+                ComplexEnum::E(_) => {
+                    let e_none = ComplexEnum::E(None);
+                    assert_bfield_codec_properties(&e_none);
+
+                    let e_some_false = ComplexEnum::E(Some(false));
+                    assert_bfield_codec_properties(&e_some_false);
+
+                    let e_some_true = ComplexEnum::E(Some(true));
+                    assert_bfield_codec_properties(&e_some_true);
+                }
+            }
+        }
     }
 }

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -410,22 +410,23 @@ impl<T: BFieldCodec> BFieldCodec for Vec<T> {
             bail!("Cannot decode empty sequence into Vec<T>");
         }
 
-        let num_elements = sequence[0].value() as usize;
+        let indicated_num_elements = sequence[0].value() as usize;
         let sequence = &sequence[1..];
-        // Initializing the vector with the correct capacity potentially allows a DOS.
+
+        // Initializing the vector with the indicated capacity potentially allows a DOS.
         let mut vec_t = vec![];
 
         if T::static_length().is_some() {
             let element_length = T::static_length().unwrap();
-            let maybe_vector_size = num_elements.checked_mul(element_length);
+            let maybe_vector_size = indicated_num_elements.checked_mul(element_length);
             let Some(vector_size) = maybe_vector_size else {
-                bail!("Length indication too large: {num_elements} * {element_length}");
+                bail!("Length indication too large: {indicated_num_elements} * {element_length}");
             };
 
             if sequence.len() != vector_size {
                 bail!(
                     "Length indication plus one must match actual sequence length. \
-                    Vector claims to contain {num_elements} items. \
+                    Vector claims to contain {indicated_num_elements} items. \
                     Item size is {element_length}. Sequence length is {}.",
                     sequence.len() + 1
                 );
@@ -434,9 +435,9 @@ impl<T: BFieldCodec> BFieldCodec for Vec<T> {
             if !raw_item_iter.remainder().is_empty() {
                 bail!("Could not chunk sequence into equal parts of size {element_length}.");
             }
-            if raw_item_iter.len() != num_elements {
+            if raw_item_iter.len() != indicated_num_elements {
                 bail!(
-                    "Vector contains wrong number of items. Expected {num_elements} found {}",
+                    "Vector contains wrong number of items. Expected {indicated_num_elements} found {}",
                     raw_item_iter.len()
                 );
             }
@@ -447,12 +448,12 @@ impl<T: BFieldCodec> BFieldCodec for Vec<T> {
         } else {
             let sequence_length = sequence.len();
             let mut sequence_index = 0;
-            for element_idx in 0..num_elements {
+            for element_idx in 0..indicated_num_elements {
                 let element_length = match sequence.get(sequence_index) {
                     Some(len) => len.value() as usize,
                     None => bail!(
                         "Index count mismatch while decoding Vec of T. \
-                        Attempted to decode element {} of {num_elements}.",
+                        Attempted to decode element {} of {indicated_num_elements}.",
                         element_idx + 1
                     ),
                 };
@@ -461,7 +462,7 @@ impl<T: BFieldCodec> BFieldCodec for Vec<T> {
                     bail!(
                         "Sequence too short to decode Vec of T: \
                         {sequence_length} < {sequence_index} + {element_length}. \
-                        Attempted to decode element {} of {num_elements}.",
+                        Attempted to decode element {} of {indicated_num_elements}.",
                         element_idx + 1
                     );
                 }
@@ -1204,9 +1205,12 @@ pub mod derive_tests {
 
     #[test]
     fn vec_of_struct_with_one_fix_len_field_test() {
+        // This is a regression test addressing #124.
+        // https://github.com/Neptune-Crypto/twenty-first/issues/124
+
         #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        pub struct OneFixedLenField {
-            pub some_digest: Digest,
+        struct OneFixedLenField {
+            some_digest: Digest,
         }
 
         let rand_struct = || OneFixedLenField {

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -1316,6 +1316,71 @@ mod tests {
         }
 
         #[test]
+        fn struct_with_tuple_field_dynamic_size() {
+            #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+            struct StructWithTupleField {
+                a: (Digest, Vec<Digest>),
+            }
+
+            fn random_struct() -> StructWithTupleField {
+                let mut rng = thread_rng();
+                StructWithTupleField {
+                    a: (random(), random_elements(rng.gen_range(0..10))),
+                }
+            }
+
+            for _ in 0..5 {
+                prop(&random_struct());
+            }
+
+            assert!(StructWithTupleField::static_length().is_none());
+        }
+
+        #[test]
+        fn struct_with_tuple_field_static_size() {
+            #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+            struct StructWithTupleField {
+                a: ([Digest; 2], XFieldElement),
+            }
+
+            fn random_struct() -> StructWithTupleField {
+                StructWithTupleField {
+                    a: ([random(), random()], random()),
+                }
+            }
+
+            for _ in 0..5 {
+                prop(&random_struct());
+            }
+
+            assert_eq!(Some(13), StructWithTupleField::static_length());
+        }
+
+        #[test]
+        fn struct_with_nested_tuple_field() {
+            #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+            struct StructWithTupleField {
+                a: (([Digest; 2], Vec<XFieldElement>), (XFieldElement, u64)),
+            }
+
+            fn random_struct() -> StructWithTupleField {
+                let mut rng = thread_rng();
+                StructWithTupleField {
+                    a: (
+                        ([random(), random()], random_elements(rng.gen_range(0..10))),
+                        (random(), random()),
+                    ),
+                }
+            }
+
+            for _ in 0..5 {
+                prop(&random_struct());
+            }
+
+            assert!(StructWithTupleField::static_length().is_none());
+        }
+
+        #[test]
         fn ms_membership_proof_derive_test() {
             #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
             struct MsMembershipProof<H: AlgebraicHasher> {

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -272,25 +272,30 @@ impl<T: BFieldCodec, S: BFieldCodec> BFieldCodec for (T, S) {
     }
 
     fn static_length() -> Option<usize> {
-        if T::static_length().is_none() || S::static_length().is_none() {
-            None
-        } else {
-            Some(T::static_length().unwrap() + S::static_length().unwrap())
+        match (T::static_length(), S::static_length()) {
+            (Some(sl_t), Some(sl_s)) => Some(sl_t + sl_s),
+            _ => None,
         }
     }
 }
 
 impl<T: BFieldCodec> BFieldCodec for Option<T> {
     fn decode(str: &[BFieldElement]) -> Result<Box<Self>> {
-        let isset = match str.get(0) {
-            Some(e) => e.value() != 0,
+        let is_some = match str.get(0) {
+            Some(e) => {
+                if e.is_one() || e.is_zero() {
+                    e.is_one()
+                } else {
+                    bail!("Invalid option indicator: {e}")
+                }
+            }
             None => bail!("Cannot decode Option of T: empty sequence"),
         };
 
-        if !isset {
-            Ok(Box::new(None))
-        } else {
+        if is_some {
             Ok(Box::new(Some(*T::decode(&str[1..])?)))
+        } else {
+            Ok(Box::new(None))
         }
     }
 
@@ -316,7 +321,7 @@ impl<T: BFieldCodec> BFieldCodec for Option<T> {
 impl<T: BFieldCodec, const N: usize> BFieldCodec for [T; N] {
     fn decode(sequence: &[BFieldElement]) -> Result<Box<Self>> {
         if sequence.is_empty() {
-            bail!("Cannot decode empty sequence into Vec<T>");
+            bail!("Cannot decode empty sequence into [T; {N}]");
         }
         let vec_t = match T::static_length() {
             Some(element_size) => {
@@ -382,7 +387,7 @@ impl<T: BFieldCodec, const N: usize> BFieldCodec for [T; N] {
             // so there's no need to prepend the length of the sequence.
             Some(_) => self.iter().flat_map(|elem| elem.encode()).collect(),
             None => {
-                // Prepend the length of the sequence as it's not known at compile time.
+                // Prepend the length of the entire sequence as it's not known at compile time.
                 let mut ret = vec![BFieldElement::new(0)];
 
                 for elem in self {
@@ -723,6 +728,57 @@ mod bfield_codec_tests {
         assert_eq!(decoded, pd);
 
         assert!(encoded.is_empty());
+    }
+
+    #[test]
+    fn decode_encode_array_with_static_element_size() {
+        const N: usize = 14;
+        type Array = [u64; N];
+
+        let an_array: Array = [14u64; N];
+        prop(&an_array);
+
+        assert_eq!(
+            Some(N * 2),
+            <Array>::static_length(),
+            "Static length must be set and correct for array with static element lengths"
+        );
+    }
+
+    #[test]
+    fn decode_encode_array_with_dynamic_element_size() {
+        const N: usize = 19;
+        type Array = [Vec<Digest>; N];
+
+        // Initialize an array with empty vectors in all elements
+        let mut an_array: Array = Default::default();
+        prop(&an_array);
+
+        // Should also work if the elements are not just the empty vectors
+        let mut rng = thread_rng();
+        for elem in an_array.iter_mut() {
+            *elem = random_elements(rng.gen_range(0..7));
+        }
+
+        prop(&an_array);
+
+        assert!(
+            <Array>::static_length().is_none(),
+            "Static length must be none for array with dynamic element lengths"
+        );
+    }
+
+    fn prop<T: BFieldCodec + PartialEq + Eq + std::fmt::Debug>(value: &T) {
+        let encoded = value.encode();
+        let decoded = T::decode(&encoded);
+        let decoded = decoded.unwrap();
+        assert_eq!(*value, *decoded);
+
+        let encoded_too_long = vec![encoded, vec![BFieldElement::new(5)]].concat();
+        assert!(T::decode(&encoded_too_long).is_err());
+
+        let encoded_too_short = encoded_too_long[..encoded_too_long.len() - 2].to_vec();
+        assert!(T::decode(&encoded_too_short).is_err());
     }
 }
 
@@ -1201,7 +1257,15 @@ pub mod derive_tests {
         };
         let encoded = my_struct.encode();
         let decoded = UnsupportedFields::decode(&encoded).unwrap();
-        assert_eq!(my_struct.a, decoded.a);
+        assert_eq!(
+            my_struct.a, decoded.a,
+            "Non-ignored fields must be preserved under encoding"
+        );
+        assert_eq!(
+            usize::default(),
+            decoded.b,
+            "Ignored field must decode to default value"
+        )
     }
 
     #[test]
@@ -1281,7 +1345,7 @@ pub mod derive_tests {
     #[test]
     fn vec_of_struct_with_fix_and_var_len_unnamed_fields_test() {
         #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        pub struct FixAndVarLenUnnamedFields(Digest, Vec<u64>);
+        struct FixAndVarLenUnnamedFields(Digest, Vec<u64>);
 
         let rand_struct = || {
             let num_elements: usize = thread_rng().gen_range(0..42);
@@ -1297,16 +1361,16 @@ pub mod derive_tests {
     #[test]
     fn vec_of_struct_with_quite_a_few_fix_and_var_len_fields_test() {
         #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec)]
-        pub struct QuiteAFewFixAndVarLenFields {
-            pub some_digest: Digest,
-            pub some_vec: Vec<u64>,
-            pub some_u64: u64,
-            pub other_vec: Vec<u32>,
-            pub other_digest: Digest,
-            pub yet_another_vec: Vec<u32>,
-            pub and_another_vec: Vec<u64>,
-            pub more_fixed_len: u64,
-            pub even_more_fixed_len: u64,
+        struct QuiteAFewFixAndVarLenFields {
+            some_digest: Digest,
+            some_vec: Vec<u64>,
+            some_u64: u64,
+            other_vec: Vec<u32>,
+            other_digest: Digest,
+            yet_another_vec: Vec<u32>,
+            and_another_vec: Vec<u64>,
+            more_fixed_len: u64,
+            even_more_fixed_len: u64,
         }
 
         let rand_struct = || {

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -541,28 +541,12 @@ mod tests {
 
         use rand::{Rng, RngCore};
 
-        use crate::{
-            shared_math::{
-                digest::Digest, digest::DIGEST_LENGTH, other::random_elements, tip5::Tip5,
-                x_field_element::XFieldElement, x_field_element::EXTENSION_DEGREE,
-            },
-            util_types::merkle_tree::PartialAuthenticationPath,
+        use crate::shared_math::{
+            digest::Digest, digest::DIGEST_LENGTH, other::random_elements, tip5::Tip5,
+            x_field_element::XFieldElement, x_field_element::EXTENSION_DEGREE,
         };
 
         use super::*;
-
-        fn random_partial_authentication_paths(
-            path_len: usize,
-            num_paths: usize,
-        ) -> Vec<PartialAuthenticationPath<Digest>> {
-            let maybe_elem = || if random() { Some(random()) } else { None };
-            let mut ret = vec![];
-            for _ in 0..num_paths {
-                let path = (0..path_len).map(|_| maybe_elem()).collect();
-                ret.push(path);
-            }
-            ret
-        }
 
         #[test]
         fn test_encode_decode_random_bfieldelement() {
@@ -640,16 +624,6 @@ mod tests {
                     })
                     .collect_vec();
                 assert_bfield_codec_properties(&xfe_vec_vec);
-            }
-        }
-
-        #[test]
-        fn test_encode_decode_random_partial_authentication_path() {
-            for _ in 1..=10 {
-                let len = 1 + thread_rng().gen_range(0..10);
-                let count = thread_rng().gen_range(0..10);
-                let pap = random_partial_authentication_paths(len, count);
-                assert_bfield_codec_properties(&pap);
             }
         }
 

--- a/twenty-first/src/shared_math/digest.rs
+++ b/twenty-first/src/shared_math/digest.rs
@@ -27,10 +27,6 @@ impl GetSize for Digest {
     fn get_heap_size(&self) -> usize {
         0
     }
-
-    fn get_size(&self) -> usize {
-        Self::get_stack_size()
-    }
 }
 
 impl PartialOrd for Digest {

--- a/twenty-first/src/shared_math/digest.rs
+++ b/twenty-first/src/shared_math/digest.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use std::str::FromStr;
 
+use bfieldcodec_derive::BFieldCodec;
 use get_size::GetSize;
 use itertools::Itertools;
 use num_bigint::{BigUint, TryFromBigIntError};
@@ -16,7 +17,7 @@ use crate::util_types::emojihash_trait::Emojihash;
 
 pub const DIGEST_LENGTH: usize = 5;
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, BFieldCodec)]
 pub struct Digest(pub [BFieldElement; DIGEST_LENGTH]);
 
 impl GetSize for Digest {

--- a/twenty-first/src/shared_math/x_field_element.rs
+++ b/twenty-first/src/shared_math/x_field_element.rs
@@ -1,3 +1,4 @@
+use bfieldcodec_derive::BFieldCodec;
 use num_traits::{One, Zero};
 use rand::Rng;
 use rand_distr::{Distribution, Standard};
@@ -15,7 +16,7 @@ use crate::util_types::emojihash_trait::Emojihash;
 
 pub const EXTENSION_DEGREE: usize = 3;
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, Serialize, Deserialize, BFieldCodec)]
 pub struct XFieldElement {
     pub coefficients: [BFieldElement; EXTENSION_DEGREE],
 }

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -46,6 +46,7 @@ where
 {
     leaf_count: u64,
     peaks: Vec<Digest>,
+    #[bfield_codec(ignore)]
     _hasher: PhantomData<H>,
 }
 


### PR DESCRIPTION
This PR updates the derive macro for BFieldCodec so that the generated code is aware when the size of encoded objects is statically known. As a result, objects with statically-known encoding sizes are not length-prepended.

Also this PR adds support for deriving BFieldCodec for enums.