### PR TITLE
feat: use rs-leveldb instead of rusty-leveldb

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,11 @@ While twenty-first's version is `0.x.y`, releasing a new version:
 [crates]: https://crates.io/crates/twenty-first/versions
 
 If you do not have the privilege to create git tags or run `cargo publish`, submit a PR and the merger will take care of these.
+
+## Building
+
+This crate depends on the [rs-leveldb](https://crates.io/crates/rs-leveldb) crate which wraps the C++ implementation of leveldb. As such, `snappy` and `leveldb` must be installed. Eg, on Ubuntu:
+
+```
+sudo apt-get install libleveldb-dev libsnappy-dev
+```

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -43,7 +43,7 @@ phf = { version = "0.11", features = ["macros"] }
 rand = { version = "0.8", features = ["min_const_gen"] }
 rand_distr = "0.4"
 rayon = "1.8"
-rusty-leveldb = "3"
+rs-leveldb = "0.1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde-big-array = "0"
 serde_derive = "1"

--- a/twenty-first/src/test_shared/mmr.rs
+++ b/twenty-first/src/test_shared/mmr.rs
@@ -1,8 +1,7 @@
 use std::sync::{Arc, Mutex};
 
-use rusty_leveldb::DB;
-
 use crate::shared_math::digest::Digest;
+use crate::util_types::level_db::DB;
 use crate::util_types::storage_vec::RustyLevelDbVec;
 use crate::util_types::{algebraic_hasher::AlgebraicHasher, mmr::archival_mmr::ArchivalMmr};
 
@@ -12,10 +11,8 @@ use crate::util_types::{algebraic_hasher::AlgebraicHasher, mmr::archival_mmr::Ar
 /// underlying data structure.
 pub fn get_empty_rustyleveldb_ammr<H: AlgebraicHasher>() -> ArchivalMmr<H, RustyLevelDbVec<Digest>>
 {
-    let opt = rusty_leveldb::in_memory();
-    let db = DB::open("mydatabase", opt).unwrap();
-    let db = Arc::new(Mutex::new(db));
-    let pv = RustyLevelDbVec::new(db, 0, "in-memory AMMR for unit tests");
+    let db = DB::open_new_test_database(true, None).unwrap();
+    let pv = RustyLevelDbVec::new(Arc::new(Mutex::new(db)), 0, "AMMR for unit tests");
     ArchivalMmr::new(pv)
 }
 

--- a/twenty-first/src/util_types.rs
+++ b/twenty-first/src/util_types.rs
@@ -3,6 +3,7 @@ pub mod blake3_wrapper;
 pub mod database_array;
 pub mod database_vector;
 pub mod emojihash_trait;
+pub mod level_db;
 pub mod merkle_tree;
 pub mod merkle_tree_maker;
 pub mod mmr;

--- a/twenty-first/src/util_types/level_db.rs
+++ b/twenty-first/src/util_types/level_db.rs
@@ -1,0 +1,208 @@
+use leveldb::{
+    batch::{Batch, WriteBatch},
+    database::comparator::Comparator,
+    database::Database,
+    error::Error as DbError,
+    key::IntoLevelDBKey,
+    options::{Options, ReadOptions, WriteOptions},
+};
+use std::path::Path;
+
+/// `DB` wraps `leveldb::database::Database` and provides
+/// functionality for reading the database on-disk path
+/// as well as destroying the on-disk database manually
+/// or automatically upon drop.  auto-destroy-on-drop is
+/// needed for unit tests that use the DB.
+//
+//  This also provides an abstraction layer in case we
+//  decide to simplify/alter the DB api a bit, or even
+//  switch crates/impls.
+pub struct DB {
+    pub db: Database,
+    pub path: std::path::PathBuf,
+    pub destroy_db_on_drop: bool,
+}
+
+impl DB {
+    /// Open a new database
+    ///
+    /// If the database is missing, the behaviour depends on `options.create_if_missing`.
+    /// The database will be created using the settings given in `options`.
+    #[inline]
+    pub fn open(name: &Path, options: &Options) -> Result<Self, DbError> {
+        let db = Database::open(name, options)?;
+        Ok(Self {
+            db,
+            path: name.into(),
+            destroy_db_on_drop: false,
+        })
+    }
+
+    /// Open a new database with a custom comparator
+    ///
+    /// If the database is missing, the behaviour depends on `options.create_if_missing`.
+    /// The database will be created using the settings given in `options`.
+    ///
+    /// The comparator must implement a total ordering over the keyspace.
+    ///
+    /// For keys that implement Ord, consider the `OrdComparator`.
+    #[inline]
+    pub fn open_with_comparator<C: Comparator>(
+        name: &Path,
+        options: &Options,
+        comparator: C,
+    ) -> Result<Self, DbError> {
+        let db = Database::open_with_comparator(name, options, comparator)?;
+        Ok(Self {
+            db,
+            path: name.into(),
+            destroy_db_on_drop: false,
+        })
+    }
+
+    /// Creates and opens a test database
+    ///
+    /// The database will be created in the system
+    /// temp directory with prefix "test-db-" followed
+    /// by a random string.
+    ///
+    /// if destroy_db_on_drop is true, the database on-disk
+    /// files will be wiped when the DB struct is dropped.
+    pub fn open_new_test_database(
+        destroy_db_on_drop: bool,
+        options: Option<Options>,
+    ) -> Result<Self, DbError> {
+        use rand::distributions::DistString;
+        use rand_distr::Alphanumeric;
+
+        let path = std::env::temp_dir().join(format!(
+            "test-db-{}",
+            Alphanumeric.sample_string(&mut rand::thread_rng(), 10)
+        ));
+        Self::open_test_database(&path, destroy_db_on_drop, options)
+    }
+
+    /// Opens an existing (test?) database, with auto-destroy option.
+    ///
+    /// if destroy_db_on_drop is true, the database on-disk
+    /// files will be wiped when the DB struct is dropped.
+    /// This is usually useful only for unit-test purposes.
+    pub fn open_test_database(
+        path: &std::path::Path,
+        destroy_db_on_drop: bool,
+        options: Option<Options>,
+    ) -> Result<Self, DbError> {
+        let mut opt = options.unwrap_or_else(Options::new);
+
+        opt.create_if_missing = true;
+        opt.error_if_exists = false;
+
+        let mut db = DB::open(path, &opt)?;
+        db.destroy_db_on_drop = destroy_db_on_drop;
+        Ok(db)
+    }
+
+    /// Set a key/val in the database
+    #[inline]
+    pub fn put(
+        &self,
+        options: &WriteOptions,
+        key: &dyn IntoLevelDBKey,
+        value: &[u8],
+    ) -> Result<(), DbError> {
+        self.db.put(options, key, value)
+    }
+
+    /// Set a key/val in the database, with key as bytes.
+    #[inline]
+    pub fn put_u8(&self, options: &WriteOptions, key: &[u8], value: &[u8]) -> Result<(), DbError> {
+        self.db.put_u8(options, key, value)
+    }
+
+    /// Get a value matching key from the database
+    #[inline]
+    pub fn get(
+        &self,
+        options: &ReadOptions,
+        key: &dyn IntoLevelDBKey,
+    ) -> Result<Option<Vec<u8>>, DbError> {
+        self.db.get(options, key)
+    }
+
+    /// Get a value matching key from the database, with key as bytes
+    #[inline]
+    pub fn get_u8(&self, options: &ReadOptions, key: &[u8]) -> Result<Option<Vec<u8>>, DbError> {
+        self.db.get_u8(options, key)
+    }
+
+    /// Delete an entry matching key from the database
+    #[inline]
+    pub fn delete(&self, options: &WriteOptions, key: &dyn IntoLevelDBKey) -> Result<(), DbError> {
+        self.db.delete(options, key)
+    }
+
+    /// Delete an entry matching key from the database, with key as bytes
+    #[inline]
+    pub fn delete_u8(&self, options: &WriteOptions, key: &[u8]) -> Result<(), DbError> {
+        self.db.delete_u8(options, key)
+    }
+
+    /// Wipe the database files, if existing.
+    fn destroy_db(&mut self) -> Result<(), std::io::Error> {
+        match self.path.exists() {
+            true => std::fs::remove_dir_all(&self.path),
+            false => Ok(()),
+        }
+    }
+}
+
+impl Drop for DB {
+    #[inline]
+    fn drop(&mut self) {
+        if self.destroy_db_on_drop {
+            // note: we do not panic if the database directory
+            // cannot be removed.  Perhaps revisit later.
+            let _ = self.destroy_db();
+        }
+    }
+}
+
+impl Batch for DB {
+    fn write(&self, options: &WriteOptions, batch: &WriteBatch) -> Result<(), DbError> {
+        self.db.write(options, batch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    use leveldb::options::WriteOptions;
+
+    #[test]
+    fn level_db_close_and_reload() {
+        // open new test database that will not be destroyed on close.
+        let db = DB::open_new_test_database(false, None).unwrap();
+        let db_path = db.path.clone();
+
+        let key = "answer-to-everything";
+        let val = vec![42];
+
+        let _ = db.put(&WriteOptions::new(), &key, &val);
+
+        drop(db); // close the DB.
+
+        assert!(db_path.exists());
+
+        // open existing database that will be destroyed on close.
+        let db2 = DB::open_test_database(&db_path, true, None).unwrap();
+
+        let val2 = db2.get(&ReadOptions::new(), &key).unwrap().unwrap();
+        assert_eq!(val, val2);
+
+        drop(db2); // close the DB.  db_path dir is auto removed.
+
+        assert!(!db_path.exists());
+    }
+}

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -9,7 +9,7 @@ use crate::util_types::algebraic_hasher::AlgebraicHasher;
 use crate::util_types::shared::bag_peaks;
 use crate::util_types::storage_vec::{RustyLevelDbVec, StorageVec};
 use crate::utils::has_unique_elements;
-use rusty_leveldb::WriteBatch;
+use leveldb::batch::WriteBatch;
 
 /// A Merkle Mountain Range is a datastructure for storing a list of hashes.
 ///
@@ -329,14 +329,18 @@ mod mmr_test {
     use crate::util_types::merkle_tree::merkle_tree_test;
     use crate::{
         shared_math::b_field_element::BFieldElement,
+        util_types::level_db::DB,
         util_types::mmr::{
             archival_mmr::ArchivalMmr, mmr_accumulator::MmrAccumulator,
             shared_advanced::get_peak_heights_and_peak_node_indices,
         },
     };
     use itertools::izip;
+    use leveldb::batch::Batch;
+    use leveldb::iterator::Iterable;
+    use leveldb::options::ReadOptions;
+    use leveldb::options::WriteOptions;
     use rand::random;
-    use rusty_leveldb::{LdbIterator, DB};
 
     impl<H: AlgebraicHasher, Storage: StorageVec<Digest>> ArchivalMmr<H, Storage> {
         /// Return the number of nodes in all the trees in the MMR
@@ -1025,12 +1029,10 @@ mod mmr_test {
     fn rust_leveldb_persist_test() {
         type H = blake3::Hasher;
 
-        let opt = rusty_leveldb::in_memory();
-        let db = DB::open("mydatabase", opt).unwrap();
+        let db = DB::open_new_test_database(true, None).unwrap();
         let db = Arc::new(Mutex::new(db));
         let persistent_vec_0 = RustyLevelDbVec::new(db.clone(), 0, "archival MMR for unit tests");
         let mut ammr0: ArchivalMmr<H, RustyLevelDbVec<Digest>> = ArchivalMmr::new(persistent_vec_0);
-
         let persistent_vec_1 = RustyLevelDbVec::new(db.clone(), 1, "archival MMR for unit tests");
         let mut ammr1: ArchivalMmr<H, RustyLevelDbVec<Digest>> = ArchivalMmr::new(persistent_vec_1);
 
@@ -1039,29 +1041,34 @@ mod mmr_test {
 
         let digest1: Digest = random();
         ammr1.append(digest1);
-
         // Verify that DB is still empty
-        let mut db_iter = db.lock().unwrap().new_iter().unwrap();
+        let db_lock = db.lock().unwrap();
+        let mut db_iter = db_lock.db.iter(&ReadOptions::new());
         assert!(db_iter.next().is_none());
+        drop(db_lock);
 
         let mut write_batch = WriteBatch::new();
         ammr0.persist(&mut write_batch);
 
         // Verify that DB is still empty, as the write batch hasn't been applied yet
-        db_iter = db.lock().unwrap().new_iter().unwrap();
-        assert!(db_iter.next().is_none());
+        let db_lock2 = db.lock().unwrap();
+        let mut db_iter2 = db_lock2.db.iter(&ReadOptions::new());
+        assert!(db_iter2.next().is_none());
+        drop(db_lock2);
 
         ammr1.persist(&mut write_batch);
 
         // Verify that DB is still empty, as the write batch hasn't been applied yet
-        db_iter = db.lock().unwrap().new_iter().unwrap();
-        assert!(db_iter.next().is_none());
+        let db_lock3 = db.lock().unwrap();
+        let mut db_iter3 = db_lock3.db.iter(&ReadOptions::new());
+        assert!(db_iter3.next().is_none());
 
-        db.lock().unwrap().write(write_batch, true).unwrap();
+        db_lock3.write(&WriteOptions::new(), &write_batch).unwrap();
 
         // Verify that DB is not empty
-        db_iter = db.lock().unwrap().new_iter().unwrap();
-        assert!(db_iter.next().is_some());
+        let mut db_iter4 = db_lock3.db.iter(&ReadOptions::new());
+        assert!(db_iter4.next().is_some());
+        drop(db_lock3);
 
         assert_eq!(digest0, ammr0.get_leaf(0));
         assert_eq!(digest1, ammr1.get_leaf(0));


### PR DESCRIPTION
Summary: This is a necessary first step that just performs a straight swap of leveldb crates but keeps our existing locks in place and changes as little code as practical.   We could review/merge this now, or wait until I've removed some locks.  (which will be a bigger set of diffs)

--------

Addresses #163

rs-leveldb is a wrapper for C++ leveldb.  It is a fork of the standard leveldb crate and seems nicer because it supports using strings and standard integer types as keys directly.

With these changes the code is equally as functional and all tests pass. Application locks remain in place, but are redundant to the locking that occurs within C++ leveldb.  Our present Mutex locks harm concurrency, so it is planned that a future commit will remove these.

Completes tasks:

- [x] switch dep from rusty-leveldb to rs-leveldb and make code/tests compile. 
- [x] implement auto-destruction of database directories for tests 
- [x] get all tests passing without any test database directories persisting after test run. 
- [x] document deps to build with c++ impl.