### PR TITLE
Lock notifications pr

### DIFF
--- a/twenty-first/src/storage/storage_schema/dbtsingleton.rs
+++ b/twenty-first/src/storage/storage_schema/dbtsingleton.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, sync::Arc};
 use super::{
     dbtsingleton_private::DbtSingletonPrivate, traits::*, RustyKey, RustyValue, WriteOperation,
 };
-use crate::sync::AtomicRw;
+use crate::sync::{AtomicRw, LockCallbackFn};
 use serde::{de::DeserializeOwned, Serialize};
 
 /// Singleton type created by [`super::DbtSchema`]
@@ -40,7 +40,12 @@ where
 {
     // DbtSingleton can not be instantiated directly outside of this crate.
     #[inline]
-    pub(crate) fn new(key: RustyKey, reader: Arc<dyn StorageReader + Sync + Send>) -> Self {
+    pub(crate) fn new(
+        key: RustyKey,
+        lock_name: String,
+        reader: Arc<dyn StorageReader + Sync + Send>,
+        lock_callback_fn: Option<LockCallbackFn>,
+    ) -> Self {
         let singleton = DbtSingletonPrivate::<V> {
             current_value: Default::default(),
             old_value: Default::default(),
@@ -48,7 +53,7 @@ where
             reader,
         };
         Self {
-            inner: AtomicRw::from(singleton),
+            inner: AtomicRw::from((singleton, Some(lock_name), lock_callback_fn)),
         }
     }
 }

--- a/twenty-first/src/storage/storage_schema/dbtvec.rs
+++ b/twenty-first/src/storage/storage_schema/dbtvec.rs
@@ -2,7 +2,7 @@ use super::super::storage_vec::traits::*;
 use super::super::storage_vec::Index;
 use super::dbtvec_private::DbtVecPrivate;
 use super::{traits::*, RustyValue, VecWriteOperation, WriteOperation};
-use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
+use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard, LockCallbackFn};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, sync::Arc};
 
@@ -42,27 +42,40 @@ where
         reader: Arc<dyn StorageReader + Send + Sync>,
         key_prefix: u8,
         name: &str,
+        lock_name: String,
+        lock_callback_fn: Option<LockCallbackFn>,
     ) -> Self {
         let vec = DbtVecPrivate::<V>::new(reader, key_prefix, name);
 
         Self {
-            inner: AtomicRw::from(vec),
+            inner: AtomicRw::from((vec, Some(lock_name), lock_callback_fn)),
         }
     }
 }
 
-impl<V> StorageVecRwLock<V> for DbtVec<V> {
-    type LockedData = DbtVecPrivate<V>;
-
+impl<T> DbtVec<T> {
     #[inline]
-    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
+    pub(crate) fn write_lock(&self) -> AtomicRwWriteGuard<'_, DbtVecPrivate<T>> {
         self.inner.lock_guard_mut()
     }
 
-    // This is a private method, but we allow unit tests in super to use it.
     #[inline]
-    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
+    pub(crate) fn read_lock(&self) -> AtomicRwReadGuard<'_, DbtVecPrivate<T>> {
         self.inner.lock_guard()
+    }
+}
+
+impl<T> StorageVecRwLock<T> for DbtVec<T> {
+    type LockedData = DbtVecPrivate<T>;
+
+    #[inline]
+    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
+        Some(self.write_lock())
+    }
+
+    #[inline]
+    fn try_read_lock(&self) -> Option<AtomicRwReadGuard<'_, Self::LockedData>> {
+        Some(self.read_lock())
     }
 }
 

--- a/twenty-first/src/storage/storage_schema/dbtvec.rs
+++ b/twenty-first/src/storage/storage_schema/dbtvec.rs
@@ -2,12 +2,9 @@ use super::super::storage_vec::traits::*;
 use super::super::storage_vec::Index;
 use super::dbtvec_private::DbtVecPrivate;
 use super::{traits::*, RustyValue, VecWriteOperation, WriteOperation};
-use crate::sync::AtomicRw;
+use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
 use serde::{de::DeserializeOwned, Serialize};
-use std::{
-    fmt::Debug,
-    sync::{Arc, RwLockReadGuard, RwLockWriteGuard},
-};
+use std::{fmt::Debug, sync::Arc};
 
 /// A DB-backed Vec for use with DBSchema
 ///
@@ -58,13 +55,13 @@ impl<V> StorageVecRwLock<V> for DbtVec<V> {
     type LockedData = DbtVecPrivate<V>;
 
     #[inline]
-    fn write_lock(&self) -> RwLockWriteGuard<'_, Self::LockedData> {
+    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
         self.inner.lock_guard_mut()
     }
 
     // This is a private method, but we allow unit tests in super to use it.
     #[inline]
-    fn read_lock(&self) -> RwLockReadGuard<'_, Self::LockedData> {
+    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
         self.inner.lock_guard()
     }
 }

--- a/twenty-first/src/storage/storage_schema/simple_rusty_storage.rs
+++ b/twenty-first/src/storage/storage_schema/simple_rusty_storage.rs
@@ -1,7 +1,7 @@
 use super::super::level_db::DB;
 use super::enums::WriteOperation;
 use super::{traits::StorageWriter, DbtSchema, SimpleRustyReader};
-use crate::sync::AtomicRw;
+use crate::sync::LockCallbackFn;
 use leveldb::batch::WriteBatch;
 use std::sync::Arc;
 
