### PR TITLE
Fix potential db-key collission for singleton and dbtvec length

### DIFF
--- a/twenty-first/src/storage/storage_schema/dbtsingleton_private.rs
+++ b/twenty-first/src/storage/storage_schema/dbtsingleton_private.rs
@@ -1,15 +1,15 @@
 use super::traits::*;
-use super::RustyKey;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 // note: no locking is required in `DbtSingletonPrivate` because locking
 // is performed in the `DbtSingleton` public wrapper.
 pub(crate) struct DbtSingletonPrivate<V> {
+    pub(super) key: u8,
     pub(super) current_value: V,
     pub(super) old_value: V,
-    pub(super) key: RustyKey,
     pub(super) reader: Arc<dyn StorageReader + Sync + Send>,
+    pub(super) name: String,
 }
 
 impl<V> Debug for DbtSingletonPrivate<V>
@@ -18,15 +18,25 @@ where
 {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         f.debug_struct("DbtSingletonPrivate")
+            .field("key", &self.key)
             .field("current_value", &self.current_value)
             .field("old_value", &self.old_value)
-            .field("key", &self.key)
             .field("reader", &"Arc<dyn StorageReader + Send + Sync>")
+            .field("name", &self.name)
             .finish()
     }
 }
 
-impl<V: Clone> DbtSingletonPrivate<V> {
+impl<V: Clone + Default> DbtSingletonPrivate<V> {
+    pub(super) fn new(key: u8, reader: Arc<dyn StorageReader + Sync + Send>, name: String) -> Self {
+        Self {
+            key,
+            current_value: Default::default(),
+            old_value: Default::default(),
+            reader,
+            name: name.to_owned(),
+        }
+    }
     pub(super) fn get(&self) -> V {
         self.current_value.clone()
     }

--- a/twenty-first/src/storage/storage_schema/mod.rs
+++ b/twenty-first/src/storage/storage_schema/mod.rs
@@ -86,7 +86,7 @@ mod tests {
         assert_eq!(1, Arc::strong_count(&rusty_storage.schema.reader));
         let singleton = rusty_storage
             .schema
-            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+            .new_singleton::<S>("singleton".to_owned());
         assert_eq!(2, Arc::strong_count(&rusty_storage.schema.reader));
 
         // initialize
@@ -128,7 +128,7 @@ mod tests {
         let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
         let new_singleton = new_rusty_storage
             .schema
-            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+            .new_singleton::<S>("singleton".to_owned());
         new_rusty_storage.restore_or_new();
 
         // test
@@ -645,6 +645,36 @@ mod tests {
     }
 
     #[test]
+    fn singleton_vector_key_collission() {
+        let db = DB::open_new_test_database(false, None, None, None).unwrap();
+        let db_path = db.path().clone();
+        let mut rusty_storage = SimpleRustyStorage::new(db);
+        let vector1 = rusty_storage.schema.new_vec::<u64>("test-vector1");
+        let singleton = rusty_storage
+            .schema
+            .new_singleton::<u64>("singleton-1".to_owned());
+
+        // initialize
+        rusty_storage.restore_or_new();
+        assert!(vector1.is_empty());
+        singleton.set(1776u64);
+        assert!(vector1.is_empty());
+        rusty_storage.persist();
+        assert!(vector1.is_empty());
+
+        drop(rusty_storage); // <-- DB ref dropped
+        drop(vector1); //       <-- DB ref dropped
+        drop(singleton); //     <-- final DB ref dropped (DB closes)
+
+        // re-open DB / restore from disk
+        let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
+        let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
+        let new_vector1 = new_rusty_storage.schema.new_vec::<S>("test-vector1");
+        new_rusty_storage.restore_or_new();
+        assert!(new_vector1.is_empty());
+    }
+
+    #[test]
     fn test_two_vectors_and_singleton() {
         let singleton_value = S([3u8, 3u8, 3u8, 1u8].to_vec());
 
@@ -657,7 +687,7 @@ mod tests {
         let vector2 = rusty_storage.schema.new_vec::<S>("test-vector2");
         let singleton = rusty_storage
             .schema
-            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+            .new_singleton::<S>("singleton".to_owned());
 
         // initialize
         rusty_storage.restore_or_new();
@@ -763,7 +793,7 @@ mod tests {
         new_rusty_storage.restore_or_new();
         let new_singleton = new_rusty_storage
             .schema
-            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+            .new_singleton::<S>("singleton".to_owned());
         new_rusty_storage.restore_or_new();
 
         // test again
@@ -1052,7 +1082,7 @@ mod tests {
                 storage.schema.create_tables_rw(|schema| {
                     (0..num)
                         .map(|_i| {
-                            let singleton = schema.new_singleton::<u64>(12u64.into());
+                            let singleton = schema.new_singleton::<u64>("singleton".to_owned());
                             singleton.set(25);
                             singleton
                         })
@@ -1067,7 +1097,7 @@ mod tests {
 
                 (0..num)
                     .map(|_i| {
-                        let singleton = storage.schema.new_singleton::<u64>(12u64.into());
+                        let singleton = storage.schema.new_singleton::<u64>("singleton".to_owned());
                         singleton.set(25);
                         singleton
                     })


### PR DESCRIPTION
By adding a deterministically derived value from the schema, the number of tables added to the schema, and using this as a key for the underlying leveldb database, we can ensure that no key collissions happen, as all tables have a unique prefix that *all* their keys start with.

This closes #177.