### PR TITLE
fix: add StorageSetter::index() method

### DIFF
--- a/twenty-first/src/storage/storage_vec/iterators.rs
+++ b/twenty-first/src/storage/storage_vec/iterators.rs
@@ -90,6 +90,10 @@ where
         self.write_lock.set(self.index, value);
     }
 
+    pub fn index(&self) -> Index {
+        self.index
+    }
+
     pub fn value(&self) -> &T {
         &self.value
     }


### PR DESCRIPTION
This method is needed by neptune-core.    It was just an oversight it was not originally included.