@@ -49,10 +49,19 @@ impl SimpleRustyStorage {
     /// Create a new SimpleRustyStorage
     #[inline]
     pub fn new(db: DB) -> Self {
-        let schema = DbtSchema::<SimpleRustyReader> {
-            tables: AtomicRw::from(Vec::new()),
-            reader: Arc::new(SimpleRustyReader { db }),
-        };
+        let schema =
+            DbtSchema::<SimpleRustyReader>::new(Arc::new(SimpleRustyReader { db }), None, None);
+        Self { schema }
+    }
+
+    /// Create a new SimpleRustyStorage and provide a
+    /// name and lock acquisition callback for tracing
+    pub fn new_with_callback(db: DB, storage_name: &str, lock_callback_fn: LockCallbackFn) -> Self {
+        let schema = DbtSchema::<SimpleRustyReader>::new(
+            Arc::new(SimpleRustyReader { db }),
+            Some(storage_name),
+            Some(lock_callback_fn),
+        );
         Self { schema }
     }
 

--- a/twenty-first/src/storage/storage_vec/iterators.rs
+++ b/twenty-first/src/storage/storage_vec/iterators.rs
@@ -1,9 +1,9 @@
 use super::{traits::*, Index};
+use crate::sync::AtomicRwWriteGuard;
 use lending_iterator::prelude::*;
 use lending_iterator::{gat, LendingIterator};
 use std::iter::Iterator;
 use std::marker::PhantomData;
-use std::sync::RwLockWriteGuard;
 
 /// A mutating iterator for [`StorageVec`] trait
 ///
@@ -17,7 +17,7 @@ where
     V: StorageVec<T> + StorageVecRwLock<T> + ?Sized,
 {
     indices: Box<dyn Iterator<Item = Index>>,
-    write_lock: RwLockWriteGuard<'a, V::LockedData>,
+    write_lock: AtomicRwWriteGuard<'a, V::LockedData>,
     phantom_t: PhantomData<T>,
     phantom_d: PhantomData<V>,
 }
@@ -75,7 +75,7 @@ where
     V: StorageVec<T> + StorageVecRwLock<T> + ?Sized,
 {
     phantom: PhantomData<V>,
-    write_lock: &'d mut RwLockWriteGuard<'c, V::LockedData>,
+    write_lock: &'d mut AtomicRwWriteGuard<'c, V::LockedData>,
     index: Index,
     value: T,
 }

--- a/twenty-first/src/storage/storage_vec/ordinary_vec.rs
+++ b/twenty-first/src/storage/storage_vec/ordinary_vec.rs
@@ -13,6 +13,32 @@ impl<T> From<Vec<T>> for OrdinaryVec<T> {
     }
 }
 
+impl<T> OrdinaryVec<T> {
+    #[inline]
+    pub(crate) fn write_lock(&self) -> AtomicRwWriteGuard<'_, OrdinaryVecPrivate<T>> {
+        self.0.lock_guard_mut()
+    }
+
+    #[inline]
+    pub(crate) fn read_lock(&self) -> AtomicRwReadGuard<'_, OrdinaryVecPrivate<T>> {
+        self.0.lock_guard()
+    }
+}
+
+impl<T> StorageVecRwLock<T> for OrdinaryVec<T> {
+    type LockedData = OrdinaryVecPrivate<T>;
+
+    #[inline]
+    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
+        Some(self.write_lock())
+    }
+
+    #[inline]
+    fn try_read_lock(&self) -> Option<AtomicRwReadGuard<'_, Self::LockedData>> {
+        Some(self.read_lock())
+    }
+}
+
 impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
     #[inline]
     fn is_empty(&self) -> bool {
@@ -91,20 +117,6 @@ impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
     #[inline]
     fn clear(&self) {
         self.write_lock().clear();
-    }
-}
-
-impl<T> StorageVecRwLock<T> for OrdinaryVec<T> {
-    type LockedData = OrdinaryVecPrivate<T>;
-
-    #[inline]
-    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
-        self.0.lock_guard_mut()
-    }
-
-    #[inline]
-    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
-        self.0.lock_guard()
     }
 }
 

--- a/twenty-first/src/storage/storage_vec/ordinary_vec.rs
+++ b/twenty-first/src/storage/storage_vec/ordinary_vec.rs
@@ -1,7 +1,6 @@
 use super::ordinary_vec_private::OrdinaryVecPrivate;
 use super::{traits::*, Index};
-use crate::sync::AtomicRw;
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
 
 /// A wrapper that adds [`RwLock`](std::sync::RwLock) and atomic snapshot
 /// guarantees around all accesses to an ordinary [`Vec`]
@@ -99,12 +98,12 @@ impl<T> StorageVecRwLock<T> for OrdinaryVec<T> {
     type LockedData = OrdinaryVecPrivate<T>;
 
     #[inline]
-    fn write_lock(&self) -> RwLockWriteGuard<'_, Self::LockedData> {
+    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
         self.0.lock_guard_mut()
     }
 
     #[inline]
-    fn read_lock(&self) -> RwLockReadGuard<'_, Self::LockedData> {
+    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
         self.0.lock_guard()
     }
 }

--- a/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
+++ b/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
@@ -125,17 +125,29 @@ impl<T: Serialize + DeserializeOwned + Clone> StorageVec<T> for RustyLevelDbVec<
     }
 }
 
-impl<T: Serialize + DeserializeOwned> StorageVecRwLock<T> for RustyLevelDbVec<T> {
-    type LockedData = RustyLevelDbVecPrivate<T>;
-
+impl<T: Serialize + DeserializeOwned> RustyLevelDbVec<T> {
     #[inline]
-    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
+    pub(crate) fn write_lock(&self) -> AtomicRwWriteGuard<'_, RustyLevelDbVecPrivate<T>> {
         self.inner.lock_guard_mut()
     }
 
     #[inline]
-    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
+    pub(crate) fn read_lock(&self) -> AtomicRwReadGuard<'_, RustyLevelDbVecPrivate<T>> {
         self.inner.lock_guard()
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> StorageVecRwLock<T> for RustyLevelDbVec<T> {
+    type LockedData = RustyLevelDbVecPrivate<T>;
+
+    #[inline]
+    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
+        Some(self.write_lock())
+    }
+
+    #[inline]
+    fn try_read_lock(&self) -> Option<AtomicRwReadGuard<'_, Self::LockedData>> {
+        Some(self.read_lock())
     }
 }
 

--- a/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
+++ b/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
@@ -1,11 +1,10 @@
 use super::super::level_db::DB;
 use super::rusty_leveldb_vec_private::RustyLevelDbVecPrivate;
 use super::{traits::*, Index};
