### PR TITLE
avoid borrowing copy-type `Digest`

### DIFF
--- a/twenty-first/benches/tip5.rs
+++ b/twenty-first/benches/tip5.rs
@@ -1,6 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use itertools::Itertools;
-use rand::RngCore;
+use rand::{thread_rng, Rng};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::digest::DIGEST_LENGTH;
@@ -14,15 +13,20 @@ fn bench_10(c: &mut Criterion) {
     let size = 10;
     group.sample_size(100);
 
-    let mut rng = rand::thread_rng();
-    let single_element: [BFieldElement; 10] = (0..10)
-        .map(|_| BFieldElement::new(rng.next_u64()))
-        .collect_vec()
-        .try_into()
-        .unwrap();
-
+    let single_element: [BFieldElement; 10] = thread_rng().gen();
     group.bench_function(BenchmarkId::new("Tip5 / Hash 10", size), |bencher| {
         bencher.iter(|| Tip5::hash_10(&single_element));
+    });
+}
+
+fn bench_pair(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tip5/hash_pair");
+
+    let left = thread_rng().gen();
+    let right = thread_rng().gen();
+
+    group.bench_function(BenchmarkId::new("Tip5 / Hash Pair", "pair"), |bencher| {
+        bencher.iter(|| Tip5::hash_pair(&left, &right));
     });
 }
 
@@ -60,5 +64,5 @@ fn bench_parallel(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_10, bench_varlen, bench_parallel);
+criterion_group!(benches, bench_10, bench_pair, bench_varlen, bench_parallel);
 criterion_main!(benches);

--- a/twenty-first/benches/tip5.rs
+++ b/twenty-first/benches/tip5.rs
@@ -26,7 +26,7 @@ fn bench_pair(c: &mut Criterion) {
     let right = thread_rng().gen();
 
     group.bench_function(BenchmarkId::new("Tip5 / Hash Pair", "pair"), |bencher| {
-        bencher.iter(|| Tip5::hash_pair(&left, &right));
+        bencher.iter(|| Tip5::hash_pair(left, right));
     });
 }
 

