### PR TITLE
improve `MerkleTree` implementation

### DIFF
--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -29,13 +29,19 @@ features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]
 
 [dependencies]
 arbitrary = { version = "1", features = ["derive"] }
-bincode = "1.3"
 bfieldcodec_derive = "0.5.2"
+bincode = "1.3"
 blake3 = "1.5.0"
 colored = "2.1"
 divan = "0.1.8"
+emojihash-rs = "0.2"
+get-size = { version = "^0.1.4", features = ["derive"] }
 hashbrown = "0.14"
 itertools = "0.12"
+keccak = "0.1.4"
+lazy_static = "1.4.0"
+lending-iterator = "0.1.7"
+leveldb-sys = "2.0.9"
 num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 phf = { version = "0.11", features = ["macros"] }
@@ -48,11 +54,6 @@ serde-big-array = "0"
 serde_derive = "1"
 serde_json = "1.0"
 thiserror = "1.0"
-emojihash-rs = "0.2"
-get-size = { version = "^0.1.4", features = ["derive"] }
-keccak = "0.1.4"
-leveldb-sys = "2.0.9"
-lending-iterator = "0.1.7"
 
 [[bench]]
 name = "tip5"

--- a/twenty-first/benches/merkle_tree.rs
+++ b/twenty-first/benches/merkle_tree.rs
@@ -18,7 +18,7 @@ fn merkle_tree(c: &mut Criterion) {
     let elements: Vec<Digest> = random_elements(size);
 
     group.bench_function(BenchmarkId::new("merkle_tree", size), |bencher| {
-        bencher.iter(|| -> MerkleTree<H> { CpuParallel::from_digests(&elements[..]) });
+        bencher.iter(|| -> MerkleTree<H> { CpuParallel::from_digests(&elements[..]).unwrap() });
     });
 }
 