-use crate::sync::AtomicRw;
+use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
 use leveldb::batch::WriteBatch;
 use serde::{de::DeserializeOwned, Serialize};
 use std::sync::Arc;
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 /// A concurrency safe database-backed Vec with in memory read/write caching for all operations.
 #[derive(Debug, Clone)]
@@ -130,12 +129,12 @@ impl<T: Serialize + DeserializeOwned> StorageVecRwLock<T> for RustyLevelDbVec<T>
     type LockedData = RustyLevelDbVecPrivate<T>;
 
     #[inline]
-    fn write_lock(&self) -> RwLockWriteGuard<'_, Self::LockedData> {
+    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
         self.inner.lock_guard_mut()
     }
 
     #[inline]
-    fn read_lock(&self) -> RwLockReadGuard<'_, Self::LockedData> {
+    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
         self.inner.lock_guard()
     }
 }

--- a/twenty-first/src/storage/storage_vec/traits.rs
+++ b/twenty-first/src/storage/storage_vec/traits.rs
@@ -412,10 +412,10 @@ pub(in super::super) trait StorageVecRwLock<T> {
     type LockedData;
 
     /// obtain write lock over mutable data.
-    fn write_lock(&self) -> AtomicRwWriteGuard<Self::LockedData>;
+    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<Self::LockedData>>;
 
     /// obtain read lock over mutable data.
-    fn read_lock(&self) -> AtomicRwReadGuard<Self::LockedData>;
+    fn try_read_lock(&self) -> Option<AtomicRwReadGuard<Self::LockedData>>;
 }
 
 pub(in super::super) trait StorageVecIterMut<T>: StorageVec<T> {}

--- a/twenty-first/src/storage/storage_vec/traits.rs
+++ b/twenty-first/src/storage/storage_vec/traits.rs
@@ -5,7 +5,7 @@
 
 // use super::iterators::{ManyIterMut, StorageSetter};
 use super::{Index, ManyIterMut};
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+use crate::sync::{AtomicRwReadGuard, AtomicRwWriteGuard};
 
 // re-export to make life easier for users of our API.
 pub use lending_iterator::LendingIterator;
@@ -412,10 +412,10 @@ pub(in super::super) trait StorageVecRwLock<T> {
     type LockedData;
 
     /// obtain write lock over mutable data.
-    fn write_lock(&self) -> RwLockWriteGuard<Self::LockedData>;
+    fn write_lock(&self) -> AtomicRwWriteGuard<Self::LockedData>;
 
     /// obtain read lock over mutable data.
-    fn read_lock(&self) -> RwLockReadGuard<Self::LockedData>;
+    fn read_lock(&self) -> AtomicRwReadGuard<Self::LockedData>;
 }
 
 pub(in super::super) trait StorageVecIterMut<T>: StorageVec<T> {}

--- a/twenty-first/src/sync/atomic_mutex.rs
+++ b/twenty-first/src/sync/atomic_mutex.rs
@@ -1,4 +1,6 @@
 use super::traits::Atomic;
+use super::{LockAcquisition, LockCallbackFn, LockCallbackInfo, LockEvent, LockType};
+use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 /// An `Arc<Mutex<T>>` wrapper to make data thread-safe and easy to work with.
@@ -13,53 +15,198 @@ use std::sync::{Arc, Mutex, MutexGuard};
 /// atomic_car.lock(|c| println!("year: {}", c.year));
 /// atomic_car.lock_mut(|mut c| c.year = 2023);
 /// ```
