### PR TITLE
Remove itertools dep from bfieldcodec deriver

### DIFF
--- a/bfieldcodec_derive/src/lib.rs
+++ b/bfieldcodec_derive/src/lib.rs
@@ -411,7 +411,7 @@ fn generate_tokens_for_enum(
                     #variant_lengths ,
                 )*
             ];
-            if variant_lengths.iter().all(|fl| fl.is_some() ) && variant_lengths.iter().tuple_windows().all(|(l, r)| l.unwrap() == r.unwrap()) {
+            if variant_lengths.iter().all(|fl| fl.is_some() ) && variant_lengths.iter().all(|x| x.unwrap() == variant_lengths[0].unwrap()) {
                 variant_lengths[0]
             }
             else {

--- a/bfieldcodec_derive/src/lib.rs
+++ b/bfieldcodec_derive/src/lib.rs
@@ -411,8 +411,8 @@ fn generate_tokens_for_enum(
                     #variant_lengths ,
                 )*
             ];
-            if variant_lengths.iter().all(|fl| fl.is_some() ) && variant_lengths.iter().all(|x| x.unwrap() == variant_lengths[0].unwrap()) {
-                variant_lengths[0]
+            if variant_lengths.iter().all(|fl| fl.is_some()) && variant_lengths.iter().all(|x| x.unwrap() == variant_lengths[0].unwrap()) {
+                Some(variant_lengths[0].unwrap() + 1)
             }
             else {
                 None

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -32,7 +32,7 @@ features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]
 anyhow = "1.0"
 arbitrary = { version = "1", features = ["derive"] }
 bincode = "1.3"
-bfieldcodec_derive = "0.4.2"
+bfieldcodec_derive = { path = "../bfieldcodec_derive" }
 blake3 = "1.5.0"
 colored = "2.0"
 hashbrown = "0.14"

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -1526,7 +1526,6 @@ mod tests {
 
         #[cfg(test)]
         mod simple_derivations {
-            use itertools::Itertools;
             use rand::random;
 
             use crate::shared_math::{


### PR DESCRIPTION
- Removes itertools as dependency when deriving `BFieldCodec`
- Fixes a bug in calculating static encoding sizes when enum variants all have same data size