### PR TITLE
Add BFieldCodec support for structs containing empty structs

### DIFF
--- a/bfieldcodec_derive/src/lib.rs
+++ b/bfieldcodec_derive/src/lib.rs
@@ -479,7 +479,8 @@ fn generate_decode_statement_for_field(
     let field_name_as_string_literal = field_name.to_string();
     quote! {
         let (#field_name, sequence) = {
-            if sequence.is_empty() {
+            if sequence.is_empty() && <#field_type
+            as ::twenty_first::shared_math::bfield_codec::BFieldCodec>::static_length().is_none() {
                 anyhow::bail!("Cannot decode field {}: sequence is empty.", #field_name_as_string_literal);
             }
             let (len, sequence) = match <#field_type

--- a/bfieldcodec_derive/src/lib.rs
+++ b/bfieldcodec_derive/src/lib.rs
@@ -523,7 +523,8 @@ fn generate_decode_clause_for_variant(
             let field_value = quote::format_ident!("variant_{}_field_{}_value", variant_index, field_index);
             quote! {
                 let (#field_value, sequence) = {
-                    if sequence.is_empty() {
+                    if sequence.is_empty() && <#field_type
+                        as ::twenty_first::shared_math::bfield_codec::BFieldCodec>::static_length().is_none() {
                         anyhow::bail!("Cannot decode variant {} field {}: sequence is empty.", #variant_index, #field_index);
                     }
                     let (len, sequence) = match <#field_type

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -29,7 +29,8 @@ features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3"
-bfieldcodec_derive = "0.4.1"
+# bfieldcodec_derive = "0.4.1"
+bfieldcodec_derive = { path = "../bfieldcodec_derive" }
 blake3 = "1.4.1"
 colored = "2.0"
 hashbrown = "0.14"

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -521,7 +521,7 @@ mod tests {
     fn assert_bfield_codec_properties<T: BFieldCodec + PartialEq + Eq + std::fmt::Debug>(
         value: &T,
     ) {
-        let encoded = value.encode();
+        let mut encoded = value.encode();
         let decoded = T::decode(&encoded);
         let decoded = *decoded.unwrap();
         assert_eq!(*value, decoded);
@@ -530,17 +530,21 @@ mod tests {
             expensive_encoding_pbt(&encoded, decoded);
         }
 
-        let encoded_too_long = [encoded, vec![BFieldElement::new(5)]].concat();
+        encoded.push(BFieldElement::new(5));
         assert!(
-            T::decode(&encoded_too_long).is_err(),
+            T::decode(&encoded).is_err(),
             "decoding a sequence that is too long does not fail"
         );
+        encoded.pop().unwrap();
 
-        let encoded_too_short = encoded_too_long[..encoded_too_long.len() - 2].to_vec();
-        assert!(
-            T::decode(&encoded_too_short).is_err(),
-            "decoding a sequence that is stoo short does not fail"
-        );
+        if !encoded.is_empty() {
+            // let encoded_too_short = encoded_too_long[..encoded_too_long.len() - 2].to_vec();
+            encoded.pop();
+            assert!(
+                T::decode(&encoded).is_err(),
+                "decoding a sequence that is stoo short does not fail"
+            );
+        }
     }
 
     mod bfield_codec_tests {
@@ -878,6 +882,37 @@ mod tests {
         #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
         struct WithNestedVec {
             a_field: Vec<Vec<u64>>,
+        }
+
+        #[test]
+        fn empty_structs_and_enums() {
+            #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+            struct EmptyStruct {}
+
+            #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+            struct StructWithEmptyStruct {
+                a: EmptyStruct,
+            }
+
+            #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+            struct StructWithTwoEmptyStructs {
+                a: EmptyStruct,
+                b: EmptyStruct,
+            }
+
+            #[derive(BFieldCodec, PartialEq, Eq, Debug, Default)]
+            struct BigStructWithEmptyStructs {
+                a: EmptyStruct,
+                b: EmptyStruct,
+                c: StructWithTwoEmptyStructs,
+                d: StructWithEmptyStruct,
+                e: EmptyStruct,
+            }
+
+            assert_bfield_codec_properties(&EmptyStruct::default());
+            assert_bfield_codec_properties(&StructWithEmptyStruct::default());
+            assert_bfield_codec_properties(&StructWithTwoEmptyStructs::default());
+            assert_bfield_codec_properties(&BigStructWithEmptyStructs::default());
         }
 
         #[test]

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -538,7 +538,6 @@ mod tests {
         encoded.pop().unwrap();
 
         if !encoded.is_empty() {
-            // let encoded_too_short = encoded_too_long[..encoded_too_long.len() - 2].to_vec();
             encoded.pop();
             assert!(
                 T::decode(&encoded).is_err(),
@@ -913,6 +912,16 @@ mod tests {
             assert_bfield_codec_properties(&StructWithEmptyStruct::default());
             assert_bfield_codec_properties(&StructWithTwoEmptyStructs::default());
             assert_bfield_codec_properties(&BigStructWithEmptyStructs::default());
+
+            #[derive(BFieldCodec, PartialEq, Eq, Debug)]
+            enum EnumWithEmptyStruct {
+                A(EmptyStruct),
+                B,
+                C(EmptyStruct),
+            }
+            assert_bfield_codec_properties(&EnumWithEmptyStruct::A(EmptyStruct::default()));
+            assert_bfield_codec_properties(&EnumWithEmptyStruct::B);
+            assert_bfield_codec_properties(&EnumWithEmptyStruct::C(EmptyStruct::default()));
         }
 
         #[test]


### PR DESCRIPTION
There was a cornercase here that was not covered: A struct containing a field of a type that encodes to an empty list. Also fixes the equivalent problem for `enum` containing an empty struct as associated data to a variant.

Note that the `bfieldcodec_derive` import was changed to a local version since the added test would otherwise fail.