-#[derive(Debug, Default, Clone)]
-pub struct AtomicMutex<T>(Arc<Mutex<T>>);
+///
+/// It is also possible to provide a name and callback fn
+/// during instantiation.  In this way, the application
+/// can easily trace lock acquisitions.
+///
+/// # Examples
+/// ```
+/// # use twenty_first::sync::{AtomicMutex, LockEvent, LockCallbackFn};
+/// struct Car {
+///     year: u16,
+/// };
+///
+/// pub fn log_lock_event(lock_event: LockEvent) {
+///     let (event, info, acquisition) =
+///     match lock_event {
+///         LockEvent::TryAcquire{info, acquisition} => ("TryAcquire", info, acquisition),
+///         LockEvent::Acquire{info, acquisition} => ("Acquire", info, acquisition),
+///         LockEvent::Release{info, acquisition} => ("Release", info, acquisition),
+///     };
+///
+///     println!(
+///         "{} lock `{}` of type `{}` for `{}` by\n\t|-- thread {}, `{:?}`",
+///         event,
+///         info.name().unwrap_or("?"),
+///         info.lock_type(),
+///         acquisition,
+///         std::thread::current().name().unwrap_or("?"),
+///         std::thread::current().id(),
+///     );
+/// }
+/// const LOG_LOCK_EVENT_CB: LockCallbackFn = log_lock_event;
+///
+/// let atomic_car = AtomicMutex::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
+/// atomic_car.lock(|c| {println!("year: {}", c.year)});
+/// atomic_car.lock_mut(|mut c| {c.year = 2023});
+/// ```
+///
+/// results in:
+/// ```text
+/// TryAcquire lock `car` of type `Mutex` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// Acquire lock `car` of type `Mutex` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// year: 2016
+/// Release lock `car` of type `Mutex` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// TryAcquire lock `car` of type `Mutex` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// Acquire lock `car` of type `Mutex` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// Release lock `car` of type `Mutex` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// ```
+#[derive(Debug)]
+pub struct AtomicMutex<T> {
+    inner: Arc<Mutex<T>>,
+    lock_callback_info: LockCallbackInfo,
+}
+
+impl<T: Default> Default for AtomicMutex<T> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, None, None),
+        }
+    }
+}
+
 impl<T> From<T> for AtomicMutex<T> {
     #[inline]
     fn from(t: T) -> Self {
-        Self(Arc::new(Mutex::new(t)))
+        Self {
+            inner: Arc::new(Mutex::new(t)),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, None, None),
+        }
+    }
+}
+impl<T> From<(T, Option<String>, Option<LockCallbackFn>)> for AtomicMutex<T> {
+    /// Create from an optional name and an optional callback function, which
+    /// is called when a lock event occurs.
+    #[inline]
+    fn from(v: (T, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(v.0)),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, v.1, v.2),
+        }
+    }
+}
+impl<T> From<(T, Option<&str>, Option<LockCallbackFn>)> for AtomicMutex<T> {
+    /// Create from a name ref and an optional callback function, which
+    /// is called when a lock event occurs.
+    #[inline]
+    fn from(v: (T, Option<&str>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(v.0)),
+            lock_callback_info: LockCallbackInfo::new(
+                LockType::Mutex,
+                v.1.map(|s| s.to_owned()),
+                v.2,
+            ),
+        }
+    }
+}
+
+impl<T> Clone for AtomicMutex<T> {
+    fn clone(&self) -> Self {
+        Self {
+            lock_callback_info: self.lock_callback_info.clone(),
+            inner: self.inner.clone(),
+        }
     }
 }
 
 impl<T> From<Mutex<T>> for AtomicMutex<T> {
     #[inline]
     fn from(t: Mutex<T>) -> Self {
-        Self(Arc::new(t))
+        Self {
+            inner: Arc::new(t),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, None, None),
+        }
+    }
+}
+impl<T> From<(Mutex<T>, Option<String>, Option<LockCallbackFn>)> for AtomicMutex<T> {
+    /// Create from an `Mutex<T>` plus an optional name
+    /// and an optional callback function, which is called
+    /// when a lock event occurs.
+    #[inline]
+    fn from(v: (Mutex<T>, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(v.0),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, v.1, v.2),
+        }
     }
 }
 
 impl<T> TryFrom<AtomicMutex<T>> for Mutex<T> {
     type Error = Arc<Mutex<T>>;
-
-    #[inline]
     fn try_from(t: AtomicMutex<T>) -> Result<Mutex<T>, Self::Error> {
-        Arc::<Mutex<T>>::try_unwrap(t.0)
+        Arc::<Mutex<T>>::try_unwrap(t.inner)
     }
 }
 
 impl<T> From<Arc<Mutex<T>>> for AtomicMutex<T> {
     #[inline]
     fn from(t: Arc<Mutex<T>>) -> Self {
-        Self(t)
+        Self {
+            inner: t,
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, None, None),
+        }
+    }
+}
+impl<T> From<(Arc<Mutex<T>>, Option<String>, Option<LockCallbackFn>)> for AtomicMutex<T> {
+    /// Create from an `Arc<Mutex<T>>` plus an optional name and
+    /// an optional callback function, which is called when a lock
+    /// event occurs.
+    #[inline]
+    fn from(v: (Arc<Mutex<T>>, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: v.0,
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, v.1, v.2),
+        }
     }
 }
 
 impl<T> From<AtomicMutex<T>> for Arc<Mutex<T>> {
     #[inline]
     fn from(t: AtomicMutex<T>) -> Self {
-        t.0
+        t.inner
     }
 }
 
 // note: we impl the Atomic trait methods here also so they
 // can be used without caller having to use the trait.
 impl<T> AtomicMutex<T> {
-    /// Acquire lock and return a `MutexGuard`
-    ///
-    /// note: this method is exactly the same as [`lock_guard_mut()`](Self::lock_guard_mut).
-    /// It exists only for compatibility with [`AtomicRw`](super::AtomicRw) so
-    /// they can be used interchangeably.
+    pub const fn const_new(
+        t: Arc<Mutex<T>>,
+        name: Option<String>,
+        lock_callback_fn: Option<LockCallbackFn>,
+    ) -> Self {
+        Self {
+            inner: t,
+            lock_callback_info: LockCallbackInfo {
+                lock_info_owned: crate::sync::shared::LockInfoOwned {
+                    name,
+                    lock_type: LockType::Mutex,
+                },
+                lock_callback_fn,
+            },
+        }
+    }
+
+    /// Acquire read lock and return an `AtomicMutexGuard`
     ///
     /// # Examples
     /// ```
@@ -68,13 +215,15 @@ impl<T> AtomicMutex<T> {
     ///     year: u16,
     /// };
     /// let atomic_car = AtomicMutex::from(Car{year: 2016});
-    /// atomic_car.lock_guard().year = 2022;
+    /// let year = atomic_car.lock_guard().year;
     /// ```
-    pub fn lock_guard(&self) -> MutexGuard<T> {
-        self.0.lock().expect("Mutex lock should succeed")
+    pub fn lock_guard(&self) -> AtomicMutexGuard<T> {
+        self.try_acquire_read_cb();
+        let guard = self.inner.lock().expect("Read lock should succeed");
+        AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Read)
     }
 
-    /// Acquire lock and return a `MutexGuard`
+    /// Acquire write lock and return an `AtomicMutexGuard`
     ///
     /// # Examples
     /// ```
@@ -85,13 +234,15 @@ impl<T> AtomicMutex<T> {
     /// let atomic_car = AtomicMutex::from(Car{year: 2016});
     /// atomic_car.lock_guard_mut().year = 2022;
     /// ```
-    pub fn lock_guard_mut(&self) -> MutexGuard<T> {
-        self.0.lock().expect("Mutex lock should succeed")
+    pub fn lock_guard_mut(&self) -> AtomicMutexGuard<T> {
+        self.try_acquire_write_cb();
+        let guard = self.inner.lock().expect("Write lock should succeed");
+        AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Write)
     }
 
-    /// Immutably access the data of type `T` in a closure and return a result
+    /// Immutably access the data of type `T` in a closure and possibly return a result of type `R`
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use twenty_first::sync::{AtomicMutex, traits::*};
     /// struct Car {
@@ -105,36 +256,42 @@ impl<T> AtomicMutex<T> {
     where
         F: FnOnce(&T) -> R,
     {
-        let mut lock = self.0.lock().expect("Write lock should succeed");
-        f(&mut lock)
+        self.try_acquire_read_cb();
+        let guard = self.inner.lock().expect("Read lock should succeed");
+        let my_guard =
+            AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Read);
+        f(&my_guard)
     }
 
-    /// Mutably access the data of type `T` in a closure and return a result
+    /// Mutably access the data of type `T` in a closure and possibly return a result of type `R`
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use twenty_first::sync::{AtomicMutex, traits::*};
     /// struct Car {
     ///     year: u16,
     /// };
     /// let atomic_car = AtomicMutex::from(Car{year: 2016});
-    /// atomic_car.lock_mut(|mut c| c.year = 2022);
+    /// atomic_car.lock_mut(|mut c| {c.year = 2022});
     /// let year = atomic_car.lock_mut(|mut c| {c.year = 2023; c.year});
     /// ```
     pub fn lock_mut<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
-        let mut lock = self.0.lock().expect("Write lock should succeed");
-        f(&mut lock)
+        self.try_acquire_write_cb();
+        let guard = self.inner.lock().expect("Write lock should succeed");
+        let mut my_guard =
+            AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Write);
+        f(&mut my_guard)
     }
 
     /// get copy of the locked value T (if T implements Copy).
     ///
     /// # Example
     /// ```
-    /// # use twenty_first::sync::{AtomicRw, traits::*};
-    /// let atomic_u64 = AtomicRw::from(25u64);
+    /// # use twenty_first::sync::{AtomicMutex, traits::*};
+    /// let atomic_u64 = AtomicMutex::from(25u64);
     /// let age = atomic_u64.get();
     /// ```
     #[inline]
@@ -149,8 +306,8 @@ impl<T> AtomicMutex<T> {
     ///
     /// # Example
     /// ```
-    /// # use twenty_first::sync::{AtomicRw, traits::*};
-    /// let atomic_bool = AtomicRw::from(false);
+    /// # use twenty_first::sync::{AtomicMutex, traits::*};
+    /// let atomic_bool = AtomicMutex::from(false);
     /// atomic_bool.set(true);
     /// ```
     #[inline]
@@ -160,9 +317,34 @@ impl<T> AtomicMutex<T> {
     {
         self.lock_mut(|v| *v = value)
     }
+
+    /// retrieve lock name if present, or None
+    #[inline]
+    pub fn name(&self) -> Option<&str> {
+        self.lock_callback_info.lock_info_owned.name.as_deref()
+    }
+
+    fn try_acquire_read_cb(&self) {
+        if let Some(cb) = self.lock_callback_info.lock_callback_fn {
+            cb(LockEvent::TryAcquire {
+                info: self.lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Read,
+            });
+        }
+    }
+
+    fn try_acquire_write_cb(&self) {
+        if let Some(cb) = self.lock_callback_info.lock_callback_fn {
+            cb(LockEvent::TryAcquire {
+                info: self.lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Write,
+            });
+        }
+    }
 }
 
 impl<T> Atomic<T> for AtomicMutex<T> {
+    #[inline]
     fn lock<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&T) -> R,
@@ -170,6 +352,7 @@ impl<T> Atomic<T> for AtomicMutex<T> {
         AtomicMutex::<T>::lock(self, f)
     }
 
+    #[inline]
     fn lock_mut<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
@@ -178,12 +361,66 @@ impl<T> Atomic<T> for AtomicMutex<T> {
     }
 }
 
+/// A wrapper for [MutexGuard](std::sync::MutexGuard) that
+/// can optionally call a callback to notify when the
+/// lock event occurs
+pub struct AtomicMutexGuard<'a, T> {
+    guard: MutexGuard<'a, T>,
+    lock_callback_info: &'a LockCallbackInfo,
+    acquisition: LockAcquisition,
+}
+
+impl<'a, T> AtomicMutexGuard<'a, T> {
+    fn new(
+        guard: MutexGuard<'a, T>,
+        lock_callback_info: &'a LockCallbackInfo,
+        acquisition: LockAcquisition,
+    ) -> Self {
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Acquire {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition,
+            });
+        }
+        Self {
+            guard,
+            lock_callback_info,
+            acquisition,
+        }
+    }
+}
+
+impl<'a, T> Drop for AtomicMutexGuard<'a, T> {
+    fn drop(&mut self) {
+        let lock_callback_info = self.lock_callback_info;
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Release {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: self.acquisition,
+            });
+        }
+    }
+}
+
+impl<'a, T> Deref for AtomicMutexGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<'a, T> DerefMut for AtomicMutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    // Verify (compile-time) that AtomicRw::lock() and ::lock_mut() accept mutable values.  (FnOnce)
+    // Verify (compile-time) that AtomicMutex::lock() and ::lock_mut() accept mutable values.  (FnMut)
     fn mutable_assignment() {
         let name = "Jim".to_string();
         let atomic_name = AtomicMutex::from(name);

--- a/twenty-first/src/sync/atomic_rw.rs
+++ b/twenty-first/src/sync/atomic_rw.rs
@@ -1,4 +1,7 @@
+use super::shared::LockAcquisition;
 use super::traits::Atomic;
+use super::{LockCallbackFn, LockCallbackInfo, LockEvent, LockType};
+use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// An `Arc<RwLock<T>>` wrapper to make data thread-safe and easy to work with.
@@ -13,46 +16,174 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// atomic_car.lock(|c| println!("year: {}", c.year));
 /// atomic_car.lock_mut(|mut c| c.year = 2023);
 /// ```
-#[derive(Debug, Default)]
-pub struct AtomicRw<T>(Arc<RwLock<T>>);
+///
+/// It is also possible to provide a name and callback fn
+/// during instantiation.  In this way, the application
+/// can easily trace lock acquisitions.
+///
+/// # Examples
+/// ```
+/// # use twenty_first::sync::{AtomicRw, LockEvent, LockCallbackFn};
+/// struct Car {
+///     year: u16,
+/// };
+///
+/// pub fn log_lock_event(lock_event: LockEvent) {
+///     let (event, info, acquisition) =
+///     match lock_event {
+///         LockEvent::TryAcquire{info, acquisition} => ("TryAcquire", info, acquisition),
+///         LockEvent::Acquire{info, acquisition} => ("Acquire", info, acquisition),
+///         LockEvent::Release{info, acquisition} => ("Release", info, acquisition),
+///     };
+///
+///     println!(
+///         "{} lock `{}` of type `{}` for `{}` by\n\t|-- thread {}, `{:?}`",
+///         event,
+///         info.name().unwrap_or("?"),
+///         info.lock_type(),
+///         acquisition,
+///         std::thread::current().name().unwrap_or("?"),
+///         std::thread::current().id(),
+///     );
+/// }
+/// const LOG_LOCK_EVENT_CB: LockCallbackFn = log_lock_event;
+///
+/// let atomic_car = AtomicRw::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
+/// atomic_car.lock(|c| {println!("year: {}", c.year)});
+/// atomic_car.lock_mut(|mut c| {c.year = 2023});
+/// ```
+///
+/// results in:
+/// ```text
+/// TryAcquire lock `car` of type `RwLock` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// Acquire lock `car` of type `RwLock` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// year: 2016
+/// Release lock `car` of type `RwLock` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// TryAcquire lock `car` of type `RwLock` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// Acquire lock `car` of type `RwLock` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// Release lock `car` of type `RwLock` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// ```
+#[derive(Debug)]
+pub struct AtomicRw<T> {
+    inner: Arc<RwLock<T>>,
+    lock_callback_info: LockCallbackInfo,
+}
+
+impl<T: Default> Default for AtomicRw<T> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, None, None),
+        }
+    }
+}
+
 impl<T> From<T> for AtomicRw<T> {
     #[inline]
     fn from(t: T) -> Self {
-        Self(Arc::new(RwLock::new(t)))
+        Self {
+            inner: Arc::new(RwLock::new(t)),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, None, None),
+        }
+    }
+}
+impl<T> From<(T, Option<String>, Option<LockCallbackFn>)> for AtomicRw<T> {
+    /// Create from an optional name and an optional callback function, which
+    /// is called when a lock is event occurs.
+    #[inline]
+    fn from(v: (T, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(v.0)),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, v.1, v.2),
+        }
+    }
+}
+impl<T> From<(T, Option<&str>, Option<LockCallbackFn>)> for AtomicRw<T> {
+    /// Create from a name ref and an optional callback function, which
+    /// is called when a lock event occurs.
+    #[inline]
+    fn from(v: (T, Option<&str>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(v.0)),
+            lock_callback_info: LockCallbackInfo::new(
+                LockType::RwLock,
+                v.1.map(|s| s.to_owned()),
+                v.2,
+            ),
+        }
     }
 }
 
 impl<T> Clone for AtomicRw<T> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            lock_callback_info: self.lock_callback_info.clone(),