--- a/twenty-first/src/shared_math/digest.rs
+++ b/twenty-first/src/shared_math/digest.rs
@@ -51,7 +51,7 @@ impl Ord for Digest {
 impl Digest {
     pub const BYTES: usize = DIGEST_LENGTH * BFieldElement::BYTES;
 
-    pub fn values(&self) -> [BFieldElement; DIGEST_LENGTH] {
+    pub fn values(self) -> [BFieldElement; DIGEST_LENGTH] {
         self.0
     }
 
@@ -214,8 +214,8 @@ impl Digest {
     /// method invokes hash_pair with the right operand being the zero
     /// digest, agreeing with the standard way to hash a digest in the
     /// virtual machine.
-    pub fn hash<H: AlgebraicHasher>(&self) -> Digest {
-        H::hash_pair(self, &Digest::new([BFieldElement::zero(); DIGEST_LENGTH]))
+    pub fn hash<H: AlgebraicHasher>(self) -> Digest {
+        H::hash_pair(self, Digest::new([BFieldElement::zero(); DIGEST_LENGTH]))
     }
 }
 

--- a/twenty-first/src/shared_math/tip5.rs
+++ b/twenty-first/src/shared_math/tip5.rs
@@ -592,10 +592,14 @@ impl Tip5 {
 
 impl AlgebraicHasher for Tip5 {
     fn hash_pair(left: Digest, right: Digest) -> Digest {
-        let mut input = [BFIELD_ZERO; 10];
-        input[..DIGEST_LENGTH].copy_from_slice(&left.values());
-        input[DIGEST_LENGTH..].copy_from_slice(&right.values());
-        Digest::new(Tip5::hash_10(&input))
+        let mut sponge = Tip5State::new(Domain::FixedLength);
+        sponge.state[..DIGEST_LENGTH].copy_from_slice(&left.values());
+        sponge.state[DIGEST_LENGTH..2 * DIGEST_LENGTH].copy_from_slice(&right.values());
+
+        Self::permutation(&mut sponge);
+
+        let digest_values = sponge.state[..DIGEST_LENGTH].try_into().unwrap();
+        Digest::new(digest_values)
     }
 
     /// Produce `num_elements` random [XFieldElement] values.

--- a/twenty-first/src/shared_math/tip5.rs
+++ b/twenty-first/src/shared_math/tip5.rs
@@ -591,7 +591,7 @@ impl Tip5 {
 }
 
 impl AlgebraicHasher for Tip5 {
-    fn hash_pair(left: &Digest, right: &Digest) -> Digest {
+    fn hash_pair(left: Digest, right: Digest) -> Digest {
         let mut input = [BFIELD_ZERO; 10];
         input[..DIGEST_LENGTH].copy_from_slice(&left.values());
         input[DIGEST_LENGTH..].copy_from_slice(&right.values());

--- a/twenty-first/src/shared_math/x_field_element.rs
+++ b/twenty-first/src/shared_math/x_field_element.rs
@@ -166,7 +166,7 @@ impl XFieldElement {
     /// more efficient `sample_weights()` implementation:
     ///
     /// https://github.com/Neptune-Crypto/twenty-first/pull/66#discussion_r1049771105
-    pub fn sample(digest: &Digest) -> Self {
+    pub fn sample(digest: Digest) -> Self {
         let elements = digest.values();
         XFieldElement::new([elements[2], elements[3], elements[4]])
     }

--- a/twenty-first/src/test_shared.rs
+++ b/twenty-first/src/test_shared.rs
@@ -2,7 +2,7 @@ use crate::shared_math::digest::Digest;
 
 pub mod mmr;
 
-pub fn corrupt_digest(digest: &Digest) -> Digest {
+pub fn corrupt_digest(digest: Digest) -> Digest {
     let mut bad_elements = digest.values();
     bad_elements[0].increment();
     Digest::new(bad_elements)

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -60,7 +60,7 @@ pub trait SpongeHasher: Clone + Send + Sync {
 
 pub trait AlgebraicHasher: SpongeHasher {
     /// Hash two [Digest]s into one.
-    fn hash_pair(left: &Digest, right: &Digest) -> Digest;
+    fn hash_pair(left: Digest, right: Digest) -> Digest;
 
     /// Hash a `value: &T` to a [Digest].
     ///

--- a/twenty-first/src/util_types/blake3_wrapper.rs
+++ b/twenty-first/src/util_types/blake3_wrapper.rs
@@ -38,7 +38,7 @@ impl SpongeHasher for blake3::Hasher {
 }
 
 impl AlgebraicHasher for blake3::Hasher {
-    fn hash_pair(left: &Digest, right: &Digest) -> Digest {
+    fn hash_pair(left: Digest, right: Digest) -> Digest {
         let mut hasher = blake3::Hasher::new();
         for elem in left.values().iter().chain(right.values().iter()) {
             hasher.update(&elem.value().to_be_bytes());

--- a/twenty-first/src/util_types/mmr/mmr_trait.rs
+++ b/twenty-first/src/util_types/mmr/mmr_trait.rs
@@ -30,7 +30,7 @@ pub trait Mmr<H: AlgebraicHasher> {
     /// Mutate an existing leaf. It is the caller's responsibility that the
     /// membership proof is valid. If the membership proof is wrong, the MMR
     /// will end up in a broken state.
-    fn mutate_leaf(&mut self, old_membership_proof: &MmrMembershipProof<H>, new_leaf: &Digest);
+    fn mutate_leaf(&mut self, old_membership_proof: &MmrMembershipProof<H>, new_leaf: Digest);
 
     /// Batch mutate an MMR while updating a list of membership proofs. Returns the indices of the
     /// membership proofs that have changed as a result of this operation.

--- a/twenty-first/src/util_types/mmr/shared_basic.rs
+++ b/twenty-first/src/util_types/mmr/shared_basic.rs
@@ -85,7 +85,7 @@ pub fn calculate_new_peaks_from_append<H: AlgebraicHasher>(
         let new_hash = peaks.pop().unwrap();
         let previous_peak = peaks.pop().unwrap();
         membership_proof.authentication_path.push(previous_peak);
-        peaks.push(H::hash_pair(&previous_peak, &new_hash));
+        peaks.push(H::hash_pair(previous_peak, new_hash));
         right_lineage_count -= 1;
     }
 
@@ -97,7 +97,7 @@ pub fn calculate_new_peaks_from_append<H: AlgebraicHasher>(
 /// than `old_peaks`
 pub fn calculate_new_peaks_from_leaf_mutation<H: AlgebraicHasher>(
     old_peaks: &[Digest],
-    new_leaf: &Digest,
+    new_leaf: Digest,
     leaf_count: u64,
     membership_proof: &MmrMembershipProof<H>,
 ) -> Vec<Digest> {
@@ -109,10 +109,10 @@ pub fn calculate_new_peaks_from_leaf_mutation<H: AlgebraicHasher>(
         let ap_element = membership_proof.authentication_path[i];
         if acc_mt_index % 2 == 1 {
             // Node with `acc_hash` is a right child
-            acc_hash = H::hash_pair(&ap_element, &acc_hash);
+            acc_hash = H::hash_pair(ap_element, acc_hash);
         } else {
             // Node with `acc_hash` is a left child
-            acc_hash = H::hash_pair(&acc_hash, &ap_element);
+            acc_hash = H::hash_pair(acc_hash, ap_element);
         }
 
         acc_mt_index /= 2;

--- a/twenty-first/src/util_types/shared.rs
+++ b/twenty-first/src/util_types/shared.rs
@@ -23,9 +23,9 @@ where
         return peaks[0].to_owned();
     }
 
-    let mut acc: Digest = H::hash_pair(&peaks[peaks_count - 2], &peaks[peaks_count - 1]);
+    let mut acc: Digest = H::hash_pair(peaks[peaks_count - 2], peaks[peaks_count - 1]);
     for i in 2..peaks_count {
-        acc = H::hash_pair(&peaks[peaks_count - 1 - i], &acc);
+        acc = H::hash_pair(peaks[peaks_count - 1 - i], acc);
     }
 
     acc


### PR DESCRIPTION
Most of the changes in this PR are boring deletion or addition of `&`s. The following things might be of interest:
- changes to the interface `hash_pair` in `AlgebraicHasher`
- commit 05a0da6b4758e11cc839dc80eb3356655663467e, introducing a benchmark
- commit e38a966acd24aa3b2b94e1620e0df94adca20da9, avoiding some copying