--- a/twenty-first/benches/merkle_tree_auth_structure_size.rs
+++ b/twenty-first/benches/merkle_tree_auth_structure_size.rs
@@ -77,7 +77,7 @@ fn auth_structure_len(c: &mut Criterion<AuthStructureEncodingLength>) {
     let num_leaves = 1 << tree_height;
     let leaves = (0..num_leaves).map(|_| rng.next_u64()).collect_vec();
     let leaf_digests = leaves.iter().map(Tip5::hash).collect_vec();
-    let mt: MerkleTree<Tip5> = CpuParallel::from_digests(&leaf_digests);
+    let mt: MerkleTree<Tip5> = CpuParallel::from_digests(&leaf_digests).unwrap();
 
     let num_opened_indices = 40;
     let mut group = c.benchmark_group("merkle_tree_auth_structure_size");

--- a/twenty-first/benches/merkle_tree_auth_structure_size.rs
+++ b/twenty-first/benches/merkle_tree_auth_structure_size.rs
@@ -90,7 +90,7 @@ fn auth_structure_len(c: &mut Criterion<AuthStructureEncodingLength>) {
                     let opened_indices = (0..num_opened_indices)
                         .map(|_| rng.gen_range(0..num_leaves))
                         .collect_vec();
-                    let auth_structure = mt.get_authentication_structure(&opened_indices);
+                    let auth_structure = mt.authentication_structure(&opened_indices);
                     let this_len = auth_structure.encode().len();
                     let this_len = AuthStructureEncodingLength(this_len as f64);
                     total_len = total_len.add(&total_len, &this_len);

--- a/twenty-first/benches/merkle_tree_auth_structure_size.rs
+++ b/twenty-first/benches/merkle_tree_auth_structure_size.rs
@@ -90,7 +90,7 @@ fn auth_structure_len(c: &mut Criterion<AuthStructureEncodingLength>) {
                     let opened_indices = (0..num_opened_indices)
                         .map(|_| rng.gen_range(0..num_leaves))
                         .collect_vec();
-                    let auth_structure = mt.authentication_structure(&opened_indices);
+                    let auth_structure = mt.authentication_structure(&opened_indices).unwrap();
                     let this_len = auth_structure.encode().len();
                     let this_len = AuthStructureEncodingLength(this_len as f64);
                     total_len = total_len.add(&total_len, &this_len);

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -22,13 +22,13 @@ fn merkle_tree_authenticate(c: &mut Criterion) {
     let leaves = (0..num_leaves).map(|_| rng.next_u64()).collect_vec();
     let leaf_digests = leaves.iter().map(Tip5::hash).collect_vec();
     let mt: MerkleTree<Tip5> = CpuParallel::from_digests(&leaf_digests);
-    let mt_root = mt.get_root();
+    let mt_root = mt.root();
 
     let num_opened_indices = 40;
     let opened_indices = (0..num_opened_indices)
         .map(|_| rng.gen_range(0..num_leaves))
         .collect_vec();
-    let authentication_structure = mt.get_authentication_structure(&opened_indices);
+    let authentication_structure = mt.authentication_structure(&opened_indices);
     let opened_leaves = opened_indices
         .iter()
         .map(|&i| leaf_digests[i])
@@ -37,7 +37,7 @@ fn merkle_tree_authenticate(c: &mut Criterion) {
     let mut group = c.benchmark_group("merkle_tree_authenticate");
     group.bench_function(
         BenchmarkId::new("gen_auth_structure", num_leaves),
-        |bencher| bencher.iter(|| mt.get_authentication_structure(&opened_indices)),
+        |bencher| bencher.iter(|| mt.authentication_structure(&opened_indices)),
     );
     group.bench_function(
         BenchmarkId::new("verify_auth_structure", num_leaves),

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -2,7 +2,6 @@ use criterion::*;
 use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand::*;
-use std::marker::PhantomData;
 
 use twenty_first::shared_math::digest::Digest;
 use twenty_first::shared_math::tip5::Tip5;
@@ -84,15 +83,8 @@ impl MerkleTreeSampler {
     }
 
     fn proof(&mut self, tree: &MerkleTree<Tip5>) -> MerkleTreeInclusionProof<Tip5> {
-        let tree_height = tree.height();
-        assert_eq!(self.tree_height, tree_height);
         let leaf_indices = self.indices_to_open();
-
-        MerkleTreeInclusionProof {
-            tree_height,
-            indexed_leaves: tree.indexed_leaves(&leaf_indices).unwrap(),
-            authentication_structure: tree.authentication_structure(&leaf_indices).unwrap(),
-            _hasher: PhantomData,
-        }
+        tree.inclusion_proof_for_leaf_indices(&leaf_indices)
+            .unwrap()
     }
 }

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -87,16 +87,11 @@ impl MerkleTreeSampler {
         let tree_height = tree.height();
         assert_eq!(self.tree_height, tree_height);
         let leaf_indices = self.indices_to_open();
-        let leaf_digests = leaf_indices
-            .iter()
-            .map(|&i| tree.leaf(i).unwrap())
-            .collect();
-        let authentication_structure = tree.authentication_structure(&leaf_indices).unwrap();
+
         MerkleTreeInclusionProof {
             tree_height,
-            leaf_indices,
-            leaf_digests,
-            authentication_structure,
+            indexed_leaves: tree.indexed_leaves(&leaf_indices).unwrap(),
+            authentication_structure: tree.authentication_structure(&leaf_indices).unwrap(),
             _hasher: PhantomData,
         }
     }

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -1,5 +1,4 @@
 use criterion::*;
-use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand::*;
 

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -65,10 +65,10 @@ impl MerkleTreeSampler {
     }
 
     fn leaf_digests(&mut self) -> Vec<Digest> {
-        let leaves = (0..self.num_leaves())
+        (0..self.num_leaves())
             .map(|_| self.rng.next_u64())
-            .collect_vec();
-        leaves.iter().map(Tip5::hash).collect_vec()
+            .map(|leaf| Tip5::hash(&leaf))
+            .collect()
     }
 
     fn tree(&mut self) -> MerkleTree<Tip5> {

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -1,59 +1,125 @@
-use criterion::criterion_group;
-use criterion::criterion_main;
-use criterion::BenchmarkId;
-use criterion::Criterion;
+use criterion::*;
 use itertools::Itertools;
 use rand::rngs::StdRng;
-use rand::Rng;
-use rand::RngCore;
-use rand::SeedableRng;
+use rand::*;
 
+use twenty_first::shared_math::digest::Digest;
 use twenty_first::shared_math::tip5::Tip5;
 use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
-use twenty_first::util_types::merkle_tree::CpuParallel;
-use twenty_first::util_types::merkle_tree::MerkleTree;
+use twenty_first::util_types::merkle_tree::*;
 use twenty_first::util_types::merkle_tree_maker::MerkleTreeMaker;
 
-fn merkle_tree_authenticate(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(0);
+criterion_main!(merkle_tree_authenticate);
+criterion_group!(
+    merkle_tree_authenticate,
+    gen_auth_structure,
+    verify_auth_structure
+);
 
-    let tree_height = 22;
-    let num_leaves = 1 << tree_height;
-    let leaves = (0..num_leaves).map(|_| rng.next_u64()).collect_vec();
-    let leaf_digests = leaves.iter().map(Tip5::hash).collect_vec();
-    let mt: MerkleTree<Tip5> = CpuParallel::from_digests(&leaf_digests);
-    let mt_root = mt.root();
+fn gen_auth_structure(c: &mut Criterion) {
+    let mut sampler = MerkleTreeSampler::default();
+    let tree = sampler.tree();
 
-    let num_opened_indices = 40;
-    let opened_indices = (0..num_opened_indices)
-        .map(|_| rng.gen_range(0..num_leaves))
-        .collect_vec();
-    let authentication_structure = mt.authentication_structure(&opened_indices).unwrap();
-    let opened_leaves = opened_indices
-        .iter()
-        .map(|&i| leaf_digests[i])
-        .collect_vec();
+    c.bench_function("gen_auth_structure", |bencher| {
+        bencher.iter_batched(
+            || sampler.indices_to_open(),
+            |indices| tree.authentication_structure(&indices),
+            BatchSize::SmallInput,
+        )
+    });
+}
 
-    let mut group = c.benchmark_group("merkle_tree_authenticate");
-    group.bench_function(
-        BenchmarkId::new("gen_auth_structure", num_leaves),
-        |bencher| bencher.iter(|| mt.authentication_structure(&opened_indices)),
-    );
-    group.bench_function(
-        BenchmarkId::new("verify_auth_structure", num_leaves),
-        |bencher| {
-            bencher.iter(|| {
+fn verify_auth_structure(c: &mut Criterion) {
+    let mut sampler = MerkleTreeSampler::default();
+    let tree = sampler.tree();
+
+    c.bench_function("verify_auth_structure", |bencher| {
+        bencher.iter_batched(
+            || sampler.auth_info(&tree),
+            |auth_info| {
+                let MerkleTreeAuthInfo {
+                    root,
+                    tree_height,
+                    opened_indices,
+                    opened_leaves,
+                    auth_structure,
+                } = auth_info;
                 MerkleTree::<Tip5>::verify_authentication_structure(
-                    mt_root,
+                    root,
                     tree_height,
                     &opened_indices,
                     &opened_leaves,
-                    &authentication_structure,
+                    &auth_structure,
                 )
-            });
-        },
-    );
+            },
+            BatchSize::SmallInput,
+        );
+    });
 }
 
-criterion_group!(benches, merkle_tree_authenticate);
-criterion_main!(benches);
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MerkleTreeSampler {
+    rng: StdRng,
+    tree_height: usize,
+    num_opened_indices: usize,
+}
+
+impl Default for MerkleTreeSampler {
+    fn default() -> Self {
+        Self {
+            rng: StdRng::seed_from_u64(0),
+            tree_height: 22,
+            num_opened_indices: 40,
+        }
+    }
+}
+
+impl MerkleTreeSampler {
+    fn num_leaves(&self) -> usize {
+        1 << self.tree_height
+    }
+
+    fn leaf_digests(&mut self) -> Vec<Digest> {
+        let leaves = (0..self.num_leaves())
+            .map(|_| self.rng.next_u64())
+            .collect_vec();
+        leaves.iter().map(Tip5::hash).collect_vec()
+    }
+
+    fn tree(&mut self) -> MerkleTree<Tip5> {
+        let leaf_digests = self.leaf_digests();
+        CpuParallel::from_digests(&leaf_digests)
+    }
+
+    fn indices_to_open(&mut self) -> Vec<usize> {
+        (0..self.num_opened_indices)
+            .map(|_| self.rng.gen_range(0..self.num_leaves()))
+            .collect()
+    }
+
+    fn auth_info(&mut self, tree: &MerkleTree<Tip5>) -> MerkleTreeAuthInfo {
+        assert_eq!(self.tree_height, tree.height());
+        let opened_indices = self.indices_to_open();
+        let opened_leaves = opened_indices
+            .iter()
+            .map(|&i| tree.leaf(i).unwrap())
+            .collect_vec();
+        let auth_structure = tree.authentication_structure(&opened_indices).unwrap();
+        MerkleTreeAuthInfo {
+            root: tree.root(),
+            tree_height: tree.height(),
+            opened_indices,
+            opened_leaves,
+            auth_structure,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MerkleTreeAuthInfo {
+    root: Digest,
+    tree_height: usize,
+    opened_indices: Vec<usize>,
+    opened_leaves: Vec<Digest>,
+    auth_structure: Vec<Digest>,
+}

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -28,7 +28,7 @@ fn merkle_tree_authenticate(c: &mut Criterion) {
     let opened_indices = (0..num_opened_indices)
         .map(|_| rng.gen_range(0..num_leaves))
         .collect_vec();
-    let authentication_structure = mt.authentication_structure(&opened_indices);
+    let authentication_structure = mt.authentication_structure(&opened_indices).unwrap();
     let opened_leaves = opened_indices
         .iter()
         .map(|&i| leaf_digests[i])

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -88,7 +88,7 @@ impl MerkleTreeSampler {
 
     fn tree(&mut self) -> MerkleTree<Tip5> {
         let leaf_digests = self.leaf_digests();
-        CpuParallel::from_digests(&leaf_digests)
+        CpuParallel::from_digests(&leaf_digests).unwrap()
     }
 
     fn indices_to_open(&mut self) -> Vec<usize> {

--- a/twenty-first/src/test_shared.rs
+++ b/twenty-first/src/test_shared.rs
@@ -1,9 +1,1 @@
-use crate::shared_math::digest::Digest;
-
 pub mod mmr;
-
-pub fn corrupt_digest(digest: Digest) -> Digest {
-    let mut bad_elements = digest.values();
-    bad_elements[0].increment();
-    Digest::new(bad_elements)
-}

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -11,7 +11,6 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterato
 use thiserror::Error;
 
 use crate::shared_math::digest::Digest;
-use crate::shared_math::other::{is_power_of_two, log_2_floor};
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
 use crate::util_types::merkle_tree_maker::MerkleTreeMaker;
 
@@ -351,14 +350,14 @@ where
 
     pub fn num_leafs(&self) -> usize {
         let node_count = self.nodes.len();
-        assert!(is_power_of_two(node_count));
+        assert!(node_count.is_power_of_two());
         node_count / 2
     }
 
     pub fn height(&self) -> usize {
-        let leaf_count = self.num_leafs() as u128;
-        assert!(is_power_of_two(leaf_count));
-        log_2_floor(leaf_count) as usize
+        let leaf_count = self.num_leafs();
+        assert!(leaf_count.is_power_of_two());
+        leaf_count.ilog2() as usize
     }
 
     /// All leaves of the Merkle tree.
@@ -388,7 +387,7 @@ impl<H: AlgebraicHasher> MerkleTreeMaker<H> for CpuParallel {
         let leaves_count = digests.len();
 
         assert!(
-            is_power_of_two(leaves_count),
+            leaves_count.is_power_of_two(),
             "Size of input for Merkle tree must be a power of 2"
         );
 
@@ -913,7 +912,7 @@ pub mod merkle_tree_test {
         let exponent = 6;
         let num_leaves = usize::pow(2, exponent);
         assert!(
-            is_power_of_two(num_leaves),
+            num_leaves.is_power_of_two(),
             "Size of input for Merkle tree must be a power of 2"
         );
 
@@ -964,7 +963,7 @@ pub mod merkle_tree_test {
         let exponent = 6;
         let num_leaves = usize::pow(2, exponent);
         assert!(
-            is_power_of_two(num_leaves),
+            num_leaves.is_power_of_two(),
             "Size of input for Merkle tree must be a power of 2"
         );
 

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -583,6 +583,14 @@ pub mod merkle_tree_test {
     }
 
     #[proptest]
+    fn building_merkle_tree_from_one_digest_makes_that_digest_the_root(
+        #[strategy(arb())] digest: Digest,
+    ) {
+        let tree: MerkleTree<Tip5> = CpuParallel::from_digests(&[digest]).unwrap();
+        assert_eq!(digest, tree.root());
+    }
+
+    #[proptest]
     fn building_merkle_tree_from_list_of_digests_with_incorrect_number_of_leaves_fails_with_expected_error(
         #[filter(!#num_leaves.is_power_of_two())]
         #[strategy(1_usize..1 << 13)]

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -483,6 +483,7 @@ pub mod merkle_tree_test {
     use test_strategy::proptest;
 
     use crate::shared_math::b_field_element::BFieldElement;
+    use crate::shared_math::digest::digest_tests::DigestCorruptor;
     use crate::shared_math::other::{
         indices_of_set_bits, random_elements, random_elements_distinct_range, random_elements_range,
     };
@@ -556,6 +557,22 @@ pub mod merkle_tree_test {
             &test_tree.auth_structure,
         );
         prop_assert!(verified);
+    }
+
+    #[proptest]
+    fn corrupt_root_cannot_be_verified(
+        #[filter(#test_tree.selected_indices.len() > 0)] test_tree: MerkleTreeToTest,
+        corruptor: DigestCorruptor,
+    ) {
+        let bad_root = corruptor.corrupt_digest(test_tree.tree.root())?;
+        let verified = MerkleTree::<Tip5>::verify_authentication_structure(
+            bad_root,
+            test_tree.tree.height(),
+            &test_tree.selected_indices,
+            &test_tree.leaves,
+            &test_tree.auth_structure,
+        );
+        prop_assert!(!verified);
     }
 
     #[test]

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -522,6 +522,14 @@ pub mod merkle_tree_test {
             tree
         }
 
+        fn partial_test_tree_for_node_indices(node_indices: &[usize]) -> HashMap<usize, Digest> {
+            node_indices
+                .iter()
+                .map(|&i| (i, BFieldElement::new(i as u64)))
+                .map(|(i, leaf)| (i, Tip5::hash_varlen(&[leaf])))
+                .collect()
+        }
+
         fn leaves_by_indices(&self, leaf_indices: &[usize]) -> Vec<Digest> {
             // test helper: `.unwrap()` is fine
             leaf_indices
@@ -926,10 +934,8 @@ pub mod merkle_tree_test {
 
         let tree_height = 3;
         let opened_leaf_indices = [0, 2];
-        let mut partial_tree: HashMap<usize, Digest> = [3, 8, 9, 10, 11]
-            .into_iter()
-            .map(|i| (i, Tip5::hash_varlen(&[BFieldElement::new(i as u64)])))
-            .collect();
+        let mut partial_tree =
+            MerkleTree::<Tip5>::partial_test_tree_for_node_indices(&[3, 8, 9, 10, 11]);
         MerkleTree::<Tip5>::fill_partial_tree(&mut partial_tree, tree_height, &opened_leaf_indices)
             .unwrap();
     }
@@ -938,7 +944,7 @@ pub mod merkle_tree_test {
     fn trying_to_compute_root_of_partial_tree_with_necessary_node_missing_gives_expected_error() {
         //         ──── _ ────
         //        ╱           ╲
-        //       _             X
+        //       _             _ (!)
         //      ╱  ╲
         //     ╱    ╲
         //    _      _
@@ -949,10 +955,8 @@ pub mod merkle_tree_test {
 
         let tree_height = 3;
         let opened_leaf_indices = [0, 2];
-        let mut partial_tree: HashMap<usize, Digest> = [8, 9, 10, 11]
-            .into_iter()
-            .map(|i| (i, Tip5::hash_varlen(&[BFieldElement::new(i as u64)])))
-            .collect();
+        let mut partial_tree =
+            MerkleTree::<Tip5>::partial_test_tree_for_node_indices(&[8, 9, 10, 11]);
 
         let err = MerkleTree::<Tip5>::fill_partial_tree(
             &mut partial_tree,
@@ -978,10 +982,8 @@ pub mod merkle_tree_test {
 
         let tree_height = 3;
         let opened_leaf_indices = [0, 2];
-        let mut partial_tree: HashMap<usize, Digest> = [2, 3, 8, 9, 10, 11]
-            .into_iter()
-            .map(|i| (i, Tip5::hash_varlen(&[BFieldElement::new(i as u64)])))
-            .collect();
+        let mut partial_tree =
+            MerkleTree::<Tip5>::partial_test_tree_for_node_indices(&[2, 3, 8, 9, 10, 11]);
 
         let err = MerkleTree::<Tip5>::fill_partial_tree(
             &mut partial_tree,

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -38,7 +38,8 @@ impl<H> MerkleTree<H>
 where
     H: AlgebraicHasher,
 {
-    const MAX_NUM_LEAVES: usize = usize::MAX / 2;
+    const MAX_NUM_NODES: usize = 1 << 32;
+    const MAX_NUM_LEAVES: usize = Self::MAX_NUM_NODES / 2;
     pub const MAX_TREE_HEIGHT: usize = Self::MAX_NUM_LEAVES.ilog2() as usize;
 
     fn num_leaves(tree_height: usize) -> Result<usize> {

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -137,18 +137,17 @@ where
         {
             return true;
         }
-        let mut partial_tree = match Self::partial_tree_from_authentication_structure(
+        let Ok(mut partial_tree) = Self::partial_tree_from_authentication_structure(
             tree_height,
             leaf_indices,
             leaf_digests,
             authentication_structure,
-        ) {
-            Ok(tree) => tree,
-            Err(_) => return false,
-        };
-        if Self::fill_partial_tree(&mut partial_tree, tree_height, leaf_indices).is_err() {
+        ) else {
             return false;
-        }
+        };
+        let Ok(()) = Self::fill_partial_tree(&mut partial_tree, tree_height, leaf_indices) else {
+            return false;
+        };
         let computed_root = partial_tree[&1];
         computed_root == expected_root
     }

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -355,10 +355,20 @@ where
         leaf_count.ilog2() as usize
     }
 
+    /// All nodes of the Merkle tree.
+    pub fn nodes(&self) -> &[Digest] {
+        &self.nodes
+    }
+
+    /// The node at the given node index, if it exists.
+    pub fn node(&self, index: usize) -> Option<Digest> {
+        self.nodes.get(index).copied()
+    }
+
     /// All leaves of the Merkle tree.
-    pub fn leaves(&self) -> Vec<Digest> {
+    pub fn leaves(&self) -> &[Digest] {
         let first_leaf = self.nodes.len() / 2;
-        self.nodes[first_leaf..].to_vec()
+        &self.nodes[first_leaf..]
     }
 
     /// The leaf at the given index, if it exists.

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -15,9 +15,7 @@ use crate::shared_math::digest::Digest;
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
 use crate::util_types::merkle_tree_maker::MerkleTreeMaker;
 
-/// Chosen from a very small number of benchmark runs, optimized for a slow hash function (the original Rescue Prime
-/// implementation). It should probably be a higher number than 16 when using a faster hash function.
-const DEFAULT_PARALLELIZATION_CUTOFF: usize = 16;
+const DEFAULT_PARALLELIZATION_CUTOFF: usize = 256;
 
 lazy_static! {
     static ref PARALLELIZATION_CUTOFF: usize = env::var("MERKLE_TREE_PARALLELIZATION_CUTOFF")

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -736,6 +736,22 @@ pub mod merkle_tree_test {
         prop_assert!(!verdict);
     }
 
+    #[proptest(cases = 30)]
+    fn honestly_generated_proof_with_duplicate_leaves_can_be_verified(
+        #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
+        #[strategy(vec(0..#test_tree.proof().indexed_leaves.len(), 1..=#test_tree.proof().indexed_leaves.len()))]
+        indices_to_duplicate: Vec<usize>,
+    ) {
+        let mut proof = test_tree.proof();
+        let duplicate_leaves = indices_to_duplicate
+            .into_iter()
+            .map(|i| proof.indexed_leaves[i])
+            .collect_vec();
+        proof.indexed_leaves.extend(duplicate_leaves);
+        let verdict = proof.verify(test_tree.tree.root());
+        prop_assert!(verdict);
+    }
+
     #[proptest(cases = 40)]
     fn incorrect_tree_height_leads_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -615,6 +615,14 @@ pub mod merkle_tree_test {
         assert_eq!(MerkleTreeError::TooFewLeaves, err);
     }
 
+    #[test]
+    fn merkle_tree_with_one_leaf_has_expected_height_and_number_of_leaves() {
+        let digest = Digest::default();
+        let tree: MerkleTree<Tip5> = CpuParallel::from_digests(&[digest]).unwrap();
+        assert_eq!(1, tree.num_leafs());
+        assert_eq!(0, tree.height());
+    }
+
     #[proptest]
     fn building_merkle_tree_from_one_digest_makes_that_digest_the_root(
         #[strategy(arb())] digest: Digest,

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -546,6 +546,24 @@ pub mod merkle_tree_test {
     }
 
     #[proptest]
+    fn trivial_proof_can_be_verified(#[strategy(arb())] merkle_tree: MerkleTree<Tip5>) {
+        let leaf_indices = [];
+        let leaf_digests = [];
+
+        let proof = merkle_tree.authentication_structure(&leaf_indices).unwrap();
+        prop_assert!(proof.is_empty());
+
+        let verdict = MerkleTree::<Tip5>::verify_authentication_structure(
+            merkle_tree.root(),
+            merkle_tree.height(),
+            &leaf_indices,
+            &leaf_digests,
+            &proof,
+        );
+        prop_assert!(verdict);
+    }
+
+    #[proptest]
     fn honestly_generated_authentication_structure_can_be_verified(test_tree: MerkleTreeToTest) {
         let verified = MerkleTree::<Tip5>::verify_authentication_structure(
             test_tree.tree.root(),
@@ -615,25 +633,6 @@ pub mod merkle_tree_test {
             &test_tree.auth_structure,
         );
         prop_assert!(!verified);
-    }
-
-    #[test]
-    fn merkle_tree_verify_authentication_structure_degenerate_test() {
-        type H = blake3::Hasher;
-        type M = CpuParallel;
-        type MT = MerkleTree<H>;
-
-        let tree_height = 5;
-        let num_leaves = 1 << tree_height;
-        let leaves: Vec<Digest> = random_elements(num_leaves);
-        let tree: MT = M::from_digests(&leaves);
-
-        let empty_proof = tree.authentication_structure(&[]).unwrap();
-        assert!(empty_proof.is_empty());
-
-        let empty_proof_verifies =
-            MT::verify_authentication_structure(tree.root(), tree_height, &[], &[], &empty_proof);
-        assert!(empty_proof_verifies);
     }
 
     #[test]

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -24,7 +24,7 @@ type Result<T> = result::Result<T, MerkleTreeError>;
 /// Static methods are called from the verifier, who does not have the original `MerkleTree` object, but only partial
 /// information from it, in the form of the quadruples: `(root_hash, index, digest, auth_path)`. These are exactly the
 /// arguments for the `verify_*` family of static methods.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MerkleTree<H>
 where
     H: AlgebraicHasher,

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -594,6 +594,26 @@ pub mod merkle_tree_test {
         }
     }
 
+    #[test]
+    fn building_merkle_tree_from_empty_list_of_digests_fails_with_expected_error() {
+        let maybe_tree: Result<MerkleTree<Tip5>> = CpuParallel::from_digests(&[]);
+        let err = maybe_tree.unwrap_err();
+        assert_eq!(MerkleTreeError::TooFewLeaves, err);
+    }
+
+    #[proptest]
+    fn building_merkle_tree_from_list_of_digests_with_incorrect_number_of_leaves_fails_with_expected_error(
+        #[filter(!#num_leaves.is_power_of_two())]
+        #[strategy(1_usize..1 << 13)]
+        num_leaves: usize,
+    ) {
+        let digest = Digest::default();
+        let digests = vec![digest; num_leaves];
+        let maybe_tree: Result<MerkleTree<Tip5>> = CpuParallel::from_digests(&digests);
+        let err = maybe_tree.unwrap_err();
+        assert_eq!(MerkleTreeError::IncorrectNumberOfLeaves, err);
+    }
+
     #[proptest]
     fn accessing_number_of_leaves_and_height_never_panics(
         #[strategy(arb())] merkle_tree: MerkleTree<Tip5>,

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -595,7 +595,7 @@ pub mod merkle_tree_test {
         assert_eq!(MerkleTreeError::IncorrectNumberOfLeaves, err);
     }
 
-    #[proptest]
+    #[proptest(cases = 100)]
     fn accessing_number_of_leaves_and_height_never_panics(
         #[strategy(arb())] merkle_tree: MerkleTree<Tip5>,
     ) {
@@ -603,7 +603,7 @@ pub mod merkle_tree_test {
         let _ = merkle_tree.height();
     }
 
-    #[proptest]
+    #[proptest(cases = 50)]
     fn trivial_proof_can_be_verified(#[strategy(arb())] merkle_tree: MerkleTree<Tip5>) {
         let leaf_indices = [];
         let leaf_digests = [];
@@ -621,7 +621,7 @@ pub mod merkle_tree_test {
         prop_assert!(verdict);
     }
 
-    #[proptest]
+    #[proptest(cases = 40)]
     fn honestly_generated_authentication_structure_can_be_verified(test_tree: MerkleTreeToTest) {
         let verified = MerkleTree::<Tip5>::verify_authentication_structure(
             test_tree.tree.root(),
@@ -633,7 +633,7 @@ pub mod merkle_tree_test {
         prop_assert!(verified);
     }
 
-    #[proptest]
+    #[proptest(cases = 30)]
     fn corrupt_root_leads_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
         corruptor: DigestCorruptor,
@@ -649,7 +649,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verified);
     }
 
-    #[proptest]
+    #[proptest(cases = 50)]
     fn supplying_too_many_indices_leads_to_verification_failure(
         test_tree: MerkleTreeToTest,
         #[strategy(vec(0..#test_tree.tree.num_leafs(), 1..100))] spurious_indices: Vec<usize>,
@@ -666,7 +666,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verified);
     }
 
-    #[proptest]
+    #[proptest(cases = 50)]
     fn supplying_too_few_indices_leads_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
         #[strategy(vec(0..#test_tree.selected_indices.len(), 1..=#test_tree.selected_indices.len()))]
@@ -693,7 +693,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verified);
     }
 
-    #[proptest]
+    #[proptest(cases = 20)]
     fn corrupt_authentication_structure_leads_to_verification_failure(
         #[filter(!#test_tree.auth_structure.is_empty())] test_tree: MerkleTreeToTest,
         #[strategy(vec(0..#test_tree.auth_structure.len(), 1..=#test_tree.auth_structure.len()))]
@@ -719,7 +719,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verified);
     }
 
-    #[proptest]
+    #[proptest(cases = 30)]
     fn corrupt_leaf_digests_lead_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
         #[strategy(vec(0..#test_tree.leaves.len(), 1..=#test_tree.leaves.len()))]
@@ -746,7 +746,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verified);
     }
 
-    #[proptest]
+    #[proptest(cases = 40)]
     fn incorrect_tree_height_leads_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
         #[strategy(0..=MerkleTree::<Tip5>::MAX_TREE_HEIGHT)]
@@ -766,7 +766,7 @@ pub mod merkle_tree_test {
     /// The property-test framework can already select the same leaves multiple times. However, this
     /// a. ensures that property, making the test explicit instead of implicit, and
     /// b. ensures the property holds even for an already-generated proof.
-    #[proptest]
+    #[proptest(cases = 30)]
     fn honestly_generated_proof_with_duplicate_leaves_can_be_verified(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
         #[strategy(vec(0..#test_tree.selected_indices.len(), 1..=#test_tree.selected_indices.len()))]
@@ -794,7 +794,7 @@ pub mod merkle_tree_test {
         prop_assert!(verified);
     }
 
-    #[proptest]
+    #[proptest(cases = 20)]
     fn honestly_generated_proof_with_all_leaves_revealed_can_be_verified(
         #[strategy(arb())] tree: MerkleTree<Tip5>,
     ) {
@@ -857,7 +857,7 @@ pub mod merkle_tree_test {
         assert_eq!(auth_path_with_nodes([14, 6, 2]), auth_path_for_leaf(7));
     }
 
-    #[proptest(cases = 50)]
+    #[proptest(cases = 10)]
     fn each_leaf_can_be_verified_individually(test_tree: MerkleTreeToTest) {
         let tree = test_tree.tree;
         for (leaf_index, &leaf) in tree.leaves().iter().enumerate() {

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -376,17 +376,6 @@ where
         );
         self.nodes[first_leaf_index + index]
     }
-
-    pub fn leaves_by_indices(&self, leaf_indices: &[usize]) -> Vec<Digest> {
-        let leaf_count = leaf_indices.len();
-
-        let mut result = Vec::with_capacity(leaf_count);
-
-        for index in leaf_indices {
-            result.push(self.leaf(*index));
-        }
-        result
-    }
 }
 
 #[derive(Debug)]
@@ -483,6 +472,15 @@ pub mod merkle_tree_test {
     use crate::util_types::shared::bag_peaks;
 
     use super::*;
+
+    impl<H> MerkleTree<H>
+    where
+        H: AlgebraicHasher,
+    {
+        fn leaves_by_indices(&self, leaf_indices: &[usize]) -> Vec<Digest> {
+            leaf_indices.iter().map(|&i| self.leaf(i)).collect()
+        }
+    }
 
     /// Calculate a Merkle root from a list of digests of arbitrary length.
     pub fn root_from_arbitrary_number_of_digests<H: AlgebraicHasher>(digests: &[Digest]) -> Digest {

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -345,13 +345,13 @@ where
 
     pub fn num_leafs(&self) -> usize {
         let node_count = self.nodes.len();
-        assert!(node_count.is_power_of_two());
+        debug_assert!(node_count.is_power_of_two());
         node_count / 2
     }
 
     pub fn height(&self) -> usize {
         let leaf_count = self.num_leafs();
-        assert!(leaf_count.is_power_of_two());
+        debug_assert!(leaf_count.is_power_of_two());
         leaf_count.ilog2() as usize
     }
 
@@ -520,6 +520,14 @@ pub mod merkle_tree_test {
         }
         let roots = trees.iter().map(|t| t.root()).collect_vec();
         bag_peaks::<H>(&roots)
+    }
+
+    #[proptest]
+    fn accessing_number_of_leaves_and_height_never_panics(
+        #[strategy(arb())] merkle_tree: MerkleTree<Tip5>,
+    ) {
+        let _ = merkle_tree.num_leafs();
+        let _ = merkle_tree.height();
     }
 
     #[proptest]

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -57,7 +57,7 @@ where
     fn indices_of_nodes_in_authentication_structure(
         num_nodes: usize,
         leaf_indices: &[usize],
-    ) -> Result<Vec<usize>> {
+    ) -> Result<impl ExactSizeIterator<Item = usize>> {
         let num_leaves = num_nodes / 2;
         let root_index = 1;
 
@@ -88,7 +88,7 @@ where
         }
 
         let set_difference = node_is_needed.difference(&node_can_be_computed).cloned();
-        Ok(set_difference.sorted_unstable().rev().collect())
+        Ok(set_difference.sorted_unstable().rev())
     }
 
     /// Generate a de-duplicated authentication structure for the given leaf indices.
@@ -126,7 +126,7 @@ where
     pub fn authentication_structure(&self, leaf_indices: &[usize]) -> Result<Vec<Digest>> {
         let num_nodes = self.nodes.len();
         let indices = Self::indices_of_nodes_in_authentication_structure(num_nodes, leaf_indices)?;
-        let auth_structure = indices.into_iter().map(|idx| self.nodes[idx]).collect();
+        let auth_structure = indices.map(|idx| self.nodes[idx]).collect();
         Ok(auth_structure)
     }
 
@@ -201,7 +201,6 @@ where
         }
 
         let mut partial_merkle_tree: HashMap<_, _> = indices_of_nodes_in_authentication_structure
-            .into_iter()
             .zip(authentication_structure.iter().copied())
             .collect();
 
@@ -806,7 +805,8 @@ pub mod merkle_tree_test {
             tree_a.num_leafs() * 2,
             &[leaf_index_a],
         )
-        .unwrap();
+        .unwrap()
+        .collect_vec();
         assert_eq!(vec![7, 2], needed_nodes);
 
         // 1: Create Merkle tree

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -575,6 +575,23 @@ pub mod merkle_tree_test {
         prop_assert!(!verified);
     }
 
+    #[proptest]
+    fn supplying_too_many_indices_leads_to_verification_failure(
+        test_tree: MerkleTreeToTest,
+        #[strategy(vec(0..#test_tree.tree.num_leafs(), 1..100))] spurious_indices: Vec<usize>,
+    ) {
+        let mut all_indices = test_tree.selected_indices.clone();
+        all_indices.extend(spurious_indices);
+        let verified = MerkleTree::<Tip5>::verify_authentication_structure(
+            test_tree.tree.root(),
+            test_tree.tree.height(),
+            &all_indices,
+            &test_tree.leaves,
+            &test_tree.auth_structure,
+        );
+        prop_assert!(!verified);
+    }
+
     #[test]
     fn merkle_tree_test_32() {
         type H = blake3::Hasher;

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -208,6 +208,9 @@ where
         Ok(indexed_leaves.collect())
     }
 
+    /// A full inclusion proof for the leaves at the supplied indices, including the leaves. Generally, using
+    /// [`authentication_structure`](Self::authentication_structure) is preferable. Use this method only if the
+    /// verifier needs explicit access to the leaves, _i.e._, cannot compute them from other information.
     pub fn inclusion_proof_for_leaf_indices(
         &self,
         indices: &[usize],

--- a/twenty-first/src/util_types/merkle_tree_maker.rs
+++ b/twenty-first/src/util_types/merkle_tree_maker.rs
@@ -1,7 +1,7 @@
 use crate::shared_math::digest::Digest;
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
-use crate::util_types::merkle_tree::MerkleTree;
+use crate::util_types::merkle_tree::*;
 
 pub trait MerkleTreeMaker<H: AlgebraicHasher> {
-    fn from_digests(digests: &[Digest]) -> MerkleTree<H>;
+    fn from_digests(digests: &[Digest]) -> Result<MerkleTree<H>, MerkleTreeError>;
 }

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -374,7 +374,7 @@ mod mmr_test {
         root_from_arbitrary_number_of_digests::<Tip5>(&[]);
     }
 
-    #[proptest]
+    #[proptest(cases = 30)]
     fn mmr_root_of_arbitrary_number_of_leaves_is_merkle_root_when_number_of_leaves_is_a_power_of_two(
         test_tree: MerkleTreeToTest,
     ) {


### PR DESCRIPTION
- [x] don't panic, return `Err(…)`
- [x] remove prefix `get_` from methods' names
- [x] rely on built-in methods more
- [x] allow (read-only) access to internal nodes (fix #134)
- [x] make all `Arbitrary` instances legal
- [x] use `proptest` framework
- [x] assess if further refactors are beneficial
  - [x] reduce length of argument lists
  - [x] introduce additional `struct`s, in particular, `MerkleTreeInclusionProof` and `PartialMerkleTree`