+            inner: self.inner.clone(),
+        }
     }
 }
 
 impl<T> From<RwLock<T>> for AtomicRw<T> {
     #[inline]
     fn from(t: RwLock<T>) -> Self {
-        Self(Arc::new(t))
+        Self {
+            inner: Arc::new(t),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, None, None),
+        }
+    }
+}
+impl<T> From<(RwLock<T>, Option<String>, Option<LockCallbackFn>)> for AtomicRw<T> {
+    /// Create from an `RwLock<T>` plus an optional name
+    /// and an optional callback function, which is called
+    /// when a lock event occurs.
+    #[inline]
+    fn from(v: (RwLock<T>, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(v.0),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, v.1, v.2),
+        }
     }
 }
 
 impl<T> TryFrom<AtomicRw<T>> for RwLock<T> {
     type Error = Arc<RwLock<T>>;
     fn try_from(t: AtomicRw<T>) -> Result<RwLock<T>, Self::Error> {
-        Arc::<RwLock<T>>::try_unwrap(t.0)
+        Arc::<RwLock<T>>::try_unwrap(t.inner)
     }
 }
 
 impl<T> From<Arc<RwLock<T>>> for AtomicRw<T> {
     #[inline]
     fn from(t: Arc<RwLock<T>>) -> Self {
-        Self(t)
+        Self {
+            inner: t,
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, None, None),
+        }
+    }
+}
+impl<T> From<(Arc<RwLock<T>>, Option<String>, Option<LockCallbackFn>)> for AtomicRw<T> {
+    /// Create from an `Arc<RwLock<T>>` plus an optional name and
+    /// an optional callback function, which is called when a lock
+    /// event occurs.
+    #[inline]
+    fn from(v: (Arc<RwLock<T>>, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: v.0,
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, v.1, v.2),
+        }
     }
 }
 
 impl<T> From<AtomicRw<T>> for Arc<RwLock<T>> {
     #[inline]
     fn from(t: AtomicRw<T>) -> Self {
-        t.0
+        t.inner
     }
 }
 
@@ -70,8 +201,10 @@ impl<T> AtomicRw<T> {
     /// let atomic_car = AtomicRw::from(Car{year: 2016});
     /// let year = atomic_car.lock_guard().year;
     /// ```
-    pub fn lock_guard(&self) -> RwLockReadGuard<T> {
-        self.0.read().expect("Read lock should succeed")
+    pub fn lock_guard(&self) -> AtomicRwReadGuard<T> {
+        self.try_acquire_read_cb();
+        let guard = self.inner.read().expect("Read lock should succeed");
+        AtomicRwReadGuard::new(guard, &self.lock_callback_info)
     }
 
     /// Acquire write lock and return an `RwLockWriteGuard`
@@ -85,8 +218,10 @@ impl<T> AtomicRw<T> {
     /// let atomic_car = AtomicRw::from(Car{year: 2016});
     /// atomic_car.lock_guard_mut().year = 2022;
     /// ```
-    pub fn lock_guard_mut(&self) -> RwLockWriteGuard<T> {
-        self.0.write().expect("Write lock should succeed")
+    pub fn lock_guard_mut(&self) -> AtomicRwWriteGuard<T> {
+        self.try_acquire_write_cb();
+        let guard = self.inner.write().expect("Write lock should succeed");
+        AtomicRwWriteGuard::new(guard, &self.lock_callback_info)
     }
 
     /// Immutably access the data of type `T` in a closure and possibly return a result of type `R`
@@ -105,8 +240,10 @@ impl<T> AtomicRw<T> {
     where
         F: FnOnce(&T) -> R,
     {
-        let lock = self.0.read().expect("Read lock should succeed");
-        f(&lock)
+        self.try_acquire_read_cb();
+        let guard = self.inner.read().expect("Read lock should succeed");
+        let my_guard = AtomicRwReadGuard::new(guard, &self.lock_callback_info);
+        f(&my_guard)
     }
 
     /// Mutably access the data of type `T` in a closure and possibly return a result of type `R`
@@ -125,10 +262,20 @@ impl<T> AtomicRw<T> {
     where
         F: FnOnce(&mut T) -> R,
     {
-        let mut lock = self.0.write().expect("Write lock should succeed");
-        f(&mut lock)
+        self.try_acquire_write_cb();
+        let guard = self.inner.write().expect("Write lock should succeed");
+        let mut my_guard = AtomicRwWriteGuard::new(guard, &self.lock_callback_info);
+        f(&mut my_guard)
     }
 
+    /// get copy of the locked value T (if T implements Copy).
+    ///
+    /// # Example
+    /// ```
+    /// # use twenty_first::sync::{AtomicRw, traits::*};
+    /// let atomic_u64 = AtomicRw::from(25u64);
+    /// let age = atomic_u64.get();
+    /// ```
     #[inline]
     pub fn get(&self) -> T
     where
@@ -137,12 +284,44 @@ impl<T> AtomicRw<T> {
         self.lock(|v| *v)
     }
 
+    /// set the locked value T (if T implements Copy).
+    ///
+    /// # Example
+    /// ```
+    /// # use twenty_first::sync::{AtomicRw, traits::*};
+    /// let atomic_bool = AtomicRw::from(false);
+    /// atomic_bool.set(true);
+    /// ```
     #[inline]
     pub fn set(&self, value: T)
     where
         T: Copy,
     {
         self.lock_mut(|v| *v = value)
+    }
+
+    /// retrieve lock name if present, or None
+    #[inline]
+    pub fn name(&self) -> Option<&str> {
+        self.lock_callback_info.lock_info_owned.name.as_deref()
+    }
+
+    fn try_acquire_read_cb(&self) {
+        if let Some(cb) = self.lock_callback_info.lock_callback_fn {
+            cb(LockEvent::TryAcquire {
+                info: self.lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Read,
+            });
+        }
+    }
+
+    fn try_acquire_write_cb(&self) {
+        if let Some(cb) = self.lock_callback_info.lock_callback_fn {
+            cb(LockEvent::TryAcquire {
+                info: self.lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Write,
+            });
+        }
     }
 }
 
@@ -161,6 +340,96 @@ impl<T> Atomic<T> for AtomicRw<T> {
         F: FnOnce(&mut T) -> R,
     {
         AtomicRw::<T>::lock_mut(self, f)
+    }
+}
+
+/// A wrapper for [RwLockReadGuard](std::sync::RwLockReadGuard) that
+/// can optionally call a callback to notify when a
+/// lock event occurs.
+pub struct AtomicRwReadGuard<'a, T> {
+    guard: RwLockReadGuard<'a, T>,
+    lock_callback_info: &'a LockCallbackInfo,
+}
+
+impl<'a, T> AtomicRwReadGuard<'a, T> {
+    fn new(guard: RwLockReadGuard<'a, T>, lock_callback_info: &'a LockCallbackInfo) -> Self {
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Acquire {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Read,
+            });
+        }
+        Self {
+            guard,
+            lock_callback_info,
+        }
+    }
+}
+
+impl<'a, T> Drop for AtomicRwReadGuard<'a, T> {
+    fn drop(&mut self) {
+        let lock_callback_info = self.lock_callback_info;
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Release {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Read,
+            });
+        }
+    }
+}
+
+impl<'a, T> Deref for AtomicRwReadGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+/// A wrapper for [RwLockWriteGuard](std::sync::RwLockWriteGuard) that
+/// can optionally call a callback to notify when the
+/// a lock event occurs.
+pub struct AtomicRwWriteGuard<'a, T> {
+    guard: RwLockWriteGuard<'a, T>,
+    lock_callback_info: &'a LockCallbackInfo,
+}
+
+impl<'a, T> AtomicRwWriteGuard<'a, T> {
+    fn new(guard: RwLockWriteGuard<'a, T>, lock_callback_info: &'a LockCallbackInfo) -> Self {
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Acquire {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Write,
+            });
+        }
+        Self {
+            guard,
+            lock_callback_info,
+        }
+    }
+}
+
+impl<'a, T> Drop for AtomicRwWriteGuard<'a, T> {
+    fn drop(&mut self) {
+        let lock_callback_info = self.lock_callback_info;
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Release {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Write,
+            });
+        }
+    }
+}
+
+impl<'a, T> Deref for AtomicRwWriteGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<'a, T> DerefMut for AtomicRwWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
     }
 }
 

--- a/twenty-first/src/sync/mod.rs
+++ b/twenty-first/src/sync/mod.rs
@@ -2,7 +2,11 @@
 
 mod atomic_mutex;
 mod atomic_rw;
+mod shared;
 pub mod traits;
 
 pub use atomic_mutex::AtomicMutex;
-pub use atomic_rw::AtomicRw;
+pub use atomic_rw::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
+pub use shared::{LockAcquisition, LockCallbackFn, LockEvent, LockInfo, LockType};
+
+use shared::LockCallbackInfo;

--- a/twenty-first/src/sync/shared.rs
+++ b/twenty-first/src/sync/shared.rs
@@ -1,0 +1,108 @@
+/// Indicates the lock's underlying type
+#[derive(Debug, Clone, Copy)]
+pub enum LockType {
+    Mutex,
+    RwLock,
+}
+
+impl std::fmt::Display for LockType {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mutex => write!(f, "Mutex"),
+            Self::RwLock => write!(f, "RwLock"),
+        }
+    }
+}
+
+/// Indicates how a lock was acquired.
+#[derive(Debug, Clone, Copy)]
+pub enum LockAcquisition {
+    Read,
+    Write,
+}
+
+impl std::fmt::Display for LockAcquisition {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read => write!(f, "Read"),
+            Self::Write => write!(f, "Write"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct LockInfoOwned {
+    pub name: Option<String>,
+    pub lock_type: LockType,
+}
+impl LockInfoOwned {
+    #[inline]
+    pub fn as_lock_info(&self) -> LockInfo<'_> {
+        LockInfo {
+            name: self.name.as_deref(),
+            lock_type: self.lock_type,
+        }
+    }
+}
+
+/// Contains metadata about a lock
+#[derive(Debug, Clone)]
+pub struct LockInfo<'a> {
+    name: Option<&'a str>,
+    lock_type: LockType,
+}
+impl<'a> LockInfo<'a> {
+    /// get the lock's name
+    #[inline]
+    pub fn name(&self) -> Option<&str> {
+        self.name
+    }
+
+    /// get the lock's type
+    #[inline]
+    pub fn lock_type(&self) -> LockType {
+        self.lock_type
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct LockCallbackInfo {
+    pub lock_info_owned: LockInfoOwned,
+    pub lock_callback_fn: Option<LockCallbackFn>,
+}
+impl LockCallbackInfo {
+    #[inline]
+    pub fn new(
+        lock_type: LockType,
+        name: Option<String>,
+        lock_callback_fn: Option<LockCallbackFn>,
+    ) -> Self {
+        Self {
+            lock_info_owned: LockInfoOwned { name, lock_type },
+            lock_callback_fn,
+        }
+    }
+}
+
+/// Represents an event (acquire/release) for a lock
+#[derive(Debug, Clone)]
+pub enum LockEvent<'a> {
+    TryAcquire {
+        info: LockInfo<'a>,
+        acquisition: LockAcquisition,
+    },
+    Acquire {
+        info: LockInfo<'a>,
+        acquisition: LockAcquisition,
+    },
+    Release {
+        info: LockInfo<'a>,
+        acquisition: LockAcquisition,
+    },
+}
+
+/// A callback fn for receiving [LockEvent] event
+/// each time a lock is acquired or released.
+pub type LockCallbackFn = fn(lock_event: LockEvent);


### PR DESCRIPTION
This PR consists of two commits that:

1) Adds an optional lock name and event callback fn to `AtomicRw` and `AtomicMutex`, which enables applications to log/trace all lock events  (TryAcquire, Acquire, Release).

2) makes use of the event callback functionality within the `Storage` types, again in a way that is optional for the application.

**Breaking Changes:**

There is one breaking API change that I'm aware of.   I added a field to `DbtSchema` which previously could only be created by direct struct {..} instantiation.   So there is no way to add a field in a non-breaking way.   This pr also adds DbtSchema::new(). 


**Motivation:**

I wanted to be able to log/trace all lock events in neptune-core, to be able to track which threads and tokio tasks are using each lock and in what manner.   For this, each lock needs to have a unique name.  

**Design Decisions:**

*How to impl Release event*.   A lock is not released until the corresponding lock guard is dropped.  For the `lock_guard()` and `lock_guard_mut()` methods this is a problem because the caller directly holds the guards.  I found a solution by wrapping the guard with a wrapper eg `AtomicMutexGuard`, which impls `Deref` and `DerefMut`.  So now the caller uses the wrapper just as they would a guard from the std lib.

*Callback or not.*  It perhaps would have been simpler to just log/trace within twenty-first without using any callback function.  I decided to go with the callback approach because:
* I wanted to also log tokio task identifiers, and twenty-first has no dep on tokio.
* I didn't want to make any assumptions about application's log/trace facilities or output format
* this just seems a more flexible approach.

*modify storage API or not*.  It might be cleaner to pass the lock name to `DbtSchema::new_vec()` and `DbtSchema::new_singleton()` however that would be a breaking change.  Instead I used existing parameters and the `DbtSchema` name to auto generate a lock name.

**Reviewing:**

I suggest to start review by looking at the changes in crate::sync, followed by changes in crate::storage.   The latter wil make more sense that way.

**Example**

Example log output that this PR enables, from a callback fn in neptune-core:

```
2024-01-08T17:42:06.746452Z TRACE block_template_is_valid_test: neptune_core: TryAcquire lock `RustyArchivalMutatorSet-Schema-DbtVec - aocl` of type `RwLock` for `Read` by
        |-- thread 74, (`mine_loop::mine_loop_tests::block_template_is_valid_test`)
        |-- tokio task ?
        |-- lock_event=TryAcquire { info: LockInfo { name: Some("RustyArchivalMutatorSet-Schema-DbtVec - aocl"), lock_type: RwLock }, acquisition: Read }
2024-01-08T17:42:06.746613Z TRACE block_template_is_valid_test: neptune_core: Acquire lock `RustyArchivalMutatorSet-Schema-DbtVec - aocl` of type `RwLock` for `Read` by
        |-- thread 74, (`mine_loop::mine_loop_tests::block_template_is_valid_test`)
        |-- tokio task ?
        |-- lock_event=Acquire { info: LockInfo { name: Some("RustyArchivalMutatorSet-Schema-DbtVec - aocl"), lock_type: RwLock }, acquisition: Read }
2024-01-08T17:42:06.746686Z TRACE block_template_is_valid_test: neptune_core: Release lock `RustyArchivalMutatorSet-Schema-DbtVec - aocl` of type `RwLock` for `Read` by
        |-- thread 74, (`mine_loop::mine_loop_tests::block_template_is_valid_test`)
        |-- tokio task ?
        |-- lock_event=Release { info: LockInfo { name: Some("RustyArchivalMutatorSet-Schema-DbtVec - aocl"), lock_type: RwLock }, acquisition: Read }
```

(note: tokio task id is not displaying in neptune-core tests for some reason and displays as "?".  That's unrelated to this PR.)


