### PR TITLE
Add storage::DbtMap, for key/val within a DbSchema.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,89 +9,16 @@ on:
 name: Rust
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
+  runner-matrix:
+    name: format, lint, test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0, 2022-10-13
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.7, 2020-03-24
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1, 2019-09-15
-        with:
-          command: check
-
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0, 2022-10-13
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.7, 2020-03-24
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1, 2019-09-15
-        with:
-          command: test
-
-      - name: Run cargo benchmark compile
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1, 2019-09-15
-        with:
-          command: bench
-          args: --no-run
-
-      - name: Run cargo test without non_atomic
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -- --skip non_atomic
-
-  lints:
-    name: Lints
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0, 2022-10-13
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.7, 2020-03-24
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1, 2019-09-15
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1, 2019-09-15
-        with:
-          command: clippy
-          args: -- -D warnings
-
-  benchmark:
-    name: Run benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0, 2022-10-13
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -99,13 +26,22 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          components: rustfmt, clippy
 
-      - name: Install criterion
-        run: cargo install cargo-criterion
-
-      - name: Run NTT benchmark
-        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1, 2019-09-15
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
         with:
-          command: criterion
-          args: ntt_forward
+          command: fmt
+          args: --all -- --check
 
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+      - name: Run cargo test without benches
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -- --skip benches

--- a/twenty-first/benches/db_dbtvec.rs
+++ b/twenty-first/benches/db_dbtvec.rs
@@ -101,7 +101,7 @@ mod write_100_entries {
         use super::*;
 
         fn push_impl(bencher: Bencher, persist: bool) {
-            let (mut storage, vector) = create_test_dbtvec();
+            let (mut storage, mut vector) = create_test_dbtvec();
 
             bencher.bench_local(|| {
                 for _i in 0..NUM_WRITE_ITEMS {
@@ -128,7 +128,7 @@ mod write_100_entries {
         use super::*;
 
         fn set_impl(bencher: Bencher, persist: bool) {
-            let (mut storage, vector) = create_test_dbtvec();
+            let (mut storage, mut vector) = create_test_dbtvec();
 
             for _i in 0..NUM_WRITE_ITEMS {
                 vector.push(value());
@@ -160,7 +160,7 @@ mod write_100_entries {
         use super::*;
 
         fn set_many_impl(bencher: Bencher, persist: bool) {
-            let (mut storage, vector) = create_test_dbtvec();
+            let (mut storage, mut vector) = create_test_dbtvec();
 
             for _ in 0..NUM_WRITE_ITEMS {
                 vector.push(vec![42]);
@@ -190,7 +190,7 @@ mod write_100_entries {
         use super::*;
 
         fn pop_impl(bencher: Bencher, persist: bool) {
-            let (mut storage, vector) = create_test_dbtvec();
+            let (mut storage, mut vector) = create_test_dbtvec();
 
             for _i in 0..NUM_WRITE_ITEMS {
                 vector.push(value());
@@ -225,7 +225,7 @@ mod read_100_entries {
     const NUM_READ_ITEMS: u64 = 100;
 
     fn get_impl(bencher: Bencher, num_each: usize, persisted: bool) {
-        let (mut storage, vector) = create_test_dbtvec();
+        let (mut storage, mut vector) = create_test_dbtvec();
 
         for _i in 0..NUM_READ_ITEMS {
             vector.push(value());
@@ -244,7 +244,7 @@ mod read_100_entries {
     }
 
     fn get_many_impl(bencher: Bencher, num_each: usize, persisted: bool) {
-        let (mut storage, vector) = create_test_dbtvec();
+        let (mut storage, mut vector) = create_test_dbtvec();
 
         for _i in 0..NUM_READ_ITEMS {
             vector.push(value());

--- a/twenty-first/benches/db_leveldb.rs
+++ b/twenty-first/benches/db_leveldb.rs
@@ -102,7 +102,7 @@ mod write_100_entries {
         use super::*;
 
         fn put(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -118,7 +118,7 @@ mod write_100_entries {
         }
 
         fn batch_put(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -136,7 +136,7 @@ mod write_100_entries {
         }
 
         fn batch_put_write(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -197,7 +197,7 @@ mod write_100_entries {
         use super::*;
 
         fn delete(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -217,7 +217,7 @@ mod write_100_entries {
         }
 
         fn batch_delete(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -244,7 +244,7 @@ mod write_100_entries {
         }
 
         fn batch_delete_write(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -319,7 +319,7 @@ mod read_100_entries {
         use super::*;
 
         fn get(bencher: Bencher, num_reads: usize, cache: bool, verify_checksum: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options(verify_checksum, cache),

--- a/twenty-first/benches/sync_atomic.rs
+++ b/twenty-first/benches/sync_atomic.rs
@@ -71,7 +71,7 @@ mod lock_mut {
 
         #[divan::bench]
         fn lock_guard_mut(bencher: Bencher) {
-            let atom = AtomicRw::from(true);
+            let mut atom = AtomicRw::from(true);
 
             bencher.bench_local(|| {
                 for _i in 0..NUM_ACQUIRES {

--- a/twenty-first/src/amount/u32s.rs
+++ b/twenty-first/src/amount/u32s.rs
@@ -405,7 +405,7 @@ mod u32s_tests {
             let a_as_u128: u128 = (rng.next_u64() as u128) << 64 | rng.next_u64() as u128;
             let a: U32s<4> = a_as_u128.try_into().unwrap();
             let a_as_biguint: BigUint = a_as_u128.into();
-            assert_eq!(a, TryInto::<U32s<4>>::try_into(a_as_biguint).unwrap());
+            assert_eq!(a, Into::<U32s<4>>::into(a_as_biguint));
         }
     }
 

--- a/twenty-first/src/shared_math/bfield_codec.rs
+++ b/twenty-first/src/shared_math/bfield_codec.rs
@@ -225,7 +225,7 @@ impl<T: BFieldCodec, S: BFieldCodec> BFieldCodec for (T, S) {
 
     fn decode(sequence: &[BFieldElement]) -> Result<Box<Self>, Self::Error> {
         // decode S
-        if S::static_length().is_none() && sequence.get(0).is_none() {
+        if S::static_length().is_none() && sequence.first().is_none() {
             return Err(Self::Error::MissingLengthIndicator);
         }
         let (length_of_s, sequence) = match S::static_length() {
@@ -239,7 +239,7 @@ impl<T: BFieldCodec, S: BFieldCodec> BFieldCodec for (T, S) {
         let s = *S::decode(sequence_for_s).map_err(|err| err.into())?;
 
         // decode T
-        if T::static_length().is_none() && sequence.get(0).is_none() {
+        if T::static_length().is_none() && sequence.first().is_none() {
             return Err(Self::Error::MissingLengthIndicator);
         }
         let (length_of_t, sequence) = match T::static_length() {

--- a/twenty-first/src/shared_math/digest.rs
+++ b/twenty-first/src/shared_math/digest.rs
@@ -358,24 +358,12 @@ mod digest_tests {
         );
 
         // Verify conversion from Digest to BigUint
-        assert_eq!(fourteen, fourteen_converted_expected.try_into().unwrap());
-        assert_eq!(bfe_max, bfe_max_converted_expected.try_into().unwrap());
-        assert_eq!(
-            bfe_max_plus_one,
-            bfe_max_plus_one_converted_expected.try_into().unwrap()
-        );
-        assert_eq!(
-            two_pow_64,
-            two_pow_64_converted_expected.try_into().unwrap()
-        );
-        assert_eq!(
-            two_pow_123,
-            two_pow_123_converted_expected.try_into().unwrap()
-        );
-        assert_eq!(
-            two_pow_315,
-            two_pow_315_converted_expected.try_into().unwrap()
-        );
+        assert_eq!(fourteen, fourteen_converted_expected.into());
+        assert_eq!(bfe_max, bfe_max_converted_expected.into());
+        assert_eq!(bfe_max_plus_one, bfe_max_plus_one_converted_expected.into());
+        assert_eq!(two_pow_64, two_pow_64_converted_expected.into());
+        assert_eq!(two_pow_123, two_pow_123_converted_expected.into());
+        assert_eq!(two_pow_315, two_pow_315_converted_expected.into());
     }
 
     #[test]

--- a/twenty-first/src/shared_math/mpolynomial.rs
+++ b/twenty-first/src/shared_math/mpolynomial.rs
@@ -7,7 +7,6 @@ use num_traits::{One, Zero};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
@@ -1114,11 +1113,7 @@ impl<FF: FiniteField> MPolynomial<FF> {
                 continue;
             }
 
-            let signed_exponents = exponents.iter().map(|e| {
-                let res = i64::try_from(*e);
-                assert!(res.is_ok());
-                res.unwrap()
-            });
+            let signed_exponents = exponents.iter().map(|&e| i64::from(e));
 
             let term_degree_bound = max_degrees
                 .iter()

--- a/twenty-first/src/storage/database_array.rs
+++ b/twenty-first/src/storage/database_array.rs
@@ -32,7 +32,7 @@ impl<const N: IndexType, T: Serialize + DeserializeOwned + Default> DatabaseArra
     }
 
     /// set all key/val pairs in `indices_and_vals`
-    pub fn batch_set(&self, indices_and_vals: &[(IndexType, T)]) {
+    pub fn batch_set(&mut self, indices_and_vals: &[(IndexType, T)]) {
         let indices: Vec<IndexType> = indices_and_vals.iter().map(|(index, _)| *index).collect();
         assert!(
             indices.iter().all(|index| *index < N),
@@ -84,7 +84,6 @@ impl<const N: IndexType, T: Serialize + DeserializeOwned + Default> DatabaseArra
 
 #[cfg(test)]
 mod database_array_tests {
-    use super::super::level_db::DB;
     use super::*;
 
     #[test]

--- a/twenty-first/src/storage/database_array.rs
+++ b/twenty-first/src/storage/database_array.rs
@@ -51,7 +51,7 @@ impl<const N: IndexType, T: Serialize + DeserializeOwned + Default> DatabaseArra
 
     /// Set the value at index
     #[inline]
-    pub fn set(&self, index: IndexType, value: T) {
+    pub fn set(&mut self, index: IndexType, value: T) {
         assert!(
             N > index,
             "Cannot set outside of length. Length: {N}, index: {index}"
@@ -91,7 +91,7 @@ mod database_array_tests {
     fn init_and_default_values_test() {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
         assert_eq!(0u64, u64::default());
-        let db_array: DatabaseArray<101, u64> = DatabaseArray::new(db);
+        let mut db_array: DatabaseArray<101, u64> = DatabaseArray::new(db);
         assert_eq!(0u64, db_array.get(0));
         assert_eq!(0u64, db_array.get(100));
         assert_eq!(0u64, db_array.get(42));
@@ -127,7 +127,7 @@ mod database_array_tests {
     fn panic_on_index_out_of_range_length_one_set_test() {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
-        let db_array: DatabaseArray<50, u64> = DatabaseArray::new(db);
+        let mut db_array: DatabaseArray<50, u64> = DatabaseArray::new(db);
         db_array.set(90, 17);
     }
 }

--- a/twenty-first/src/storage/database_vector.rs
+++ b/twenty-first/src/storage/database_vector.rs
@@ -30,7 +30,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     ///
     /// This function will panic if the database write fails
     #[inline]
-    fn set_length(&self, length: IndexType) {
+    fn set_length(&mut self, length: IndexType) {
         let length = utils::serialize(&length);
         self.db
             .put_u8(&LENGTH_KEY, &length)
@@ -43,7 +43,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     ///
     /// This function will panic if the index is not found
     #[inline]
-    fn delete(&self, index: IndexType) {
+    fn delete(&mut self, index: IndexType) {
         self.db
             .delete(&index)
             .expect("Deleting element must succeed");
@@ -99,7 +99,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     /// # Panics
     ///
     /// This function will panic if the DB batch write fails
-    pub fn overwrite_with_vec(&self, new_vector: Vec<T>) {
+    pub fn overwrite_with_vec(&mut self, new_vector: Vec<T>) {
         let old_length = self.len();
         let new_length = new_vector.len() as IndexType;
         self.set_length(new_length);
@@ -130,7 +130,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     /// This function will panic if the new Vec is not empty.
     #[inline]
     pub fn new(db: DB) -> Self {
-        let ret = DatabaseVector {
+        let mut ret = DatabaseVector {
             db,
             _type: PhantomData,
         };
@@ -186,7 +186,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     ///
     /// This function will panic if any index is out of range
     /// or if any database write fails.
-    pub fn batch_set(&self, indices_and_vals: &[(IndexType, T)]) {
+    pub fn batch_set(&mut self, indices_and_vals: &[(IndexType, T)]) {
         let indices: Vec<IndexType> = indices_and_vals.iter().map(|(index, _)| *index).collect();
         let length = self.len();
         assert!(
@@ -245,7 +245,6 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
 
 #[cfg(test)]
 mod database_vector_tests {
-    use super::super::level_db::DB;
     use super::*;
 
     fn test_constructor() -> DatabaseVector<u64> {

--- a/twenty-first/src/storage/database_vector.rs
+++ b/twenty-first/src/storage/database_vector.rs
@@ -169,7 +169,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     /// This function will panic if index is out of range
     /// or if the database write fails.
     #[inline]
-    pub fn set(&self, index: IndexType, value: T) {
+    pub fn set(&mut self, index: IndexType, value: T) {
         debug_assert!(
             self.len() > index,
             "Cannot set outside of length. Length: {}, index: {}",
@@ -211,7 +211,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     /// This function will panic if get, delete, or
     /// set_length operations panic.
     #[inline]
-    pub fn pop(&self) -> Option<T> {
+    pub fn pop(&mut self) -> Option<T> {
         match self.len() {
             0 => None,
             length => {
@@ -229,7 +229,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     ///
     /// This function will panic if the DB write fails
     #[inline]
-    pub fn push(&self, value: T) {
+    pub fn push(&mut self, value: T) {
         let length = self.len();
         let value_bytes = utils::serialize(&value);
         self.db.put(&length, &value_bytes).unwrap();
@@ -255,7 +255,7 @@ mod database_vector_tests {
 
     #[test]
     fn push_pop_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         assert_eq!(0, db_vector.len());
         assert!(db_vector.is_empty());
 
@@ -285,7 +285,7 @@ mod database_vector_tests {
 
     #[test]
     fn overwrite_with_vec_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         for _ in 0..10 {
             db_vector.push(17);
         }
@@ -306,7 +306,7 @@ mod database_vector_tests {
 
     #[test]
     fn batch_set_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         for _ in 0..100 {
             db_vector.push(17);
         }
@@ -327,7 +327,7 @@ mod database_vector_tests {
 
     #[test]
     fn push_many_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         for _ in 0..1000 {
             db_vector.push(17);
         }
@@ -345,7 +345,7 @@ mod database_vector_tests {
     #[should_panic = "Cannot get outside of length. Length: 1, index: 1"]
     #[test]
     fn panic_on_index_out_of_range_length_one_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         db_vector.push(5558999);
         db_vector.get(1);
     }
@@ -353,7 +353,7 @@ mod database_vector_tests {
     #[should_panic = "Cannot set outside of length. Length: 1, index: 1"]
     #[test]
     fn panic_on_index_out_of_range_length_one_set_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         db_vector.push(5558999);
         db_vector.set(1, 14);
     }
@@ -371,7 +371,7 @@ mod database_vector_tests {
     #[test]
     fn index_zero_test() {
         // Verify that index zero does not overwrite the stored length
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         db_vector.push(17);
         assert_eq!(1, db_vector.len());
         assert_eq!(17u64, db_vector.get(0));

--- a/twenty-first/src/storage/level_db.rs
+++ b/twenty-first/src/storage/level_db.rs
@@ -21,7 +21,12 @@ use rand_distr::Alphanumeric;
 use std::path::Path;
 use std::sync::Arc;
 
-/// DB provides thread-safe access to LevelDB API.
+/// `DbIntMut` provides thread-safe access to LevelDB API with `&self` setters
+///
+/// Interior mutability is available without rust locks because the underlying
+/// C++ levelDB API is internally thread-safe.
+///
+/// If `&self` setters are not needed, prefer [`DB`] instead.
 //
 //  This also provides an abstraction layer which enables
 //  us to provide an API that is somewhat backwards compatible
@@ -30,7 +35,7 @@ use std::sync::Arc;
 //
 //  Do not add any public (mutable) fields to this struct.
 #[derive(Debug, Clone)]
-pub struct DB {
+pub struct DbIntMut {
     // note: these must be private and unchanged after creation.
 
     // This Option is needed for the Drop impl.  See comments there.
@@ -43,7 +48,7 @@ pub struct DB {
     write_options: WriteOptions,
 }
 
-impl DB {
+impl DbIntMut {
     /// Open a new database
     ///
     /// If the database is missing, the behaviour depends on `options.create_if_missing`.
@@ -151,7 +156,7 @@ impl DB {
         opt.create_if_missing = true;
         opt.error_if_exists = false;
 
-        let mut db = DB::open_with_options(path, &opt, read_opt, write_opt)?;
+        let mut db = Self::open_with_options(path, &opt, read_opt, write_opt)?;
         db.destroy_db_on_drop = destroy_db_on_drop;
         Ok(db)
     }
@@ -237,7 +242,7 @@ impl DB {
     }
 
     /// Wipe the database files, if existing.
-    fn destroy_db(&mut self) -> Result<(), std::io::Error> {
+    fn destroy_db(&self) -> Result<(), std::io::Error> {
         match self.path.exists() {
             true => std::fs::remove_dir_all(&self.path),
             false => Ok(()),
@@ -245,7 +250,7 @@ impl DB {
     }
 }
 
-impl Drop for DB {
+impl Drop for DbIntMut {
     #[inline]
     fn drop(&mut self) {
         if self.destroy_db_on_drop {
@@ -284,21 +289,21 @@ impl Drop for DB {
     }
 }
 
-// impl Batch for DB {
+// impl Batch for DbIntMut {
 //     #[inline]
 //     fn write(&self, options: &WriteOptions, batch: &WriteBatch) -> Result<(), DbError> {
 //         self.db.write(options, batch)
 //     }
 // }
 
-impl<'a> Compaction<'a> for DB {
+impl<'a> Compaction<'a> for DbIntMut {
     #[inline]
     fn compact(&self, start: &'a [u8], limit: &'a [u8]) {
         self.db.as_ref().unwrap().compact(start, limit)
     }
 }
 
-impl<'a> Iterable<'a> for DB {
+impl<'a> Iterable<'a> for DbIntMut {
     #[inline]
     fn iter(&'a self, options: &ReadOptions) -> Iterator<'a> {
         self.db.as_ref().unwrap().iter(options)
@@ -315,9 +320,214 @@ impl<'a> Iterable<'a> for DB {
     }
 }
 
-impl Snapshots for DB {
+impl Snapshots for DbIntMut {
     fn snapshot(&self) -> Snapshot {
         self.db.as_ref().unwrap().snapshot()
+    }
+}
+
+/// `DB` provides thread-safe access to LevelDB API with `&mut self` setters.
+///
+/// `DB` is a newtype wrapper for [`DbIntMut`] that hides the interior mutability
+/// of the underlying C++ levelDB API, which is internally thread-safe.
+///
+/// If interior mutability is needed, use [`DbIntMut`] instead.
+//
+//  This also provides an abstraction layer which enables
+//  us to provide an API that is somewhat backwards compatible
+//  with rusty-leveldb.  For example, our get() and put()
+//  do not require ReadOptions and WriteOptions param.
+#[derive(Debug, Clone)]
+pub struct DB(DbIntMut);
+
+impl DB {
+    /// Open a new database
+    ///
+    /// If the database is missing, the behaviour depends on `options.create_if_missing`.
+    /// The database will be created using the settings given in `options`.
+    #[inline]
+    pub fn open(name: &Path, options: &Options) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open(name, options)?))
+    }
+
+    /// Open a new database
+    ///
+    /// If the database is missing, the behaviour depends on `options.create_if_missing`.
+    /// The database will be created using the settings given in `options`.
+    #[inline]
+    pub fn open_with_options(
+        name: &Path,
+        options: &Options,
+        read_options: ReadOptions,
+        write_options: WriteOptions,
+    ) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open_with_options(
+            name,
+            options,
+            read_options,
+            write_options,
+        )?))
+    }
+
+    /// Open a new database with a custom comparator
+    ///
+    /// If the database is missing, the behaviour depends on `options.create_if_missing`.
+    /// The database will be created using the settings given in `options`.
+    ///
+    /// The comparator must implement a total ordering over the keyspace.
+    ///
+    /// For keys that implement Ord, consider the `OrdComparator`.
+    #[inline]
+    pub fn open_with_comparator<C: Comparator>(
+        name: &Path,
+        options: &Options,
+        comparator: C,
+    ) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open_with_comparator(
+            name, options, comparator,
+        )?))
+    }
+
+    /// Creates and opens a test database
+    ///
+    /// The database will be created in the system
+    /// temp directory with prefix "test-db-" followed
+    /// by a random string.
+    ///
+    /// if destroy_db_on_drop is true, the database on-disk
+    /// files will be wiped when the DB struct is dropped.
+    pub fn open_new_test_database(
+        destroy_db_on_drop: bool,
+        options: Option<Options>,
+        read_options: Option<ReadOptions>,
+        write_options: Option<WriteOptions>,
+    ) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open_new_test_database(
+            destroy_db_on_drop,
+            options,
+            read_options,
+            write_options,
+        )?))
+    }
+
+    /// Opens an existing (test?) database, with auto-destroy option.
+    ///
+    /// if destroy_db_on_drop is true, the database on-disk
+    /// files will be wiped when the DB struct is dropped.
+    /// This is usually useful only for unit-test purposes.
+    pub fn open_test_database(
+        path: &std::path::Path,
+        destroy_db_on_drop: bool,
+        options: Option<Options>,
+        read_options: Option<ReadOptions>,
+        write_options: Option<WriteOptions>,
+    ) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open_test_database(
+            path,
+            destroy_db_on_drop,
+            options,
+            read_options,
+            write_options,
+        )?))
+    }
+
+    /// Set a key/val in the database
+    #[inline]
+    pub fn put(&mut self, key: &dyn IntoLevelDBKey, value: &[u8]) -> Result<(), DbError> {
+        self.0.put(key, value)
+    }
+
+    /// Set a key/val in the database, with key as bytes.
+    #[inline]
+    pub fn put_u8(&mut self, key: &[u8], value: &[u8]) -> Result<(), DbError> {
+        self.0.put_u8(key, value)
+    }
+
+    /// Get a value matching key from the database
+    #[inline]
+    pub fn get(&self, key: &dyn IntoLevelDBKey) -> Result<Option<Vec<u8>>, DbError> {
+        self.0.get(key)
+    }
+
+    /// Get a value matching key from the database, with key as bytes
+    #[inline]
+    pub fn get_u8(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DbError> {
+        self.0.get_u8(key)
+    }
+
+    /// Delete an entry matching key from the database
+    #[inline]
+    pub fn delete(&mut self, key: &dyn IntoLevelDBKey) -> Result<(), DbError> {
+        self.0.delete(key)
+    }
+
+    /// Delete an entry matching key from the database, with key as bytes
+    #[inline]
+    pub fn delete_u8(&mut self, key: &[u8]) -> Result<(), DbError> {
+        self.0.delete_u8(key)
+    }
+
+    /// Write the WriteBatch to database atomically
+    ///
+    /// The sync flag forces filesystem sync operation eg fsync
+    /// which will be slower than async writes, which are not
+    /// guaranteed to complete. See leveldb Docs.
+    pub fn write(&mut self, batch: &WriteBatch, sync: bool) -> Result<(), DbError> {
+        self.0.write(batch, sync)
+    }
+
+    /// Write [`WriteBatch`] to database atomically
+    ///
+    /// Sync behavior will be determined by the WriteOptions
+    /// supplied at `DB` creation.
+    pub fn write_auto(&mut self, batch: &WriteBatch) -> Result<(), DbError> {
+        self.0.write_auto(batch)
+    }
+
+    /// returns the directory path of the database files on disk.
+    #[inline]
+    pub fn path(&self) -> &std::path::PathBuf {
+        self.0.path()
+    }
+
+    /// returns `destroy_db_on_drop` setting
+    #[inline]
+    pub fn destroy_db_on_drop(&self) -> bool {
+        self.0.destroy_db_on_drop()
+    }
+
+    /// compacts the database file.  should be called periodically.
+    #[inline]
+    pub fn compact<'a>(&mut self, start: &'a [u8], limit: &'a [u8]) {
+        self.0.compact(start, limit)
+    }
+
+    /// Wipe the database files, if existing.
+    pub fn destroy_db(&mut self) -> Result<(), std::io::Error> {
+        self.0.destroy_db()
+    }
+}
+
+impl<'a> Iterable<'a> for DB {
+    #[inline]
+    fn iter(&'a self, options: &ReadOptions) -> Iterator<'a> {
+        self.0.iter(options)
+    }
+
+    #[inline]
+    fn keys_iter(&'a self, options: &ReadOptions) -> KeyIterator<'a> {
+        self.0.keys_iter(options)
+    }
+
+    #[inline]
+    fn value_iter(&'a self, options: &ReadOptions) -> ValueIterator<'a> {
+        self.0.value_iter(options)
+    }
+}
+
+impl Snapshots for DB {
+    fn snapshot(&self) -> Snapshot {
+        self.0.snapshot()
     }
 }
 
@@ -329,8 +539,8 @@ mod tests {
     #[test]
     fn level_db_close_and_reload() {
         // open new test database that will not be destroyed on close.
-        let db = DB::open_new_test_database(false, None, None, None).unwrap();
-        let db_path = db.path.clone();
+        let mut db = DB::open_new_test_database(false, None, None, None).unwrap();
+        let db_path = db.path().clone();
 
         let key = "answer-to-everything";
         let val = vec![42];
@@ -342,7 +552,7 @@ mod tests {
         assert!(db_path.exists());
 
         // open existing database that will be destroyed on close.
-        let db2 = DB::open_test_database(&db_path, true, None, None, None).unwrap();
+        let db2 = DbIntMut::open_test_database(&db_path, true, None, None, None).unwrap();
 
         let val2 = db2.get(&key).unwrap().unwrap();
         assert_eq!(val, val2);

--- a/twenty-first/src/storage/storage_schema/dbtmap.rs
+++ b/twenty-first/src/storage/storage_schema/dbtmap.rs
@@ -1,0 +1,187 @@
+use serde::{de::DeserializeOwned, Serialize};
+
+use super::dbtmap_private::DbtMapPrivate;
+use super::{traits::*, WriteOperation};
+use crate::sync::{AtomicRw, LockCallbackFn};
+use itertools::Itertools;
+use std::hash::Hash;
+use std::{fmt::Debug, sync::Arc};
+
+/// A DB-backed Map for use with DBSchema
+///
+/// This type is concurrency-safe.  A single RwLock is employed
+/// for all read and write ops.  Callers do not need to perform
+/// any additional locking.
+///
+/// `DbtMap` is a NewType around Arc<RwLock<..>>.  Thus it
+/// can be cheaply cloned to create a reference as if it were an
+/// Arc.
+///
+/// Important!  This type should only be used for storing
+/// a small number of values, eg under 1000, although there
+/// is no fixed limit.
+///
+/// DbtMap is essentially creating a logical sub-set of key/val
+/// pairs inside the full set, which is the LevelDB database.
+///
+/// In order to persist its list of known keys, DbtMap stores
+/// that list in a single LevelDB key, which must be updated for
+/// every insert or delete.
+///
+/// Additionally, DbtMap keeps a copy of the key-list in RAM,
+/// which is loaded from the DB during initialization.
+///
+/// For this reason, this type is not suited to storing
+/// huge numbers of entries.
+///
+#[derive(Debug)]
+pub struct DbtMap<K, V> {
+    inner: AtomicRw<DbtMapPrivate<K, V>>,
+}
+
+impl<K, V> Clone for DbtMap<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<K, V> DbtMap<K, V>
+where
+    K: DeserializeOwned + Serialize + Eq + Hash + Clone,
+    V: DeserializeOwned + Serialize + Clone,
+{
+    // DbtMap cannot be instantiated directly outside of this crate.
+    #[inline]
+    pub(crate) fn new(
+        reader: Arc<dyn StorageReader + Send + Sync>,
+        key_prefix: u8,
+        name: &str,
+        lock_name: String,
+        lock_callback_fn: Option<LockCallbackFn>,
+    ) -> Self {
+        let vec = DbtMapPrivate::<K, V>::new(reader, key_prefix, name);
+
+        Self {
+            inner: AtomicRw::from((vec, Some(lock_name), lock_callback_fn)),
+        }
+    }
+
+    /// check if map is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock(|inner| inner.is_empty())
+    }
+
+    /// get length of map
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.lock(|inner| inner.len())
+    }
+
+    /// get value identified by key
+    #[inline]
+    pub fn get(&self, k: &K) -> Option<V> {
+        self.inner
+            .lock(|inner| inner.get(k).map(|v| v.into_owned()))
+    }
+
+    /// insert value identified by key
+    #[inline]
+    pub fn insert(&mut self, k: K, v: V) -> bool {
+        self.inner.lock_mut(|inner| inner.insert(k, v))
+    }
+
+    /// remove entry identified by key
+    #[inline]
+    pub fn remove(&mut self, k: &K) -> bool {
+        self.inner.lock_mut(|inner| inner.remove(k))
+    }
+
+    /// clear all entries
+    #[inline]
+    pub fn clear(&mut self) {
+        self.inner.lock_mut(|inner| inner.clear());
+    }
+
+    /// get an iterator over all keys and values
+    ///
+    /// The returned iterator holds a read-lock over the collection contents.
+    /// This enables consistent (snapshot) reads because any writer must
+    /// wait until the lock is released.
+    ///
+    /// The lock is not released until the iterator is dropped, so it is
+    /// important to drop the iterator immediately after use.  Typical
+    /// for-loop usage does this automatically.
+    ///
+    /// note: this call performs an internal collect() over all values.
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = (K, V)> {
+        let inner = self.inner.lock_guard();
+        inner
+            .iter()
+            .map(|(k, v)| (k.clone(), v.into_owned()))
+            .collect_vec()
+            .into_iter()
+    }
+
+    /// get an iterator over all keys
+    ///
+    /// The returned iterator holds a read-lock over the collection contents.
+    /// This enables consistent (snapshot) reads because any writer must
+    /// wait until the lock is released.
+    ///
+    /// The lock is not released until the iterator is dropped, so it is
+    /// important to drop the iterator immediately after use.  Typical
+    /// for-loop usage does this automatically.
+    ///
+    /// note: this call performs an internal collect() over all values.
+    #[inline]
+    pub fn iter_keys(&self) -> impl Iterator<Item = K> {
+        let inner = self.inner.lock_guard();
+        inner.iter_keys().cloned().collect_vec().into_iter()
+    }
+
+    /// get an iterator over all values
+    ///
+    /// The returned iterator holds a read-lock over the collection contents.
+    /// This enables consistent (snapshot) reads because any writer must
+    /// wait until the lock is released.
+    ///
+    /// The lock is not released until the iterator is dropped, so it is
+    /// important to drop the iterator immediately after use.  Typical
+    /// for-loop usage does this automatically.
+    ///
+    /// note: this call performs an internal collect() over all values.
+    #[inline]
+    pub fn iter_values(&self) -> impl Iterator<Item = V> {
+        let inner = self.inner.lock_guard();
+        inner
+            .iter_values()
+            .map(|v| v.into_owned())
+            .collect_vec()
+            .into_iter()
+    }
+}
+
+impl<K, V> DbTable for DbtMap<K, V>
+where
+    K: DeserializeOwned + Serialize + Eq + Hash + Clone + Debug,
+    V: DeserializeOwned + Serialize + Clone,
+{
+    /// Collect all added elements that have not yet been persisted
+    ///
+    /// note: this clears the internal cache.  Thus the cache does
+    /// not grow unbounded, so long as `pull_queue()` is called
+    /// regularly.  It also means the cache must be rebuilt after
+    /// each call (batch write)
+    fn pull_queue(&mut self) -> Vec<WriteOperation> {
+        self.inner.lock_mut(|inner| inner.pull_queue())
+    }
+
+    #[inline]
+    fn restore_or_new(&mut self) {
+        self.inner.lock_mut(|inner| inner.restore_or_new())
+    }
+}

--- a/twenty-first/src/storage/storage_schema/dbtmap_private.rs
+++ b/twenty-first/src/storage/storage_schema/dbtmap_private.rs
@@ -1,0 +1,246 @@
+use super::{traits::*, WriteOperation};
+use super::{RustyKey, RustyValue};
+use serde::{de::DeserializeOwned, Serialize};
+use std::borrow::Cow;
+use std::collections::HashSet;
+use std::fmt::{Debug, Formatter};
+use std::hash::Hash;
+use std::{collections::HashMap, sync::Arc};
+
+/// Important!  This type should only be used for storing
+/// a small number of values, eg under 1000, although there
+/// is no fixed limit.
+///
+/// DbtMap is essentially creating a logical sub-set of key/val
+/// pairs inside the full set, which is the LevelDB database.
+///
+/// In order to persist its list of known keys, DbtMap stores
+/// that list in a single LevelDB key, which must be updated for
+/// every insert or delete.
+///
+/// Additionally, DbtMap keeps a copy of the key-list in RAM,
+/// which is loaded from the DB during initialization.
+///
+/// For this reason, this type is not suited to storing
+/// huge numbers of entries.
+///
+/// So in this design, for a DbtMap with prefix `0` and values
+/// `{(10,100), (20,200), (30,300)}`, the levelDB representation logically
+/// looks like:
+/// ```text
+///   0_kl: [10,20,30],
+///   0_10: 100,
+///   0_20: 200,
+///   0_30: 300
+/// ```
+///
+/// So the entire `0_kl` list must be updated for each insertion/removal.
+///
+/// An alternative design is possible where the DbtMap
+/// keys are stored in an ascending list of LevelDB keys,
+/// eg:
+/// ```text
+///   0_kl_0: 10,
+///   0_kl_1: 20,
+///   0_kl_2: 30,
+///   0_10: 100,
+///   0_20: 200,
+///   0_30: 300
+/// ```
+/// Here only a single small `0_kl_x` key needs to be added or removed
+/// for each insertion/removal.
+///
+/// This design could scale better to large numbers of entries
+/// but would be slower for read access without all keys
+/// cached in RAM.
+pub(crate) struct DbtMapPrivate<K, V> {
+    pub(super) name: String,
+    pub(super) reader: Arc<dyn StorageReader + Send + Sync>,
+    pub(super) key_prefix: u8,
+    pub(super) keys: HashSet<K>,
+    pub(super) write_queue: Vec<WriteOperation>,
+    pub(super) write_cache: HashMap<K, V>,
+}
+
+impl<K, V> Debug for DbtMapPrivate<K, V>
+where
+    K: Debug,
+    V: Debug,
+{
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        f.debug_struct("DbtMapPrivate")
+            .field("name", &self.name)
+            .field("reader", &"Arc<dyn StorageReader + Send + Sync>")
+            .field("key_prefix", &self.key_prefix)
+            .field("keys", &self.keys)
+            .field("write_queue", &self.write_queue)
+            .field("write_cache", &self.write_cache)
+            .finish()
+    }
+}
+
+impl<K, V> DbtMapPrivate<K, V>
+where
+    K: DeserializeOwned + Serialize + Eq + Hash + Clone,
+    V: DeserializeOwned + Serialize + Clone,
+{
+    #[inline]
+    pub(crate) fn new(
+        reader: Arc<dyn StorageReader + Send + Sync>,
+        key_prefix: u8,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            key_prefix,
+            reader,
+            keys: HashSet::default(),
+            write_queue: Vec::default(),
+            write_cache: HashMap::default(),
+        }
+    }
+
+    pub fn contains_key(&self, k: &K) -> bool {
+        self.keys.contains(k)
+    }
+
+    #[inline]
+    pub fn get(&self, k: &K) -> Option<Cow<V>> {
+        if let Some(v) = self.write_cache.get(k) {
+            return Some(Cow::Borrowed(v));
+        }
+
+        if !self.contains_key(k) {
+            return None;
+        }
+
+        // try persistent storage
+        let db_key: RustyKey = self.db_key(k);
+        self.reader.get(db_key).map(|v| Cow::Owned(v.into_any()))
+    }
+
+    pub fn insert(&mut self, k: K, v: V) -> bool {
+        let new = self.keys.insert(k.clone());
+        if new {
+            // key list grew by 1.  Set entire key-list
+            self.write_queue.push(WriteOperation::Write(
+                self.keylist_db_key(),
+                RustyValue::from_any(&self.keys),
+            ));
+        }
+
+        self.write_queue.push(WriteOperation::Write(
+            self.db_key(&k),
+            RustyValue::from_any(&v),
+        ));
+
+        let _ = self.write_cache.insert(k, v);
+
+        new
+    }
+
+    /// This will remove the entry identified by `k` if it
+    /// exists.
+    pub fn remove(&mut self, k: &K) -> bool {
+        // no-op if key not found.
+        if !self.keys.remove(k) {
+            return false;
+        }
+
+        self.write_queue.push(WriteOperation::Write(
+            self.keylist_db_key(),
+            RustyValue::from_any(&self.keys),
+        ));
+
+        self.write_cache.remove(k);
+
+        // add to write queue
+        self.write_queue
+            .push(WriteOperation::Delete(self.db_key(k)));
+
+        true
+    }
+
+    // Return the key used to store the length of the vector
+    #[inline]
+    pub(super) fn keylist_db_key(&self) -> RustyKey {
+        let prefix_rk: RustyKey = self.key_prefix.into();
+        let keylist_rk = RustyKey::from(b"_kl".as_ref());
+
+        // This concatenates prefix + "_kl" to form the
+        // real Key as used in LevelDB
+        (prefix_rk, keylist_rk).into()
+    }
+
+    pub(super) fn persisted_keys(&self) -> Option<HashSet<K>> {
+        self.reader.get(self.keylist_db_key()).map(|v| v.into_any())
+    }
+
+    /// Return the key of K type used to store the element at a given usize of usize type
+    #[inline]
+    pub(super) fn db_key(&self, k: &K) -> RustyKey {
+        let prefix_rk: RustyKey = self.key_prefix.into();
+        let k_rk = RustyKey::from_any(&k);
+
+        // This concatenates prefix + "_kl" to form the
+        // real Key as used in LevelDB
+        (prefix_rk, k_rk).into()
+    }
+
+    #[inline]
+    pub(super) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    pub(super) fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    #[inline]
+    pub(super) fn clear(&mut self) {
+        for k in self.keys.clone().iter() {
+            self.remove(k);
+        }
+        self.keys.clear()
+    }
+
+    pub(super) fn iter_keys(&self) -> impl Iterator<Item = &K> {
+        self.keys.iter()
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = (&K, Cow<'_, V>)> {
+        self.keys.iter().map(|k| (k, self.get(k).unwrap()))
+    }
+
+    pub(super) fn iter_values(&self) -> impl Iterator<Item = Cow<'_, V>> {
+        self.keys.iter().map(|k| self.get(k).unwrap())
+    }
+}
+
+impl<K, V> DbTable for DbtMapPrivate<K, V>
+where
+    K: DeserializeOwned + Serialize + Eq + Hash + Clone + Debug,
+    V: DeserializeOwned + Serialize + Clone,
+{
+    /// Collect all added elements that have not yet been persisted
+    ///
+    /// note: this clears the internal cache.  Thus the cache does
+    /// not grow unbounded, so long as `pull_queue()` is called
+    /// regularly.  It also means the cache must be rebuilt after
+    /// each call (batch write)
+    fn pull_queue(&mut self) -> Vec<WriteOperation> {
+        self.write_cache.clear();
+        std::mem::take(&mut self.write_queue)
+    }
+
+    #[inline]
+    fn restore_or_new(&mut self) {
+        self.write_cache.clear();
+        self.write_queue.clear();
+
+        if let Some(keys) = self.persisted_keys() {
+            self.keys = keys;
+        }
+    }
+}

--- a/twenty-first/src/storage/storage_schema/dbtsingleton.rs
+++ b/twenty-first/src/storage/storage_schema/dbtsingleton.rs
@@ -69,7 +69,7 @@ where
     }
 
     #[inline]
-    fn set(&self, t: V) {
+    fn set(&mut self, t: V) {
         self.inner.lock_mut(|inner| inner.set(t));
     }
 }
@@ -80,7 +80,7 @@ where
     V: Serialize + DeserializeOwned,
 {
     #[inline]
-    fn pull_queue(&self) -> Vec<WriteOperation> {
+    fn pull_queue(&mut self) -> Vec<WriteOperation> {
         self.inner.lock_mut(|inner| {
             if inner.current_value == inner.old_value {
                 vec![]
@@ -95,7 +95,7 @@ where
     }
 
     #[inline]
-    fn restore_or_new(&self) {
+    fn restore_or_new(&mut self) {
         self.inner.lock_mut(|inner| {
             inner.current_value = match inner.reader.get(inner.key.clone()) {
                 Some(value) => value.into_any(),

--- a/twenty-first/src/storage/storage_schema/dbtsingleton.rs
+++ b/twenty-first/src/storage/storage_schema/dbtsingleton.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, sync::Arc};
 use super::{
     dbtsingleton_private::DbtSingletonPrivate, traits::*, RustyKey, RustyValue, WriteOperation,
 };
-use crate::sync::AtomicRw;
+use crate::sync::{AtomicRw, LockCallbackFn};
 use serde::{de::DeserializeOwned, Serialize};
 
 /// Singleton type created by [`super::DbtSchema`]
@@ -40,7 +40,12 @@ where
 {
     // DbtSingleton can not be instantiated directly outside of this crate.
     #[inline]
-    pub(crate) fn new(key: RustyKey, reader: Arc<dyn StorageReader + Sync + Send>) -> Self {
+    pub(crate) fn new(
+        key: RustyKey,
+        lock_name: String,
+        reader: Arc<dyn StorageReader + Sync + Send>,
+        lock_callback_fn: Option<LockCallbackFn>,
+    ) -> Self {
         let singleton = DbtSingletonPrivate::<V> {
             current_value: Default::default(),
             old_value: Default::default(),
@@ -48,7 +53,7 @@ where
             reader,
         };
         Self {
-            inner: AtomicRw::from(singleton),
+            inner: AtomicRw::from((singleton, Some(lock_name), lock_callback_fn)),
         }
     }
 }

--- a/twenty-first/src/storage/storage_schema/dbtvec.rs
+++ b/twenty-first/src/storage/storage_schema/dbtvec.rs
@@ -2,7 +2,7 @@ use super::super::storage_vec::traits::*;
 use super::super::storage_vec::Index;
 use super::dbtvec_private::DbtVecPrivate;
 use super::{traits::*, RustyValue, VecWriteOperation, WriteOperation};
-use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
+use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard, LockCallbackFn};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, sync::Arc};
 
@@ -42,27 +42,40 @@ where
         reader: Arc<dyn StorageReader + Send + Sync>,
         key_prefix: u8,
         name: &str,
+        lock_name: String,
+        lock_callback_fn: Option<LockCallbackFn>,
     ) -> Self {
         let vec = DbtVecPrivate::<V>::new(reader, key_prefix, name);
 
         Self {
-            inner: AtomicRw::from(vec),
+            inner: AtomicRw::from((vec, Some(lock_name), lock_callback_fn)),
         }
     }
 }
 
-impl<V> StorageVecRwLock<V> for DbtVec<V> {
-    type LockedData = DbtVecPrivate<V>;
-
+impl<T> DbtVec<T> {
     #[inline]
-    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
+    pub(crate) fn write_lock(&self) -> AtomicRwWriteGuard<'_, DbtVecPrivate<T>> {
         self.inner.lock_guard_mut()
     }
 
-    // This is a private method, but we allow unit tests in super to use it.
     #[inline]
-    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
+    pub(crate) fn read_lock(&self) -> AtomicRwReadGuard<'_, DbtVecPrivate<T>> {
         self.inner.lock_guard()
+    }
+}
+
+impl<T> StorageVecRwLock<T> for DbtVec<T> {
+    type LockedData = DbtVecPrivate<T>;
+
+    #[inline]
+    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
+        Some(self.write_lock())
+    }
+
+    #[inline]
+    fn try_read_lock(&self) -> Option<AtomicRwReadGuard<'_, Self::LockedData>> {
+        Some(self.read_lock())
     }
 }
 

--- a/twenty-first/src/storage/storage_schema/dbtvec.rs
+++ b/twenty-first/src/storage/storage_schema/dbtvec.rs
@@ -2,12 +2,9 @@ use super::super::storage_vec::traits::*;
 use super::super::storage_vec::Index;
 use super::dbtvec_private::DbtVecPrivate;
 use super::{traits::*, RustyValue, VecWriteOperation, WriteOperation};
-use crate::sync::AtomicRw;
+use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
 use serde::{de::DeserializeOwned, Serialize};
-use std::{
-    fmt::Debug,
-    sync::{Arc, RwLockReadGuard, RwLockWriteGuard},
-};
+use std::{fmt::Debug, sync::Arc};
 
 /// A DB-backed Vec for use with DBSchema
 ///
@@ -58,13 +55,13 @@ impl<V> StorageVecRwLock<V> for DbtVec<V> {
     type LockedData = DbtVecPrivate<V>;
 
     #[inline]
-    fn write_lock(&self) -> RwLockWriteGuard<'_, Self::LockedData> {
+    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
         self.inner.lock_guard_mut()
     }
 
     // This is a private method, but we allow unit tests in super to use it.
     #[inline]
-    fn read_lock(&self) -> RwLockReadGuard<'_, Self::LockedData> {
+    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
         self.inner.lock_guard()
     }
 }

--- a/twenty-first/src/storage/storage_schema/mod.rs
+++ b/twenty-first/src/storage/storage_schema/mod.rs
@@ -84,7 +84,7 @@ mod tests {
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
         assert_eq!(1, Arc::strong_count(&rusty_storage.schema.reader));
-        let singleton = rusty_storage
+        let mut singleton = rusty_storage
             .schema
             .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
         assert_eq!(2, Arc::strong_count(&rusty_storage.schema.reader));
@@ -142,7 +142,7 @@ mod tests {
         let db_path = db.path().clone();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -267,7 +267,7 @@ mod tests {
         let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
 
         let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
-        let new_vector = new_rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut new_vector = new_rusty_storage.schema.new_vec::<S>("test-vector");
 
         // initialize
         new_rusty_storage.restore_or_new();
@@ -345,7 +345,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -398,7 +398,7 @@ mod tests {
         // initialize storage
         let mut rusty_storage = SimpleRustyStorage::new(db);
         rusty_storage.restore_or_new();
-        let vector = rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
         // Generate initial index/value pairs.
         const TEST_LIST_LENGTH: u8 = 105;
@@ -481,7 +481,7 @@ mod tests {
         // initialize storage
         let mut rusty_storage = SimpleRustyStorage::new(db);
         rusty_storage.restore_or_new();
-        let vector = rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
         // Generate initial index/value pairs.
         const TEST_LIST_LENGTH: u8 = 105;
@@ -547,7 +547,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let persisted_vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut persisted_vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // Insert 1000 elements
         let mut rng = rand::thread_rng();
@@ -653,9 +653,9 @@ mod tests {
         let db_path = db.path().clone();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector1 = rusty_storage.schema.new_vec::<S>("test-vector1");
-        let vector2 = rusty_storage.schema.new_vec::<S>("test-vector2");
-        let singleton = rusty_storage
+        let mut vector1 = rusty_storage.schema.new_vec::<S>("test-vector1");
+        let mut vector2 = rusty_storage.schema.new_vec::<S>("test-vector2");
+        let mut singleton = rusty_storage
             .schema
             .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
 
@@ -759,7 +759,7 @@ mod tests {
         let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
         let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
         let new_vector1 = new_rusty_storage.schema.new_vec::<S>("test-vector1");
-        let new_vector2 = new_rusty_storage.schema.new_vec::<S>("test-vector2");
+        let mut new_vector2 = new_rusty_storage.schema.new_vec::<S>("test-vector2");
         new_rusty_storage.restore_or_new();
         let new_singleton = new_rusty_storage
             .schema
@@ -837,7 +837,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -855,7 +855,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -873,7 +873,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -890,7 +890,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -907,7 +907,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -926,7 +926,7 @@ mod tests {
         // initialize storage
         let mut rusty_storage = SimpleRustyStorage::new(db);
         rusty_storage.restore_or_new();
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // Generate initial index/value pairs.
         const TEST_LIST_LENGTH: u64 = 105;
@@ -1007,37 +1007,39 @@ mod tests {
             #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
             #[test]
             fn non_atomic_set_and_get() {
-                traits_tests::concurrency::non_atomic_set_and_get(&gen_concurrency_test_vec());
+                traits_tests::concurrency::non_atomic_set_and_get(&mut gen_concurrency_test_vec());
             }
 
             #[test]
             #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
             fn non_atomic_set_and_get_wrapped_atomic_rw() {
                 traits_tests::concurrency::non_atomic_set_and_get_wrapped_atomic_rw(
-                    &gen_concurrency_test_vec(),
+                    &mut gen_concurrency_test_vec(),
                 );
             }
 
             #[test]
             fn atomic_set_and_get_wrapped_atomic_rw() {
                 traits_tests::concurrency::atomic_set_and_get_wrapped_atomic_rw(
-                    &gen_concurrency_test_vec(),
+                    &mut gen_concurrency_test_vec(),
                 );
             }
 
             #[test]
             fn atomic_setmany_and_getmany() {
-                traits_tests::concurrency::atomic_setmany_and_getmany(&gen_concurrency_test_vec());
+                traits_tests::concurrency::atomic_setmany_and_getmany(
+                    &mut gen_concurrency_test_vec(),
+                );
             }
 
             #[test]
             fn atomic_setall_and_getall() {
-                traits_tests::concurrency::atomic_setall_and_getall(&gen_concurrency_test_vec());
+                traits_tests::concurrency::atomic_setall_and_getall(&mut gen_concurrency_test_vec());
             }
 
             #[test]
             fn atomic_iter_mut_and_iter() {
-                traits_tests::concurrency::atomic_iter_mut_and_iter(&gen_concurrency_test_vec());
+                traits_tests::concurrency::atomic_iter_mut_and_iter(&mut gen_concurrency_test_vec());
             }
         }
 
@@ -1052,7 +1054,7 @@ mod tests {
                 storage.schema.create_tables_rw(|schema| {
                     (0..num)
                         .map(|_i| {
-                            let singleton = schema.new_singleton::<u64>(12u64.into());
+                            let mut singleton = schema.new_singleton::<u64>(12u64.into());
                             singleton.set(25);
                             singleton
                         })
@@ -1067,7 +1069,7 @@ mod tests {
 
                 (0..num)
                     .map(|_i| {
-                        let singleton = storage.schema.new_singleton::<u64>(12u64.into());
+                        let mut singleton = storage.schema.new_singleton::<u64>(12u64.into());
                         singleton.set(25);
                         singleton
                     })
@@ -1145,9 +1147,9 @@ mod tests {
                         // This is our writer thread
                         let sets = s.spawn(|| {
                             // start locked write ops
-                            table_singletons.lock_mut(|tables| {
+                            table_singletons.clone().lock_mut(|tables| {
                                 // iterate tables backwards from reader to find inconsistencies faster.
-                                for singleton in tables.iter().rev() {
+                                for singleton in tables.iter_mut().rev() {
                                     singleton.set(modified);
                                 }
                             }); // <--- end locked write ops
@@ -1158,7 +1160,7 @@ mod tests {
                         println!("--- Both threads (reader, writer) finished. restart. ---");
 
                         // start locked write ops
-                        table_singletons.lock_mut(|tables| {
+                        table_singletons.clone().lock_mut(|tables| {
                             for singleton in tables.iter_mut() {
                                 singleton.set(orig);
                             }
@@ -1194,6 +1196,7 @@ mod tests {
             #[test]
             pub fn non_atomic_multi_table_set_and_get() {
                 let singletons = gen_non_atomic_test_singleton(2);
+
                 let orig = singletons[0].get();
                 let modified = orig * 2;
 
@@ -1230,7 +1233,7 @@ mod tests {
 
                         let sets = s.spawn(|| {
                             // iterate tables backwards from reader to find inconsistencies faster.
-                            for singleton in singletons.iter().rev() {
+                            for singleton in singletons.clone().iter_mut().rev() {
                                 singleton.set(modified);
                             }
                         });
@@ -1239,7 +1242,7 @@ mod tests {
 
                         println!("--- threads finished. restart. ---");
 
-                        for singleton in singletons.iter() {
+                        for singleton in singletons.clone().iter_mut() {
                             singleton.set(orig);
                         }
                     });
@@ -1258,7 +1261,7 @@ mod tests {
                 storage.schema.create_tables_rw(|schema| {
                     (0..num)
                         .map(|i| {
-                            let vec =
+                            let mut vec =
                                 schema.new_vec::<u64>(&format!("atomicity-test-vector #{}", i));
                             for j in 0u64..300 {
                                 vec.push(j);
@@ -1276,7 +1279,7 @@ mod tests {
 
                 (0..num)
                     .map(|i| {
-                        let vec = rusty_storage
+                        let mut vec = rusty_storage
                             .schema
                             .new_vec::<u64>(&format!("atomicity-test-vector #{}", i));
                         for j in 0u64..300 {
@@ -1365,9 +1368,9 @@ mod tests {
                         // This is our writer thread
                         let sets = s.spawn(|| {
                             // start locked write ops
-                            table_vecs.lock_mut(|tables| {
+                            table_vecs.clone().lock_mut(|tables| {
                                 // iterate tables backwards from reader to find inconsistencies faster.
-                                for vec in tables.iter().rev() {
+                                for vec in tables.iter_mut().rev() {
                                     vec.set_many(
                                         orig.iter().enumerate().map(|(k, _v)| (k as u64, 50u64)),
                                     );
@@ -1380,7 +1383,7 @@ mod tests {
                         println!("--- Both threads (reader, writer) finished. restart. ---");
 
                         // start locked write ops
-                        table_vecs.lock_mut(|tables| {
+                        table_vecs.clone().lock_mut(|tables| {
                             for vec in tables.iter_mut() {
                                 vec.set_all(orig.clone());
                             }
@@ -1459,7 +1462,7 @@ mod tests {
 
                         let sets = s.spawn(|| {
                             // iterate tables backwards from reader to find inconsistencies faster.
-                            for vec in vecs.iter().rev() {
+                            for vec in vecs.clone().iter_mut().rev() {
                                 vec.set_many(
                                     orig.iter().enumerate().map(|(k, _v)| (k as u64, 50u64)),
                                 );
@@ -1470,7 +1473,7 @@ mod tests {
 
                         println!("--- threads finished. restart. ---");
 
-                        for vec in vecs.iter() {
+                        for vec in vecs.clone().iter_mut() {
                             vec.set_all(orig.clone());
                         }
                     });

--- a/twenty-first/src/storage/storage_schema/mod.rs
+++ b/twenty-first/src/storage/storage_schema/mod.rs
@@ -6,6 +6,8 @@
 //! Mutating operations to these "tables" are cached and written to the
 //! database in a single atomic batch operation.
 
+mod dbtmap;
+mod dbtmap_private;
 mod dbtsingleton;
 mod dbtsingleton_private;
 mod dbtvec;
@@ -19,6 +21,7 @@ mod simple_rusty_reader;
 mod simple_rusty_storage;
 pub mod traits;
 
+pub use dbtmap::*;
 pub use dbtsingleton::*;
 pub use dbtvec::*;
 pub use enums::*;
@@ -74,906 +77,969 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_simple_singleton() {
-        let singleton_value = S([1u8, 3u8, 3u8, 7u8].to_vec());
+    mod dbtsingleton {
 
-        // open new DB that will not be dropped on close.
-        let db = DB::open_new_test_database(false, None, None, None).unwrap();
-        let db_path = db.path().clone();
+        use super::*;
 
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        assert_eq!(1, Arc::strong_count(&rusty_storage.schema.reader));
-        let mut singleton = rusty_storage
-            .schema
-            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
-        assert_eq!(2, Arc::strong_count(&rusty_storage.schema.reader));
+        #[test]
+        fn test_simple_singleton() {
+            let singleton_value = S([1u8, 3u8, 3u8, 7u8].to_vec());
 
-        // initialize
-        rusty_storage.restore_or_new();
+            // open new DB that will not be dropped on close.
+            let db = DB::open_new_test_database(false, None, None, None).unwrap();
+            let db_path = db.path().clone();
 
-        // test
-        assert_eq!(singleton.get(), S([].to_vec()));
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            assert_eq!(1, Arc::strong_count(&rusty_storage.schema.reader));
+            let mut singleton = rusty_storage
+                .schema
+                .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+            assert_eq!(2, Arc::strong_count(&rusty_storage.schema.reader));
 
-        // set
-        singleton.set(singleton_value.clone());
+            // initialize
+            rusty_storage.restore_or_new();
 
-        // test
-        assert_eq!(singleton.get(), singleton_value);
+            // test
+            assert_eq!(singleton.get(), S([].to_vec()));
 
-        // persist
-        rusty_storage.persist();
+            // set
+            singleton.set(singleton_value.clone());
 
-        // test
-        assert_eq!(singleton.get(), singleton_value);
+            // test
+            assert_eq!(singleton.get(), singleton_value);
 
-        assert_eq!(2, Arc::strong_count(&rusty_storage.schema.reader));
+            // persist
+            rusty_storage.persist();
 
-        // This is just so we can count reader references
-        // after rusty_storage is dropped.
-        let reader_ref = rusty_storage.schema.reader.clone();
-        assert_eq!(3, Arc::strong_count(&reader_ref));
+            // test
+            assert_eq!(singleton.get(), singleton_value);
 
-        // drop
-        drop(rusty_storage); // <--- 1 reader ref dropped.
-        assert_eq!(2, Arc::strong_count(&reader_ref));
+            assert_eq!(2, Arc::strong_count(&rusty_storage.schema.reader));
 
-        drop(singleton); //     <--- 1 reader ref dropped
-        assert_eq!(1, Arc::strong_count(&reader_ref));
+            // This is just so we can count reader references
+            // after rusty_storage is dropped.
+            let reader_ref = rusty_storage.schema.reader.clone();
+            assert_eq!(3, Arc::strong_count(&reader_ref));
 
-        drop(reader_ref); // <--- Final reader ref dropped. Db closes.
+            // drop
+            drop(rusty_storage); // <--- 1 reader ref dropped.
+            assert_eq!(2, Arc::strong_count(&reader_ref));
 
-        // restore.  re-open existing DB.
-        let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
-        let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
-        let new_singleton = new_rusty_storage
-            .schema
-            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
-        new_rusty_storage.restore_or_new();
+            drop(singleton); //     <--- 1 reader ref dropped
+            assert_eq!(1, Arc::strong_count(&reader_ref));
 
-        // test
-        assert_eq!(new_singleton.get(), singleton_value);
+            drop(reader_ref); // <--- Final reader ref dropped. Db closes.
+
+            // restore.  re-open existing DB.
+            let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
+            let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
+            let new_singleton = new_rusty_storage
+                .schema
+                .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+            new_rusty_storage.restore_or_new();
+
+            // test
+            assert_eq!(new_singleton.get(), singleton_value);
+        }
     }
 
-    #[test]
-    fn test_simple_vector() {
-        // open new DB that will not be dropped on close.
-        let db = DB::open_new_test_database(false, None, None, None).unwrap();
-        let db_path = db.path().clone();
+    mod dbtvec {
 
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
+        use super::*;
 
-        // initialize
-        rusty_storage.restore_or_new();
+        #[test]
+        fn test_simple_vector() {
+            // open new DB that will not be dropped on close.
+            let db = DB::open_new_test_database(false, None, None, None).unwrap();
+            let db_path = db.path().clone();
 
-        // should work to pass empty array, when vector.is_empty() == true
-        vector.set_all([]);
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
-        // test `get_all`
-        assert!(
-            vector.get_all().is_empty(),
-            "`get_all` on unpopulated vector must return empty vector"
-        );
+            // initialize
+            rusty_storage.restore_or_new();
 
-        // populate
-        vector.push(S([1u8].to_vec()));
-        vector.push(S([3u8].to_vec()));
-        vector.push(S([4u8].to_vec()));
-        vector.push(S([7u8].to_vec()));
-        vector.push(S([8u8].to_vec()));
+            // should work to pass empty array, when vector.is_empty() == true
+            vector.set_all([]);
 
-        // test `get`
-        assert_eq!(vector.get(0), S([1u8].to_vec()));
-        assert_eq!(vector.get(1), S([3u8].to_vec()));
-        assert_eq!(vector.get(2), S([4u8].to_vec()));
-        assert_eq!(vector.get(3), S([7u8].to_vec()));
-        assert_eq!(vector.get(4), S([8u8].to_vec()));
-        assert_eq!(vector.len(), 5);
+            // test `get_all`
+            assert!(
+                vector.get_all().is_empty(),
+                "`get_all` on unpopulated vector must return empty vector"
+            );
 
-        // test `get_many`
-        assert_eq!(
-            vector.get_many(&[0, 2, 3]),
-            vec![vector.get(0), vector.get(2), vector.get(3)]
-        );
-        assert_eq!(
-            vector.get_many(&[2, 3, 0]),
-            vec![vector.get(2), vector.get(3), vector.get(0)]
-        );
-        assert_eq!(
-            vector.get_many(&[3, 0, 2]),
-            vec![vector.get(3), vector.get(0), vector.get(2)]
-        );
-        assert_eq!(
-            vector.get_many(&[0, 1, 2, 3, 4]),
-            vec![
-                vector.get(0),
-                vector.get(1),
-                vector.get(2),
-                vector.get(3),
-                vector.get(4),
-            ]
-        );
-        assert_eq!(vector.get_many(&[]), vec![]);
-        assert_eq!(vector.get_many(&[3]), vec![vector.get(3)]);
+            // populate
+            vector.push(S([1u8].to_vec()));
+            vector.push(S([3u8].to_vec()));
+            vector.push(S([4u8].to_vec()));
+            vector.push(S([7u8].to_vec()));
+            vector.push(S([8u8].to_vec()));
 
-        // We allow `get_many` to take repeated indices.
-        assert_eq!(vector.get_many(&[3; 0]), vec![vector.get(3); 0]);
-        assert_eq!(vector.get_many(&[3; 1]), vec![vector.get(3); 1]);
-        assert_eq!(vector.get_many(&[3; 2]), vec![vector.get(3); 2]);
-        assert_eq!(vector.get_many(&[3; 3]), vec![vector.get(3); 3]);
-        assert_eq!(vector.get_many(&[3; 4]), vec![vector.get(3); 4]);
-        assert_eq!(vector.get_many(&[3; 5]), vec![vector.get(3); 5]);
-        assert_eq!(
-            vector.get_many(&[3, 3, 2, 3]),
-            vec![vector.get(3), vector.get(3), vector.get(2), vector.get(3)]
-        );
+            // test `get`
+            assert_eq!(vector.get(0), S([1u8].to_vec()));
+            assert_eq!(vector.get(1), S([3u8].to_vec()));
+            assert_eq!(vector.get(2), S([4u8].to_vec()));
+            assert_eq!(vector.get(3), S([7u8].to_vec()));
+            assert_eq!(vector.get(4), S([8u8].to_vec()));
+            assert_eq!(vector.len(), 5);
 
-        // at this point, `vector` should contain:
-        let expect_values = vec![
-            S([1u8].to_vec()),
-            S([3u8].to_vec()),
-            S([4u8].to_vec()),
-            S([7u8].to_vec()),
-            S([8u8].to_vec()),
-        ];
+            // test `get_many`
+            assert_eq!(
+                vector.get_many(&[0, 2, 3]),
+                vec![vector.get(0), vector.get(2), vector.get(3)]
+            );
+            assert_eq!(
+                vector.get_many(&[2, 3, 0]),
+                vec![vector.get(2), vector.get(3), vector.get(0)]
+            );
+            assert_eq!(
+                vector.get_many(&[3, 0, 2]),
+                vec![vector.get(3), vector.get(0), vector.get(2)]
+            );
+            assert_eq!(
+                vector.get_many(&[0, 1, 2, 3, 4]),
+                vec![
+                    vector.get(0),
+                    vector.get(1),
+                    vector.get(2),
+                    vector.get(3),
+                    vector.get(4),
+                ]
+            );
+            assert_eq!(vector.get_many(&[]), vec![]);
+            assert_eq!(vector.get_many(&[3]), vec![vector.get(3)]);
 
-        // test `get_all`
-        assert_eq!(
-            expect_values,
-            vector.get_all(),
-            "`get_all` must return expected values"
-        );
+            // We allow `get_many` to take repeated indices.
+            assert_eq!(vector.get_many(&[3; 0]), vec![vector.get(3); 0]);
+            assert_eq!(vector.get_many(&[3; 1]), vec![vector.get(3); 1]);
+            assert_eq!(vector.get_many(&[3; 2]), vec![vector.get(3); 2]);
+            assert_eq!(vector.get_many(&[3; 3]), vec![vector.get(3); 3]);
+            assert_eq!(vector.get_many(&[3; 4]), vec![vector.get(3); 4]);
+            assert_eq!(vector.get_many(&[3; 5]), vec![vector.get(3); 5]);
+            assert_eq!(
+                vector.get_many(&[3, 3, 2, 3]),
+                vec![vector.get(3), vector.get(3), vector.get(2), vector.get(3)]
+            );
 
-        // test roundtrip through `set_all`, `get_all`
-        let values_tmp = vec![
-            S([2u8].to_vec()),
-            S([4u8].to_vec()),
-            S([6u8].to_vec()),
-            S([8u8].to_vec()),
-            S([9u8].to_vec()),
-        ];
-        vector.set_all(values_tmp.clone());
-
-        assert_eq!(
-            values_tmp,
-            vector.get_all(),
-            "`get_all` must return values passed to `set_all`",
-        );
-
-        vector.set_all(expect_values.clone());
-
-        // persist
-        rusty_storage.persist();
-
-        // test `get_all` after persist
-        assert_eq!(
-            expect_values,
-            vector.get_all(),
-            "`get_all` must return expected values after persist"
-        );
-
-        // modify
-        let last = vector.pop().unwrap();
-
-        // test
-        assert_eq!(last, S([8u8].to_vec()));
-
-        // drop without persisting
-        drop(rusty_storage); // <--- DB ref dropped.
-        drop(vector); //        <--- Final DB ref dropped. DB closes
-
-        // Open existing database.
-        let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
-
-        let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
-        let mut new_vector = new_rusty_storage.schema.new_vec::<S>("test-vector");
-
-        // initialize
-        new_rusty_storage.restore_or_new();
-
-        // modify
-        new_vector.set(2, S([3u8].to_vec()));
-        println!("vec: {:?}", new_vector);
-        let last_again = new_vector.pop().unwrap();
-        assert_eq!(last_again, S([8u8].to_vec()));
-
-        // test
-        assert_eq!(new_vector.get(0), S([1u8].to_vec()));
-        assert_eq!(new_vector.get(1), S([3u8].to_vec()));
-        assert_eq!(new_vector.get(2), S([3u8].to_vec()));
-        assert_eq!(new_vector.get(3), S([7u8].to_vec()));
-        assert_eq!(new_vector.len(), 4);
-
-        // test `get_many`, ensure that output matches input ordering
-        assert_eq!(new_vector.get_many(&[2]), vec![new_vector.get(2)]);
-        assert_eq!(
-            new_vector.get_many(&[3, 1, 0]),
-            vec![new_vector.get(3), new_vector.get(1), new_vector.get(0)]
-        );
-        assert_eq!(
-            new_vector.get_many(&[0, 2, 3]),
-            vec![new_vector.get(0), new_vector.get(2), new_vector.get(3)]
-        );
-        assert_eq!(
-            new_vector.get_many(&[0, 1, 2, 3]),
-            vec![
-                new_vector.get(0),
-                new_vector.get(1),
-                new_vector.get(2),
-                new_vector.get(3),
-            ]
-        );
-        assert_eq!(new_vector.get_many(&[]), vec![]);
-        assert_eq!(new_vector.get_many(&[3]), vec![new_vector.get(3)]);
-
-        // We allow `get_many` to take repeated indices.
-        assert_eq!(new_vector.get_many(&[3; 0]), vec![new_vector.get(3); 0]);
-        assert_eq!(new_vector.get_many(&[3; 1]), vec![new_vector.get(3); 1]);
-        assert_eq!(new_vector.get_many(&[3; 2]), vec![new_vector.get(3); 2]);
-        assert_eq!(new_vector.get_many(&[3; 3]), vec![new_vector.get(3); 3]);
-        assert_eq!(new_vector.get_many(&[3; 4]), vec![new_vector.get(3); 4]);
-        assert_eq!(new_vector.get_many(&[3; 5]), vec![new_vector.get(3); 5]);
-
-        // test `get_all`
-        assert_eq!(
-            vec![
+            // at this point, `vector` should contain:
+            let expect_values = vec![
                 S([1u8].to_vec()),
                 S([3u8].to_vec()),
-                S([3u8].to_vec()),
-                S([7u8].to_vec()),
-            ],
-            new_vector.get_all(),
-            "`get_all` must return expected values"
-        );
-
-        new_vector.set(1, S([130u8].to_vec()));
-        assert_eq!(
-            vec![
-                S([1u8].to_vec()),
-                S([130u8].to_vec()),
-                S([3u8].to_vec()),
-                S([7u8].to_vec()),
-            ],
-            new_vector.get_all(),
-            "`get_all` must return expected values, after mutation"
-        );
-    }
-
-    #[test]
-    fn test_dbtcvecs_get_many() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
-
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
-
-        // initialize
-        rusty_storage.restore_or_new();
-
-        // populate
-        const TEST_LIST_LENGTH: u8 = 105;
-        for i in 0u8..TEST_LIST_LENGTH {
-            vector.push(S(vec![i, i, i]));
-        }
-
-        let read_indices: Vec<u64> = random_elements::<u64>(30)
-            .into_iter()
-            .map(|x| x % TEST_LIST_LENGTH as u64)
-            .collect();
-        let values = vector.get_many(&read_indices);
-        assert!(read_indices
-            .iter()
-            .zip(values)
-            .all(|(index, value)| value == S(vec![*index as u8, *index as u8, *index as u8])));
-
-        // Mutate some indices
-        let mutate_indices: Vec<u64> = random_elements::<u64>(30)
-            .into_iter()
-            .map(|x| x % TEST_LIST_LENGTH as u64)
-            .collect();
-        for index in mutate_indices.iter() {
-            vector.set(
-                *index,
-                S(vec![*index as u8 + 1, *index as u8 + 1, *index as u8 + 1]),
-            )
-        }
-
-        let new_values = vector.get_many(&read_indices);
-        for (value, index) in new_values.into_iter().zip(read_indices) {
-            if mutate_indices.contains(&index) {
-                assert_eq!(
-                    S(vec![index as u8 + 1, index as u8 + 1, index as u8 + 1]),
-                    value
-                )
-            } else {
-                assert_eq!(S(vec![index as u8, index as u8, index as u8]), value)
-            }
-        }
-    }
-
-    #[test]
-    fn test_dbtcvecs_set_many_get_many() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
-
-        // initialize storage
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        rusty_storage.restore_or_new();
-        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
-
-        // Generate initial index/value pairs.
-        const TEST_LIST_LENGTH: u8 = 105;
-        let init_keyvals: Vec<(Index, S)> = (0u8..TEST_LIST_LENGTH)
-            .map(|i| (i as Index, S(vec![i, i, i])))
-            .collect();
-
-        // set_many() does not grow the list, so we must first push
-        // some empty elems, to desired length.
-        for _ in 0u8..TEST_LIST_LENGTH {
-            vector.push(S(vec![]));
-        }
-
-        // set the initial values
-        vector.set_many(init_keyvals);
-
-        // generate some random indices to read
-        let read_indices: Vec<u64> = random_elements::<u64>(30)
-            .into_iter()
-            .map(|x| x % TEST_LIST_LENGTH as u64)
-            .collect();
-
-        // perform read, and validate as expected
-        let values = vector.get_many(&read_indices);
-        assert!(read_indices
-            .iter()
-            .zip(values)
-            .all(|(index, value)| value == S(vec![*index as u8, *index as u8, *index as u8])));
-
-        // Generate some random indices for mutation
-        let mutate_indices: Vec<u64> = random_elements::<u64>(30)
-            .iter()
-            .map(|x| x % TEST_LIST_LENGTH as u64)
-            .collect();
-
-        // Generate keyvals for mutation
-        let mutate_keyvals: Vec<(Index, S)> = mutate_indices
-            .iter()
-            .map(|index| {
-                let val = (index % TEST_LIST_LENGTH as u64 + 1) as u8;
-                (*index, S(vec![val, val, val]))
-            })
-            .collect();
-
-        // Mutate values at randomly generated indices
-        vector.set_many(mutate_keyvals);
-
-        // Verify mutated values, and non-mutated also.
-        let new_values = vector.get_many(&read_indices);
-        for (value, index) in new_values.into_iter().zip(read_indices.clone()) {
-            if mutate_indices.contains(&index) {
-                assert_eq!(
-                    S(vec![index as u8 + 1, index as u8 + 1, index as u8 + 1]),
-                    value
-                )
-            } else {
-                assert_eq!(S(vec![index as u8, index as u8, index as u8]), value)
-            }
-        }
-
-        // Persist and verify that result is unchanged
-        rusty_storage.persist();
-        let new_values_after_persist = vector.get_many(&read_indices);
-        for (value, index) in new_values_after_persist.into_iter().zip(read_indices) {
-            if mutate_indices.contains(&index) {
-                assert_eq!(
-                    S(vec![index as u8 + 1, index as u8 + 1, index as u8 + 1]),
-                    value
-                )
-            } else {
-                assert_eq!(S(vec![index as u8, index as u8, index as u8]), value)
-            }
-        }
-    }
-
-    #[test]
-    fn test_dbtcvecs_set_all_get_many() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
-
-        // initialize storage
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        rusty_storage.restore_or_new();
-        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
-
-        // Generate initial index/value pairs.
-        const TEST_LIST_LENGTH: u8 = 105;
-        let init_vals: Vec<S> = (0u8..TEST_LIST_LENGTH)
-            .map(|i| (S(vec![i, i, i])))
-            .collect();
-
-        let mut mutate_vals = init_vals.clone(); // for later
-
-        // set_all() does not grow the list, so we must first push
-        // some empty elems, to desired length.
-        for _ in 0u8..TEST_LIST_LENGTH {
-            vector.push(S(vec![]));
-        }
-
-        // set the initial values
-        vector.set_all(init_vals);
-
-        // generate some random indices to read
-        let read_indices: Vec<u64> = random_elements::<u64>(30)
-            .into_iter()
-            .map(|x| x % TEST_LIST_LENGTH as u64)
-            .collect();
-
-        // perform read, and validate as expected
-        let values = vector.get_many(&read_indices);
-        assert!(read_indices
-            .iter()
-            .zip(values)
-            .all(|(index, value)| value == S(vec![*index as u8, *index as u8, *index as u8])));
-
-        // Generate some random indices for mutation
-        let mutate_indices: Vec<u64> = random_elements::<u64>(30)
-            .iter()
-            .map(|x| x % TEST_LIST_LENGTH as u64)
-            .collect();
-
-        // Generate vals for mutation
-        for index in mutate_indices.iter() {
-            let val = (index % TEST_LIST_LENGTH as u64 + 1) as u8;
-            mutate_vals[*index as usize] = S(vec![val, val, val]);
-        }
-
-        // Mutate values at randomly generated indices
-        vector.set_all(mutate_vals);
-
-        // Verify mutated values, and non-mutated also.
-        let new_values = vector.get_many(&read_indices);
-        for (value, index) in new_values.into_iter().zip(read_indices) {
-            if mutate_indices.contains(&index) {
-                assert_eq!(
-                    S(vec![index as u8 + 1, index as u8 + 1, index as u8 + 1]),
-                    value
-                )
-            } else {
-                assert_eq!(S(vec![index as u8, index as u8, index as u8]), value)
-            }
-        }
-    }
-
-    #[test]
-    fn storage_schema_vector_pbt() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
-
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        let mut persisted_vector = rusty_storage.schema.new_vec::<u64>("test-vector");
-
-        // Insert 1000 elements
-        let mut rng = rand::thread_rng();
-        let mut normal_vector = vec![];
-        for _ in 0..1000 {
-            let value = random();
-            normal_vector.push(value);
-            persisted_vector.push(value);
-        }
-        rusty_storage.persist();
-
-        for _ in 0..1000 {
-            match rng.gen_range(0..=5) {
-                0 => {
-                    // `push`
-                    let push_val = rng.next_u64();
-                    persisted_vector.push(push_val);
-                    normal_vector.push(push_val);
-                }
-                1 => {
-                    // `pop`
-                    let persisted_pop_val = persisted_vector.pop().unwrap();
-                    let normal_pop_val = normal_vector.pop().unwrap();
-                    assert_eq!(persisted_pop_val, normal_pop_val);
-                }
-                2 => {
-                    // `get_many`
-                    assert_eq!(normal_vector.len(), persisted_vector.len() as usize);
-
-                    let index = rng.gen_range(0..normal_vector.len());
-                    assert_eq!(Vec::<u64>::default(), persisted_vector.get_many(&[]));
-                    assert_eq!(normal_vector[index], persisted_vector.get(index as u64));
-                    assert_eq!(
-                        vec![normal_vector[index]],
-                        persisted_vector.get_many(&[index as u64])
-                    );
-                    assert_eq!(
-                        vec![normal_vector[index], normal_vector[index]],
-                        persisted_vector.get_many(&[index as u64, index as u64])
-                    );
-                }
-                3 => {
-                    // `set`
-                    let value = rng.next_u64();
-                    let index = rng.gen_range(0..normal_vector.len());
-                    normal_vector[index] = value;
-                    persisted_vector.set(index as u64, value);
-                }
-                4 => {
-                    // `set_many`
-                    let indices: Vec<u64> = (0..rng.gen_range(0..10))
-                        .map(|_| rng.gen_range(0..normal_vector.len() as u64))
-                        .unique()
-                        .collect();
-                    let values: Vec<u64> = (0..indices.len()).map(|_| rng.next_u64()).collect_vec();
-                    let update: Vec<(u64, u64)> =
-                        indices.into_iter().zip_eq(values.into_iter()).collect();
-                    for (key, val) in update.iter() {
-                        normal_vector[*key as usize] = *val;
-                    }
-                    persisted_vector.set_many(update);
-                }
-                5 => {
-                    // persist
-                    rusty_storage.persist();
-                }
-                _ => unreachable!(),
-            }
-        }
-
-        // Check equality after above loop
-        assert_eq!(normal_vector.len(), persisted_vector.len() as usize);
-        for (i, nvi) in normal_vector.iter().enumerate() {
-            assert_eq!(*nvi, persisted_vector.get(i as u64));
-        }
-
-        // Check equality using `get_many`
-        assert_eq!(
-            normal_vector,
-            persisted_vector.get_many(&(0..normal_vector.len() as u64).collect_vec())
-        );
-
-        // Check equality after persisting updates
-        rusty_storage.persist();
-        assert_eq!(normal_vector.len(), persisted_vector.len() as usize);
-        for (i, nvi) in normal_vector.iter().enumerate() {
-            assert_eq!(*nvi, persisted_vector.get(i as u64));
-        }
-
-        // Check equality using `get_many`
-        assert_eq!(
-            normal_vector,
-            persisted_vector.get_many(&(0..normal_vector.len() as u64).collect_vec())
-        );
-    }
-
-    #[test]
-    fn test_two_vectors_and_singleton() {
-        let singleton_value = S([3u8, 3u8, 3u8, 1u8].to_vec());
-
-        // Open new database that will not be destroyed on close.
-        let db = DB::open_new_test_database(false, None, None, None).unwrap();
-        let db_path = db.path().clone();
-
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        let mut vector1 = rusty_storage.schema.new_vec::<S>("test-vector1");
-        let mut vector2 = rusty_storage.schema.new_vec::<S>("test-vector2");
-        let mut singleton = rusty_storage
-            .schema
-            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
-
-        // initialize
-        rusty_storage.restore_or_new();
-
-        assert!(
-            vector1.get_all().is_empty(),
-            "`get_all` call to unpopulated persistent vector must return empty vector"
-        );
-        assert!(
-            vector2.get_all().is_empty(),
-            "`get_all` call to unpopulated persistent vector must return empty vector"
-        );
-
-        // populate 1
-        vector1.push(S([1u8].to_vec()));
-        vector1.push(S([30u8].to_vec()));
-        vector1.push(S([4u8].to_vec()));
-        vector1.push(S([7u8].to_vec()));
-        vector1.push(S([8u8].to_vec()));
-
-        // populate 2
-        vector2.push(S([1u8].to_vec()));
-        vector2.push(S([3u8].to_vec()));
-        vector2.push(S([3u8].to_vec()));
-        vector2.push(S([7u8].to_vec()));
-
-        // set singleton
-        singleton.set(singleton_value.clone());
-
-        // modify 1
-        vector1.set(0, S([8u8].to_vec()));
-
-        // test
-        assert_eq!(vector1.get(0), S([8u8].to_vec()));
-        assert_eq!(vector1.get(1), S([30u8].to_vec()));
-        assert_eq!(vector1.get(2), S([4u8].to_vec()));
-        assert_eq!(vector1.get(3), S([7u8].to_vec()));
-        assert_eq!(vector1.get(4), S([8u8].to_vec()));
-        assert_eq!(
-            vector1.get_many(&[2, 0, 3]),
-            vec![vector1.get(2), vector1.get(0), vector1.get(3)]
-        );
-        assert_eq!(
-            vector1.get_many(&[2, 3, 1]),
-            vec![vector1.get(2), vector1.get(3), vector1.get(1)]
-        );
-        assert_eq!(vector1.len(), 5);
-        assert_eq!(vector2.get(0), S([1u8].to_vec()));
-        assert_eq!(vector2.get(1), S([3u8].to_vec()));
-        assert_eq!(vector2.get(2), S([3u8].to_vec()));
-        assert_eq!(vector2.get(3), S([7u8].to_vec()));
-        assert_eq!(
-            vector2.get_many(&[0, 1, 2]),
-            vec![vector2.get(0), vector2.get(1), vector2.get(2)]
-        );
-        assert_eq!(vector2.get_many(&[]), vec![]);
-        assert_eq!(
-            vector2.get_many(&[1, 2]),
-            vec![vector2.get(1), vector2.get(2)]
-        );
-        assert_eq!(
-            vector2.get_many(&[2, 1]),
-            vec![vector2.get(2), vector2.get(1)]
-        );
-        assert_eq!(vector2.len(), 4);
-        assert_eq!(singleton.get(), singleton_value);
-        assert_eq!(
-            vec![
-                S([8u8].to_vec()),
-                S([30u8].to_vec()),
                 S([4u8].to_vec()),
                 S([7u8].to_vec()),
-                S([8u8].to_vec())
-            ],
-            vector1.get_all()
-        );
-        assert_eq!(
-            vec![
-                S([1u8].to_vec()),
-                S([3u8].to_vec()),
-                S([3u8].to_vec()),
-                S([7u8].to_vec()),
-            ],
-            vector2.get_all()
-        );
+                S([8u8].to_vec()),
+            ];
 
-        // persist and drop
-        rusty_storage.persist();
-        assert_eq!(
-            vector2.get_many(&[2, 1]),
-            vec![vector2.get(2), vector2.get(1)]
-        );
-        drop(rusty_storage); // <-- DB ref dropped
-        drop(vector1); //       <-- DB ref dropped
-        drop(vector2); //       <-- DB ref dropped
-        drop(singleton); //     <-- final DB ref dropped (DB closes)
+            // test `get_all`
+            assert_eq!(
+                expect_values,
+                vector.get_all(),
+                "`get_all` must return expected values"
+            );
 
-        // re-open DB / restore from disk
-        let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
-        let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
-        let new_vector1 = new_rusty_storage.schema.new_vec::<S>("test-vector1");
-        let mut new_vector2 = new_rusty_storage.schema.new_vec::<S>("test-vector2");
-        new_rusty_storage.restore_or_new();
-        let new_singleton = new_rusty_storage
-            .schema
-            .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
-        new_rusty_storage.restore_or_new();
+            // test roundtrip through `set_all`, `get_all`
+            let values_tmp = vec![
+                S([2u8].to_vec()),
+                S([4u8].to_vec()),
+                S([6u8].to_vec()),
+                S([8u8].to_vec()),
+                S([9u8].to_vec()),
+            ];
+            vector.set_all(values_tmp.clone());
 
-        // test again
-        assert_eq!(new_vector1.get(0), S([8u8].to_vec()));
-        assert_eq!(new_vector1.get(1), S([30u8].to_vec()));
-        assert_eq!(new_vector1.get(2), S([4u8].to_vec()));
-        assert_eq!(new_vector1.get(3), S([7u8].to_vec()));
-        assert_eq!(new_vector1.get(4), S([8u8].to_vec()));
-        assert_eq!(new_vector1.len(), 5);
-        assert_eq!(new_vector2.get(0), S([1u8].to_vec()));
-        assert_eq!(new_vector2.get(1), S([3u8].to_vec()));
-        assert_eq!(new_vector2.get(2), S([3u8].to_vec()));
-        assert_eq!(new_vector2.get(3), S([7u8].to_vec()));
-        assert_eq!(new_vector2.len(), 4);
-        assert_eq!(new_singleton.get(), singleton_value);
+            assert_eq!(
+                values_tmp,
+                vector.get_all(),
+                "`get_all` must return values passed to `set_all`",
+            );
 
-        // Test `get_many` for a restored DB
-        assert_eq!(
-            new_vector2.get_many(&[2, 1]),
-            vec![new_vector2.get(2), new_vector2.get(1)]
-        );
-        assert_eq!(
-            new_vector2.get_many(&[0, 1]),
-            vec![new_vector2.get(0), new_vector2.get(1)]
-        );
-        assert_eq!(
-            new_vector2.get_many(&[1, 0]),
-            vec![new_vector2.get(1), new_vector2.get(0)]
-        );
-        assert_eq!(
-            new_vector2.get_many(&[0, 1, 2, 3]),
-            vec![
-                new_vector2.get(0),
-                new_vector2.get(1),
-                new_vector2.get(2),
-                new_vector2.get(3),
-            ]
-        );
-        assert_eq!(new_vector2.get_many(&[2]), vec![new_vector2.get(2),]);
-        assert_eq!(new_vector2.get_many(&[]), vec![]);
+            vector.set_all(expect_values.clone());
 
-        // Test `get_all` for a restored DB
-        assert_eq!(
-            vec![
-                S([1u8].to_vec()),
-                S([3u8].to_vec()),
-                S([3u8].to_vec()),
-                S([7u8].to_vec()),
-            ],
-            new_vector2.get_all(),
-            "`get_all` must return expected values, before mutation"
-        );
-        new_vector2.set(1, S([130u8].to_vec()));
-        assert_eq!(
-            vec![
-                S([1u8].to_vec()),
-                S([130u8].to_vec()),
-                S([3u8].to_vec()),
-                S([7u8].to_vec()),
-            ],
-            new_vector2.get_all(),
-            "`get_all` must return expected values, after mutation"
-        );
-    }
+            // persist
+            rusty_storage.persist();
 
-    #[should_panic(
-        expected = "Out-of-bounds. Got 2 but length was 2. persisted vector name: test-vector"
-    )]
-    #[test]
-    fn out_of_bounds_using_get() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
+            // test `get_all` after persist
+            assert_eq!(
+                expect_values,
+                vector.get_all(),
+                "`get_all` must return expected values after persist"
+            );
 
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+            // modify
+            let last = vector.pop().unwrap();
 
-        // initialize
-        rusty_storage.restore_or_new();
+            // test
+            assert_eq!(last, S([8u8].to_vec()));
 
-        vector.push(1);
-        vector.push(1);
-        vector.get(2);
-    }
+            // drop without persisting
+            drop(rusty_storage); // <--- DB ref dropped.
+            drop(vector); //        <--- Final DB ref dropped. DB closes
 
-    #[should_panic(
-        expected = "Out-of-bounds. Got index 2 but length was 2. persisted vector name: test-vector"
-    )]
-    #[test]
-    fn out_of_bounds_using_get_many() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
+            // Open existing database.
+            let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
 
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+            let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
+            let mut new_vector = new_rusty_storage.schema.new_vec::<S>("test-vector");
 
-        // initialize
-        rusty_storage.restore_or_new();
+            // initialize
+            new_rusty_storage.restore_or_new();
 
-        vector.push(1);
-        vector.push(1);
-        vector.get_many(&[0, 0, 0, 1, 1, 2]);
-    }
+            // modify
+            new_vector.set(2, S([3u8].to_vec()));
+            println!("vec: {:?}", new_vector);
+            let last_again = new_vector.pop().unwrap();
+            assert_eq!(last_again, S([8u8].to_vec()));
 
-    #[should_panic(
-        expected = "Out-of-bounds. Got 1 but length was 1. persisted vector name: test-vector"
-    )]
-    #[test]
-    fn out_of_bounds_using_set_many() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
+            // test
+            assert_eq!(new_vector.get(0), S([1u8].to_vec()));
+            assert_eq!(new_vector.get(1), S([3u8].to_vec()));
+            assert_eq!(new_vector.get(2), S([3u8].to_vec()));
+            assert_eq!(new_vector.get(3), S([7u8].to_vec()));
+            assert_eq!(new_vector.len(), 4);
 
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+            // test `get_many`, ensure that output matches input ordering
+            assert_eq!(new_vector.get_many(&[2]), vec![new_vector.get(2)]);
+            assert_eq!(
+                new_vector.get_many(&[3, 1, 0]),
+                vec![new_vector.get(3), new_vector.get(1), new_vector.get(0)]
+            );
+            assert_eq!(
+                new_vector.get_many(&[0, 2, 3]),
+                vec![new_vector.get(0), new_vector.get(2), new_vector.get(3)]
+            );
+            assert_eq!(
+                new_vector.get_many(&[0, 1, 2, 3]),
+                vec![
+                    new_vector.get(0),
+                    new_vector.get(1),
+                    new_vector.get(2),
+                    new_vector.get(3),
+                ]
+            );
+            assert_eq!(new_vector.get_many(&[]), vec![]);
+            assert_eq!(new_vector.get_many(&[3]), vec![new_vector.get(3)]);
 
-        // initialize
-        rusty_storage.restore_or_new();
+            // We allow `get_many` to take repeated indices.
+            assert_eq!(new_vector.get_many(&[3; 0]), vec![new_vector.get(3); 0]);
+            assert_eq!(new_vector.get_many(&[3; 1]), vec![new_vector.get(3); 1]);
+            assert_eq!(new_vector.get_many(&[3; 2]), vec![new_vector.get(3); 2]);
+            assert_eq!(new_vector.get_many(&[3; 3]), vec![new_vector.get(3); 3]);
+            assert_eq!(new_vector.get_many(&[3; 4]), vec![new_vector.get(3); 4]);
+            assert_eq!(new_vector.get_many(&[3; 5]), vec![new_vector.get(3); 5]);
 
-        vector.push(1);
+            // test `get_all`
+            assert_eq!(
+                vec![
+                    S([1u8].to_vec()),
+                    S([3u8].to_vec()),
+                    S([3u8].to_vec()),
+                    S([7u8].to_vec()),
+                ],
+                new_vector.get_all(),
+                "`get_all` must return expected values"
+            );
 
-        // attempt to set 2 values, when only one is in vector.
-        vector.set_many([(0, 0), (1, 1)]);
-    }
+            new_vector.set(1, S([130u8].to_vec()));
+            assert_eq!(
+                vec![
+                    S([1u8].to_vec()),
+                    S([130u8].to_vec()),
+                    S([3u8].to_vec()),
+                    S([7u8].to_vec()),
+                ],
+                new_vector.get_all(),
+                "`get_all` must return expected values, after mutation"
+            );
+        }
 
-    #[should_panic(expected = "size-mismatch.  input has 2 elements and target has 1 elements")]
-    #[test]
-    fn size_mismatch_too_many_using_set_all() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
+        #[test]
+        fn test_dbtcvecs_get_many() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
-        // initialize
-        rusty_storage.restore_or_new();
+            // initialize
+            rusty_storage.restore_or_new();
 
-        vector.push(1);
+            // populate
+            const TEST_LIST_LENGTH: u8 = 105;
+            for i in 0u8..TEST_LIST_LENGTH {
+                vector.push(S(vec![i, i, i]));
+            }
 
-        // attempt to set 2 values, when only one is in vector.
-        vector.set_all([0, 1]);
-    }
+            let read_indices: Vec<u64> = random_elements::<u64>(30)
+                .into_iter()
+                .map(|x| x % TEST_LIST_LENGTH as u64)
+                .collect();
+            let values = vector.get_many(&read_indices);
+            assert!(read_indices
+                .iter()
+                .zip(values)
+                .all(|(index, value)| value == S(vec![*index as u8, *index as u8, *index as u8])));
 
-    #[should_panic(expected = "size-mismatch.  input has 1 elements and target has 2 elements")]
-    #[test]
-    fn size_mismatch_too_few_using_set_all() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
+            // Mutate some indices
+            let mutate_indices: Vec<u64> = random_elements::<u64>(30)
+                .into_iter()
+                .map(|x| x % TEST_LIST_LENGTH as u64)
+                .collect();
+            for index in mutate_indices.iter() {
+                vector.set(
+                    *index,
+                    S(vec![*index as u8 + 1, *index as u8 + 1, *index as u8 + 1]),
+                )
+            }
 
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+            let new_values = vector.get_many(&read_indices);
+            for (value, index) in new_values.into_iter().zip(read_indices) {
+                if mutate_indices.contains(&index) {
+                    assert_eq!(
+                        S(vec![index as u8 + 1, index as u8 + 1, index as u8 + 1]),
+                        value
+                    )
+                } else {
+                    assert_eq!(S(vec![index as u8, index as u8, index as u8]), value)
+                }
+            }
+        }
 
-        // initialize
-        rusty_storage.restore_or_new();
+        #[test]
+        fn test_dbtcvecs_set_many_get_many() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
-        vector.push(0);
-        vector.push(1);
+            // initialize storage
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            rusty_storage.restore_or_new();
+            let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
-        // attempt to set 1 values, when two are in vector.
-        vector.set_all([5]);
-    }
+            // Generate initial index/value pairs.
+            const TEST_LIST_LENGTH: u8 = 105;
+            let init_keyvals: Vec<(Index, S)> = (0u8..TEST_LIST_LENGTH)
+                .map(|i| (i as Index, S(vec![i, i, i])))
+                .collect();
 
-    #[test]
-    fn test_dbtcvecs_iter_mut() {
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
+            // set_many() does not grow the list, so we must first push
+            // some empty elems, to desired length.
+            for _ in 0u8..TEST_LIST_LENGTH {
+                vector.push(S(vec![]));
+            }
 
-        // initialize storage
-        let mut rusty_storage = SimpleRustyStorage::new(db);
-        rusty_storage.restore_or_new();
-        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+            // set the initial values
+            vector.set_many(init_keyvals);
 
-        // Generate initial index/value pairs.
-        const TEST_LIST_LENGTH: u64 = 105;
-        let init_vals: Vec<u64> = (0..TEST_LIST_LENGTH).map(|i| i * 2).collect();
+            // generate some random indices to read
+            let read_indices: Vec<u64> = random_elements::<u64>(30)
+                .into_iter()
+                .map(|x| x % TEST_LIST_LENGTH as u64)
+                .collect();
 
-        // let mut mutate_vals = init_vals.clone(); // for later
+            // perform read, and validate as expected
+            let values = vector.get_many(&read_indices);
+            assert!(read_indices
+                .iter()
+                .zip(values)
+                .all(|(index, value)| value == S(vec![*index as u8, *index as u8, *index as u8])));
 
-        // set_all() does not grow the list, so we must first push
-        // some empty elems, to desired length.
-        for _ in 0..TEST_LIST_LENGTH {
+            // Generate some random indices for mutation
+            let mutate_indices: Vec<u64> = random_elements::<u64>(30)
+                .iter()
+                .map(|x| x % TEST_LIST_LENGTH as u64)
+                .collect();
+
+            // Generate keyvals for mutation
+            let mutate_keyvals: Vec<(Index, S)> = mutate_indices
+                .iter()
+                .map(|index| {
+                    let val = (index % TEST_LIST_LENGTH as u64 + 1) as u8;
+                    (*index, S(vec![val, val, val]))
+                })
+                .collect();
+
+            // Mutate values at randomly generated indices
+            vector.set_many(mutate_keyvals);
+
+            // Verify mutated values, and non-mutated also.
+            let new_values = vector.get_many(&read_indices);
+            for (value, index) in new_values.into_iter().zip(read_indices.clone()) {
+                if mutate_indices.contains(&index) {
+                    assert_eq!(
+                        S(vec![index as u8 + 1, index as u8 + 1, index as u8 + 1]),
+                        value
+                    )
+                } else {
+                    assert_eq!(S(vec![index as u8, index as u8, index as u8]), value)
+                }
+            }
+
+            // Persist and verify that result is unchanged
+            rusty_storage.persist();
+            let new_values_after_persist = vector.get_many(&read_indices);
+            for (value, index) in new_values_after_persist.into_iter().zip(read_indices) {
+                if mutate_indices.contains(&index) {
+                    assert_eq!(
+                        S(vec![index as u8 + 1, index as u8 + 1, index as u8 + 1]),
+                        value
+                    )
+                } else {
+                    assert_eq!(S(vec![index as u8, index as u8, index as u8]), value)
+                }
+            }
+        }
+
+        #[test]
+        fn test_dbtcvecs_set_all_get_many() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
+
+            // initialize storage
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            rusty_storage.restore_or_new();
+            let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
+
+            // Generate initial index/value pairs.
+            const TEST_LIST_LENGTH: u8 = 105;
+            let init_vals: Vec<S> = (0u8..TEST_LIST_LENGTH)
+                .map(|i| (S(vec![i, i, i])))
+                .collect();
+
+            let mut mutate_vals = init_vals.clone(); // for later
+
+            // set_all() does not grow the list, so we must first push
+            // some empty elems, to desired length.
+            for _ in 0u8..TEST_LIST_LENGTH {
+                vector.push(S(vec![]));
+            }
+
+            // set the initial values
+            vector.set_all(init_vals);
+
+            // generate some random indices to read
+            let read_indices: Vec<u64> = random_elements::<u64>(30)
+                .into_iter()
+                .map(|x| x % TEST_LIST_LENGTH as u64)
+                .collect();
+
+            // perform read, and validate as expected
+            let values = vector.get_many(&read_indices);
+            assert!(read_indices
+                .iter()
+                .zip(values)
+                .all(|(index, value)| value == S(vec![*index as u8, *index as u8, *index as u8])));
+
+            // Generate some random indices for mutation
+            let mutate_indices: Vec<u64> = random_elements::<u64>(30)
+                .iter()
+                .map(|x| x % TEST_LIST_LENGTH as u64)
+                .collect();
+
+            // Generate vals for mutation
+            for index in mutate_indices.iter() {
+                let val = (index % TEST_LIST_LENGTH as u64 + 1) as u8;
+                mutate_vals[*index as usize] = S(vec![val, val, val]);
+            }
+
+            // Mutate values at randomly generated indices
+            vector.set_all(mutate_vals);
+
+            // Verify mutated values, and non-mutated also.
+            let new_values = vector.get_many(&read_indices);
+            for (value, index) in new_values.into_iter().zip(read_indices) {
+                if mutate_indices.contains(&index) {
+                    assert_eq!(
+                        S(vec![index as u8 + 1, index as u8 + 1, index as u8 + 1]),
+                        value
+                    )
+                } else {
+                    assert_eq!(S(vec![index as u8, index as u8, index as u8]), value)
+                }
+            }
+        }
+
+        #[test]
+        fn storage_schema_vector_pbt() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
+
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            let mut persisted_vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+
+            // Insert 1000 elements
+            let mut rng = rand::thread_rng();
+            let mut normal_vector = vec![];
+            for _ in 0..1000 {
+                let value = random();
+                normal_vector.push(value);
+                persisted_vector.push(value);
+            }
+            rusty_storage.persist();
+
+            for _ in 0..1000 {
+                match rng.gen_range(0..=5) {
+                    0 => {
+                        // `push`
+                        let push_val = rng.next_u64();
+                        persisted_vector.push(push_val);
+                        normal_vector.push(push_val);
+                    }
+                    1 => {
+                        // `pop`
+                        let persisted_pop_val = persisted_vector.pop().unwrap();
+                        let normal_pop_val = normal_vector.pop().unwrap();
+                        assert_eq!(persisted_pop_val, normal_pop_val);
+                    }
+                    2 => {
+                        // `get_many`
+                        assert_eq!(normal_vector.len(), persisted_vector.len() as usize);
+
+                        let index = rng.gen_range(0..normal_vector.len());
+                        assert_eq!(Vec::<u64>::default(), persisted_vector.get_many(&[]));
+                        assert_eq!(normal_vector[index], persisted_vector.get(index as u64));
+                        assert_eq!(
+                            vec![normal_vector[index]],
+                            persisted_vector.get_many(&[index as u64])
+                        );
+                        assert_eq!(
+                            vec![normal_vector[index], normal_vector[index]],
+                            persisted_vector.get_many(&[index as u64, index as u64])
+                        );
+                    }
+                    3 => {
+                        // `set`
+                        let value = rng.next_u64();
+                        let index = rng.gen_range(0..normal_vector.len());
+                        normal_vector[index] = value;
+                        persisted_vector.set(index as u64, value);
+                    }
+                    4 => {
+                        // `set_many`
+                        let indices: Vec<u64> = (0..rng.gen_range(0..10))
+                            .map(|_| rng.gen_range(0..normal_vector.len() as u64))
+                            .unique()
+                            .collect();
+                        let values: Vec<u64> =
+                            (0..indices.len()).map(|_| rng.next_u64()).collect_vec();
+                        let update: Vec<(u64, u64)> =
+                            indices.into_iter().zip_eq(values.into_iter()).collect();
+                        for (key, val) in update.iter() {
+                            normal_vector[*key as usize] = *val;
+                        }
+                        persisted_vector.set_many(update);
+                    }
+                    5 => {
+                        // persist
+                        rusty_storage.persist();
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            // Check equality after above loop
+            assert_eq!(normal_vector.len(), persisted_vector.len() as usize);
+            for (i, nvi) in normal_vector.iter().enumerate() {
+                assert_eq!(*nvi, persisted_vector.get(i as u64));
+            }
+
+            // Check equality using `get_many`
+            assert_eq!(
+                normal_vector,
+                persisted_vector.get_many(&(0..normal_vector.len() as u64).collect_vec())
+            );
+
+            // Check equality after persisting updates
+            rusty_storage.persist();
+            assert_eq!(normal_vector.len(), persisted_vector.len() as usize);
+            for (i, nvi) in normal_vector.iter().enumerate() {
+                assert_eq!(*nvi, persisted_vector.get(i as u64));
+            }
+
+            // Check equality using `get_many`
+            assert_eq!(
+                normal_vector,
+                persisted_vector.get_many(&(0..normal_vector.len() as u64).collect_vec())
+            );
+        }
+
+        #[test]
+        fn test_two_vectors_and_singleton() {
+            let singleton_value = S([3u8, 3u8, 3u8, 1u8].to_vec());
+
+            // Open new database that will not be destroyed on close.
+            let db = DB::open_new_test_database(false, None, None, None).unwrap();
+            let db_path = db.path().clone();
+
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            let mut vector1 = rusty_storage.schema.new_vec::<S>("test-vector1");
+            let mut vector2 = rusty_storage.schema.new_vec::<S>("test-vector2");
+            let mut singleton = rusty_storage
+                .schema
+                .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+
+            // initialize
+            rusty_storage.restore_or_new();
+
+            assert!(
+                vector1.get_all().is_empty(),
+                "`get_all` call to unpopulated persistent vector must return empty vector"
+            );
+            assert!(
+                vector2.get_all().is_empty(),
+                "`get_all` call to unpopulated persistent vector must return empty vector"
+            );
+
+            // populate 1
+            vector1.push(S([1u8].to_vec()));
+            vector1.push(S([30u8].to_vec()));
+            vector1.push(S([4u8].to_vec()));
+            vector1.push(S([7u8].to_vec()));
+            vector1.push(S([8u8].to_vec()));
+
+            // populate 2
+            vector2.push(S([1u8].to_vec()));
+            vector2.push(S([3u8].to_vec()));
+            vector2.push(S([3u8].to_vec()));
+            vector2.push(S([7u8].to_vec()));
+
+            // set singleton
+            singleton.set(singleton_value.clone());
+
+            // modify 1
+            vector1.set(0, S([8u8].to_vec()));
+
+            // test
+            assert_eq!(vector1.get(0), S([8u8].to_vec()));
+            assert_eq!(vector1.get(1), S([30u8].to_vec()));
+            assert_eq!(vector1.get(2), S([4u8].to_vec()));
+            assert_eq!(vector1.get(3), S([7u8].to_vec()));
+            assert_eq!(vector1.get(4), S([8u8].to_vec()));
+            assert_eq!(
+                vector1.get_many(&[2, 0, 3]),
+                vec![vector1.get(2), vector1.get(0), vector1.get(3)]
+            );
+            assert_eq!(
+                vector1.get_many(&[2, 3, 1]),
+                vec![vector1.get(2), vector1.get(3), vector1.get(1)]
+            );
+            assert_eq!(vector1.len(), 5);
+            assert_eq!(vector2.get(0), S([1u8].to_vec()));
+            assert_eq!(vector2.get(1), S([3u8].to_vec()));
+            assert_eq!(vector2.get(2), S([3u8].to_vec()));
+            assert_eq!(vector2.get(3), S([7u8].to_vec()));
+            assert_eq!(
+                vector2.get_many(&[0, 1, 2]),
+                vec![vector2.get(0), vector2.get(1), vector2.get(2)]
+            );
+            assert_eq!(vector2.get_many(&[]), vec![]);
+            assert_eq!(
+                vector2.get_many(&[1, 2]),
+                vec![vector2.get(1), vector2.get(2)]
+            );
+            assert_eq!(
+                vector2.get_many(&[2, 1]),
+                vec![vector2.get(2), vector2.get(1)]
+            );
+            assert_eq!(vector2.len(), 4);
+            assert_eq!(singleton.get(), singleton_value);
+            assert_eq!(
+                vec![
+                    S([8u8].to_vec()),
+                    S([30u8].to_vec()),
+                    S([4u8].to_vec()),
+                    S([7u8].to_vec()),
+                    S([8u8].to_vec())
+                ],
+                vector1.get_all()
+            );
+            assert_eq!(
+                vec![
+                    S([1u8].to_vec()),
+                    S([3u8].to_vec()),
+                    S([3u8].to_vec()),
+                    S([7u8].to_vec()),
+                ],
+                vector2.get_all()
+            );
+
+            // persist and drop
+            rusty_storage.persist();
+            assert_eq!(
+                vector2.get_many(&[2, 1]),
+                vec![vector2.get(2), vector2.get(1)]
+            );
+            drop(rusty_storage); // <-- DB ref dropped
+            drop(vector1); //       <-- DB ref dropped
+            drop(vector2); //       <-- DB ref dropped
+            drop(singleton); //     <-- final DB ref dropped (DB closes)
+
+            // re-open DB / restore from disk
+            let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
+            let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
+            let new_vector1 = new_rusty_storage.schema.new_vec::<S>("test-vector1");
+            let mut new_vector2 = new_rusty_storage.schema.new_vec::<S>("test-vector2");
+            new_rusty_storage.restore_or_new();
+            let new_singleton = new_rusty_storage
+                .schema
+                .new_singleton::<S>(RustyKey([1u8; 1].to_vec()));
+            new_rusty_storage.restore_or_new();
+
+            // test again
+            assert_eq!(new_vector1.get(0), S([8u8].to_vec()));
+            assert_eq!(new_vector1.get(1), S([30u8].to_vec()));
+            assert_eq!(new_vector1.get(2), S([4u8].to_vec()));
+            assert_eq!(new_vector1.get(3), S([7u8].to_vec()));
+            assert_eq!(new_vector1.get(4), S([8u8].to_vec()));
+            assert_eq!(new_vector1.len(), 5);
+            assert_eq!(new_vector2.get(0), S([1u8].to_vec()));
+            assert_eq!(new_vector2.get(1), S([3u8].to_vec()));
+            assert_eq!(new_vector2.get(2), S([3u8].to_vec()));
+            assert_eq!(new_vector2.get(3), S([7u8].to_vec()));
+            assert_eq!(new_vector2.len(), 4);
+            assert_eq!(new_singleton.get(), singleton_value);
+
+            // Test `get_many` for a restored DB
+            assert_eq!(
+                new_vector2.get_many(&[2, 1]),
+                vec![new_vector2.get(2), new_vector2.get(1)]
+            );
+            assert_eq!(
+                new_vector2.get_many(&[0, 1]),
+                vec![new_vector2.get(0), new_vector2.get(1)]
+            );
+            assert_eq!(
+                new_vector2.get_many(&[1, 0]),
+                vec![new_vector2.get(1), new_vector2.get(0)]
+            );
+            assert_eq!(
+                new_vector2.get_many(&[0, 1, 2, 3]),
+                vec![
+                    new_vector2.get(0),
+                    new_vector2.get(1),
+                    new_vector2.get(2),
+                    new_vector2.get(3),
+                ]
+            );
+            assert_eq!(new_vector2.get_many(&[2]), vec![new_vector2.get(2),]);
+            assert_eq!(new_vector2.get_many(&[]), vec![]);
+
+            // Test `get_all` for a restored DB
+            assert_eq!(
+                vec![
+                    S([1u8].to_vec()),
+                    S([3u8].to_vec()),
+                    S([3u8].to_vec()),
+                    S([7u8].to_vec()),
+                ],
+                new_vector2.get_all(),
+                "`get_all` must return expected values, before mutation"
+            );
+            new_vector2.set(1, S([130u8].to_vec()));
+            assert_eq!(
+                vec![
+                    S([1u8].to_vec()),
+                    S([130u8].to_vec()),
+                    S([3u8].to_vec()),
+                    S([7u8].to_vec()),
+                ],
+                new_vector2.get_all(),
+                "`get_all` must return expected values, after mutation"
+            );
+        }
+
+        #[should_panic(
+            expected = "Out-of-bounds. Got 2 but length was 2. persisted vector name: test-vector"
+        )]
+        #[test]
+        fn out_of_bounds_using_get() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
+
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+
+            // initialize
+            rusty_storage.restore_or_new();
+
+            vector.push(1);
+            vector.push(1);
+            vector.get(2);
+        }
+
+        #[should_panic(
+            expected = "Out-of-bounds. Got index 2 but length was 2. persisted vector name: test-vector"
+        )]
+        #[test]
+        fn out_of_bounds_using_get_many() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
+
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+
+            // initialize
+            rusty_storage.restore_or_new();
+
+            vector.push(1);
+            vector.push(1);
+            vector.get_many(&[0, 0, 0, 1, 1, 2]);
+        }
+
+        #[should_panic(
+            expected = "Out-of-bounds. Got 1 but length was 1. persisted vector name: test-vector"
+        )]
+        #[test]
+        fn out_of_bounds_using_set_many() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
+
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+
+            // initialize
+            rusty_storage.restore_or_new();
+
+            vector.push(1);
+
+            // attempt to set 2 values, when only one is in vector.
+            vector.set_many([(0, 0), (1, 1)]);
+        }
+
+        #[should_panic(expected = "size-mismatch.  input has 2 elements and target has 1 elements")]
+        #[test]
+        fn size_mismatch_too_many_using_set_all() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
+
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+
+            // initialize
+            rusty_storage.restore_or_new();
+
+            vector.push(1);
+
+            // attempt to set 2 values, when only one is in vector.
+            vector.set_all([0, 1]);
+        }
+
+        #[should_panic(expected = "size-mismatch.  input has 1 elements and target has 2 elements")]
+        #[test]
+        fn size_mismatch_too_few_using_set_all() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
+
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+
+            // initialize
+            rusty_storage.restore_or_new();
+
             vector.push(0);
+            vector.push(1);
+
+            // attempt to set 1 values, when two are in vector.
+            vector.set_all([5]);
         }
 
-        // set the initial values
-        vector.set_all(init_vals);
+        #[test]
+        fn test_dbtcvecs_iter_mut() {
+            let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
-        // Generate some random indices for mutation
-        let mutate_indices: BTreeSet<u64> = random_elements::<u64>(30)
-            .iter()
-            .map(|x| x % TEST_LIST_LENGTH)
-            .collect();
+            // initialize storage
+            let mut rusty_storage = SimpleRustyStorage::new(db);
+            rusty_storage.restore_or_new();
+            let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
-        // note: with LendingIterator for loop is not available.
-        let mut iter = vector.many_iter_mut(mutate_indices.clone());
-        while let Some(mut setter) = iter.next() {
-            let val = setter.value();
-            setter.set(*val / 2);
-        }
-        drop(iter); // <--- without this, code will deadlock at next read.
+            // Generate initial index/value pairs.
+            const TEST_LIST_LENGTH: u64 = 105;
+            let init_vals: Vec<u64> = (0..TEST_LIST_LENGTH).map(|i| i * 2).collect();
 
-        // Verify mutated values, and non-mutated also.
-        for (index, value) in vector.iter() {
-            if mutate_indices.contains(&index) {
-                assert_eq!(index, value)
-            } else {
-                assert_eq!(index * 2, value)
+            // let mut mutate_vals = init_vals.clone(); // for later
+
+            // set_all() does not grow the list, so we must first push
+            // some empty elems, to desired length.
+            for _ in 0..TEST_LIST_LENGTH {
+                vector.push(0);
+            }
+
+            // set the initial values
+            vector.set_all(init_vals);
+
+            // Generate some random indices for mutation
+            let mutate_indices: BTreeSet<u64> = random_elements::<u64>(30)
+                .iter()
+                .map(|x| x % TEST_LIST_LENGTH)
+                .collect();
+
+            // note: with LendingIterator for loop is not available.
+            let mut iter = vector.many_iter_mut(mutate_indices.clone());
+            while let Some(mut setter) = iter.next() {
+                let val = setter.value();
+                setter.set(*val / 2);
+            }
+            drop(iter); // <--- without this, code will deadlock at next read.
+
+            // Verify mutated values, and non-mutated also.
+            for (index, value) in vector.iter() {
+                if mutate_indices.contains(&index) {
+                    assert_eq!(index, value)
+                } else {
+                    assert_eq!(index * 2, value)
+                }
             }
         }
     }
 
-    #[test]
-    fn test_db_sync_and_send() {
-        fn sync_and_send<T: Sync + Send>(_t: T) {}
+    mod dbtmap {
+        use super::*;
 
-        // open new DB that will not be dropped on close.
-        let db = DB::open_new_test_database(false, None, None, None).unwrap();
-        sync_and_send(db);
+        #[test]
+        fn test_map() {
+            let db_path = {
+                // open new DB that will not be dropped on close.
+                let db = DB::open_new_test_database(false, None, None, None).unwrap();
+                let db_path = db.path().clone();
+
+                let mut storage = SimpleRustyStorage::new(db);
+                let mut map = storage.schema.new_map::<u8, u32>("test-map");
+
+                // initialize
+                storage.restore_or_new();
+
+                assert!(map.is_empty());
+
+                // should work to pass empty array, when vector.is_empty() == true
+                map.insert(1, 10);
+                map.insert(2, 20);
+                map.insert(3, 30);
+                assert_eq!(map.len(), 3);
+                assert!(!map.is_empty());
+
+                assert_eq!(map.get(&1), Some(10));
+                assert_eq!(map.get(&2), Some(20));
+                assert_eq!(map.get(&3), Some(30));
+
+                assert!(map.remove(&2));
+
+                assert_eq!(map.len(), 2);
+                assert!(!map.is_empty());
+                assert_eq!(map.get(&1), Some(10));
+                assert_eq!(map.get(&3), Some(30));
+
+                storage.persist();
+
+                assert_eq!(map.len(), 2);
+                assert!(!map.is_empty());
+                assert_eq!(map.get(&1), Some(10));
+                assert_eq!(map.get(&3), Some(30));
+
+                db_path
+            };
+
+            let db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
+
+            let mut storage = SimpleRustyStorage::new(db);
+            let map = storage.schema.new_map::<u8, u32>("test-map");
+
+            // initialize
+            storage.restore_or_new();
+
+            assert_eq!(map.len(), 2);
+            assert!(!map.is_empty());
+            assert_eq!(map.get(&1), Some(10));
+            assert_eq!(map.get(&3), Some(30));
+        }
     }
 
     pub mod concurrency {
@@ -991,6 +1057,19 @@ mod tests {
                 None => return true,
             };
             iter.all(|elem| elem == first)
+        }
+
+        mod db {
+            use super::*;
+
+            #[test]
+            fn test_db_sync_and_send() {
+                fn sync_and_send<T: Sync + Send>(_t: T) {}
+
+                // open new DB that will not be dropped on close.
+                let db = DB::open_new_test_database(false, None, None, None).unwrap();
+                sync_and_send(db);
+            }
         }
 
         mod storage_vec {

--- a/twenty-first/src/storage/storage_schema/schema.rs
+++ b/twenty-first/src/storage/storage_schema/schema.rs
@@ -38,13 +38,14 @@ use std::sync::Arc;
 /// # let db = level_db::DB::open_new_test_database(true, None, None, None).unwrap();
 /// use std::sync::{Arc, RwLock};
 /// let mut storage = SimpleRustyStorage::new(db);
-/// storage.restore_or_new();
 ///
 /// let tables = (
 ///     storage.schema.new_vec::<u16>("ages"),
 ///     storage.schema.new_vec::<String>("names"),
 ///     storage.schema.new_singleton::<bool>(12u64.into())
 /// );
+///
+/// storage.restore_or_new();  // populate tables.
 ///
 /// let atomic_tables = Arc::new(RwLock::new(tables));
 /// let mut lock = atomic_tables.write().unwrap();
@@ -71,7 +72,6 @@ use std::sync::Arc;
 /// # use twenty_first::storage::{level_db, storage_vec::traits::*, storage_schema::{SimpleRustyStorage, traits::*}};
 /// # let db = level_db::DB::open_new_test_database(true, None, None, None).unwrap();
 /// let mut storage = SimpleRustyStorage::new(db);
-/// storage.restore_or_new();
 ///
 /// let atomic_tables = storage.schema.create_tables_rw(|s| {
 ///     (
@@ -80,6 +80,8 @@ use std::sync::Arc;
 ///         s.new_singleton::<bool>(12u64.into())
 ///     )
 /// });
+///
+/// storage.restore_or_new();  // populate tables.
 ///
 /// // these writes happen atomically.
 /// atomic_tables.lock_mut(|tables| {
@@ -197,7 +199,6 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     /// # use twenty_first::storage::{level_db, storage_vec::traits::*, storage_schema::{SimpleRustyStorage, traits::*}};
     /// # let db = level_db::DB::open_new_test_database(true, None, None, None).unwrap();
     /// let mut storage = SimpleRustyStorage::new(db);
-    /// storage.restore_or_new();
     ///
     /// let atomic_tables = storage.schema.create_tables_rw(|s| {
     ///     (
@@ -206,6 +207,8 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     ///         s.new_singleton::<bool>(12u64.into())
     ///     )
     /// });
+    ///
+    /// storage.restore_or_new();  // populate tables.
     ///
     /// // these writes happen atomically.
     /// atomic_tables.lock_mut(|tables| {
@@ -235,7 +238,6 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     /// # use twenty_first::storage::{level_db, storage_vec::traits::*, storage_schema::{SimpleRustyStorage, traits::*}};
     /// # let db = level_db::DB::open_new_test_database(true, None, None, None).unwrap();
     /// let mut storage = SimpleRustyStorage::new(db);
-    /// storage.restore_or_new();
     ///
     /// let atomic_tables = storage.schema.create_tables_mutex(|s| {
     ///     (
@@ -244,6 +246,8 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     ///         s.new_singleton::<bool>(12u64.into())
     ///     )
     /// });
+    ///
+    /// storage.restore_or_new();  // populate tables.
     ///
     /// // these writes happen atomically.
     /// atomic_tables.lock_mut(|tables| {
@@ -270,11 +274,12 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     /// # use twenty_first::storage::{level_db, storage_vec::traits::*, storage_schema::{DbtSchema, SimpleRustyStorage, traits::*}};
     /// # let db = level_db::DB::open_new_test_database(true, None, None, None).unwrap();
     /// let mut storage = SimpleRustyStorage::new(db);
-    /// storage.restore_or_new();
     ///
     /// let ages = storage.schema.new_vec::<u16>("ages");
     /// let names = storage.schema.new_vec::<String>("names");
     /// let proceed = storage.schema.new_singleton::<bool>(12u64.into());
+    ///
+    /// storage.restore_or_new();  // populate tables.
     ///
     /// let tables = (ages, names, proceed);
     /// let atomic_tables = storage.schema.atomic_rw(tables);
@@ -300,11 +305,12 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     /// # use twenty_first::storage::{level_db, storage_vec::traits::*, storage_schema::{DbtSchema, SimpleRustyStorage, traits::*}};
     /// # let db = level_db::DB::open_new_test_database(true, None, None, None).unwrap();
     /// let mut storage = SimpleRustyStorage::new(db);
-    /// storage.restore_or_new();
     ///
     /// let ages = storage.schema.new_vec::<u16>("ages");
     /// let names = storage.schema.new_vec::<String>("names");
     /// let proceed = storage.schema.new_singleton::<bool>(12u64.into());
+    ///
+    /// storage.restore_or_new();  // populate tables.
     ///
     /// let tables = (ages, names, proceed);
     /// let atomic_tables = storage.schema.atomic_mutex(tables);

--- a/twenty-first/src/storage/storage_schema/simple_rusty_storage.rs
+++ b/twenty-first/src/storage/storage_schema/simple_rusty_storage.rs
@@ -1,7 +1,7 @@
 use super::super::level_db::DB;
 use super::enums::WriteOperation;
 use super::{traits::StorageWriter, DbtSchema, SimpleRustyReader};
-use crate::sync::AtomicRw;
+use crate::sync::LockCallbackFn;
 use leveldb::batch::WriteBatch;
 use std::sync::Arc;
 
@@ -49,10 +49,19 @@ impl SimpleRustyStorage {
     /// Create a new SimpleRustyStorage
     #[inline]
     pub fn new(db: DB) -> Self {
-        let schema = DbtSchema::<SimpleRustyReader> {
-            tables: AtomicRw::from(Vec::new()),
-            reader: Arc::new(SimpleRustyReader { db }),
-        };
+        let schema =
+            DbtSchema::<SimpleRustyReader>::new(Arc::new(SimpleRustyReader { db }), None, None);
+        Self { schema }
+    }
+
+    /// Create a new SimpleRustyStorage and provide a
+    /// name and lock acquisition callback for tracing
+    pub fn new_with_callback(db: DB, storage_name: &str, lock_callback_fn: LockCallbackFn) -> Self {
+        let schema = DbtSchema::<SimpleRustyReader>::new(
+            Arc::new(SimpleRustyReader { db }),
+            Some(storage_name),
+            Some(lock_callback_fn),
+        );
         Self { schema }
     }
 

--- a/twenty-first/src/storage/storage_schema/traits.rs
+++ b/twenty-first/src/storage/storage_schema/traits.rs
@@ -9,9 +9,9 @@ pub use crate::leveldb::database::key::IntoLevelDBKey;
 /// Defines table interface for types used by [`super::DbtSchema`]
 pub trait DbTable {
     /// Retrieve all unwritten operations and empty write-queue
-    fn pull_queue(&self) -> Vec<WriteOperation>;
+    fn pull_queue(&mut self) -> Vec<WriteOperation>;
     /// Restore existing table if present, else create a new one
-    fn restore_or_new(&self);
+    fn restore_or_new(&mut self);
 }
 
 /// Defines storage singleton for types created by [`super::DbtSchema`]
@@ -23,7 +23,7 @@ where
     fn get(&self) -> T;
 
     /// Set value
-    fn set(&self, t: T);
+    fn set(&mut self, t: T);
 }
 
 /// Defines storage reader interface

--- a/twenty-first/src/storage/storage_vec/iterators.rs
+++ b/twenty-first/src/storage/storage_vec/iterators.rs
@@ -90,6 +90,10 @@ where
         self.write_lock.set(self.index, value);
     }
 
+    pub fn index(&self) -> Index {
+        self.index
+    }
+
     pub fn value(&self) -> &T {
         &self.value
     }

--- a/twenty-first/src/storage/storage_vec/iterators.rs
+++ b/twenty-first/src/storage/storage_vec/iterators.rs
@@ -1,9 +1,9 @@
 use super::{traits::*, Index};
+use crate::sync::AtomicRwWriteGuard;
 use lending_iterator::prelude::*;
 use lending_iterator::{gat, LendingIterator};
 use std::iter::Iterator;
 use std::marker::PhantomData;
-use std::sync::RwLockWriteGuard;
 
 /// A mutating iterator for [`StorageVec`] trait
 ///
@@ -17,7 +17,7 @@ where
     V: StorageVec<T> + StorageVecRwLock<T> + ?Sized,
 {
     indices: Box<dyn Iterator<Item = Index>>,
-    write_lock: RwLockWriteGuard<'a, V::LockedData>,
+    write_lock: AtomicRwWriteGuard<'a, V::LockedData>,
     phantom_t: PhantomData<T>,
     phantom_d: PhantomData<V>,
 }
@@ -75,7 +75,7 @@ where
     V: StorageVec<T> + StorageVecRwLock<T> + ?Sized,
 {
     phantom: PhantomData<V>,
-    write_lock: &'d mut RwLockWriteGuard<'c, V::LockedData>,
+    write_lock: &'d mut AtomicRwWriteGuard<'c, V::LockedData>,
     index: Index,
     value: T,
 }

--- a/twenty-first/src/storage/storage_vec/ordinary_vec.rs
+++ b/twenty-first/src/storage/storage_vec/ordinary_vec.rs
@@ -13,6 +13,32 @@ impl<T> From<Vec<T>> for OrdinaryVec<T> {
     }
 }
 
+impl<T> OrdinaryVec<T> {
+    #[inline]
+    pub(crate) fn write_lock(&self) -> AtomicRwWriteGuard<'_, OrdinaryVecPrivate<T>> {
+        self.0.lock_guard_mut()
+    }
+
+    #[inline]
+    pub(crate) fn read_lock(&self) -> AtomicRwReadGuard<'_, OrdinaryVecPrivate<T>> {
+        self.0.lock_guard()
+    }
+}
+
+impl<T> StorageVecRwLock<T> for OrdinaryVec<T> {
+    type LockedData = OrdinaryVecPrivate<T>;
+
+    #[inline]
+    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
+        Some(self.write_lock())
+    }
+
+    #[inline]
+    fn try_read_lock(&self) -> Option<AtomicRwReadGuard<'_, Self::LockedData>> {
+        Some(self.read_lock())
+    }
+}
+
 impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
     #[inline]
     fn is_empty(&self) -> bool {
@@ -91,20 +117,6 @@ impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
     #[inline]
     fn clear(&self) {
         self.write_lock().clear();
-    }
-}
-
-impl<T> StorageVecRwLock<T> for OrdinaryVec<T> {
-    type LockedData = OrdinaryVecPrivate<T>;
-
-    #[inline]
-    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
-        self.0.lock_guard_mut()
-    }
-
-    #[inline]
-    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
-        self.0.lock_guard()
     }
 }
 

--- a/twenty-first/src/storage/storage_vec/ordinary_vec.rs
+++ b/twenty-first/src/storage/storage_vec/ordinary_vec.rs
@@ -1,7 +1,6 @@
 use super::ordinary_vec_private::OrdinaryVecPrivate;
 use super::{traits::*, Index};
-use crate::sync::AtomicRw;
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
 
 /// A wrapper that adds [`RwLock`](std::sync::RwLock) and atomic snapshot
 /// guarantees around all accesses to an ordinary [`Vec`]
@@ -99,12 +98,12 @@ impl<T> StorageVecRwLock<T> for OrdinaryVec<T> {
     type LockedData = OrdinaryVecPrivate<T>;
 
     #[inline]
-    fn write_lock(&self) -> RwLockWriteGuard<'_, Self::LockedData> {
+    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
         self.0.lock_guard_mut()
     }
 
     #[inline]
-    fn read_lock(&self) -> RwLockReadGuard<'_, Self::LockedData> {
+    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
         self.0.lock_guard()
     }
 }

--- a/twenty-first/src/storage/storage_vec/ordinary_vec.rs
+++ b/twenty-first/src/storage/storage_vec/ordinary_vec.rs
@@ -15,7 +15,7 @@ impl<T> From<Vec<T>> for OrdinaryVec<T> {
 
 impl<T> OrdinaryVec<T> {
     #[inline]
-    pub(crate) fn write_lock(&self) -> AtomicRwWriteGuard<'_, OrdinaryVecPrivate<T>> {
+    pub(crate) fn write_lock(&mut self) -> AtomicRwWriteGuard<'_, OrdinaryVecPrivate<T>> {
         self.0.lock_guard_mut()
     }
 
@@ -29,7 +29,7 @@ impl<T> StorageVecRwLock<T> for OrdinaryVec<T> {
     type LockedData = OrdinaryVecPrivate<T>;
 
     #[inline]
-    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
+    fn try_write_lock(&mut self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
         Some(self.write_lock())
     }
 
@@ -55,9 +55,9 @@ impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
         self.read_lock().get(index)
     }
 
-    fn many_iter(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter<'a>(
+        &'a self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> Box<dyn Iterator<Item = (Index, T)> + '_> {
         // note: this lock is moved into the iterator closure and is not
         //       released until caller drops the returned iterator
@@ -74,9 +74,9 @@ impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
         }))
     }
 
-    fn many_iter_values(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter_values<'a>(
+        &'a self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> Box<dyn Iterator<Item = T> + '_> {
         // note: this lock is moved into the iterator closure and is not
         //       released until caller drops the returned iterator
@@ -94,28 +94,28 @@ impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
     }
 
     #[inline]
-    fn set(&self, index: Index, value: T) {
+    fn set(&mut self, index: Index, value: T) {
         // note: on 32 bit systems, this could panic.
         self.write_lock().set(index, value);
     }
 
     #[inline]
-    fn set_many(&self, key_vals: impl IntoIterator<Item = (Index, T)>) {
+    fn set_many(&mut self, key_vals: impl IntoIterator<Item = (Index, T)>) {
         self.write_lock().set_many(key_vals);
     }
 
     #[inline]
-    fn pop(&self) -> Option<T> {
+    fn pop(&mut self) -> Option<T> {
         self.write_lock().pop()
     }
 
     #[inline]
-    fn push(&self, value: T) {
+    fn push(&mut self, value: T) {
         self.write_lock().push(value);
     }
 
     #[inline]
-    fn clear(&self) {
+    fn clear(&mut self) {
         self.write_lock().clear();
     }
 }
@@ -135,37 +135,37 @@ mod tests {
         #[test]
         #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
         fn non_atomic_set_and_get() {
-            traits_tests::concurrency::non_atomic_set_and_get(&gen_concurrency_test_vec());
+            traits_tests::concurrency::non_atomic_set_and_get(&mut gen_concurrency_test_vec());
         }
 
         #[test]
         #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
         fn non_atomic_set_and_get_wrapped_atomic_rw() {
             traits_tests::concurrency::non_atomic_set_and_get_wrapped_atomic_rw(
-                &gen_concurrency_test_vec(),
+                &mut gen_concurrency_test_vec(),
             );
         }
 
         #[test]
         fn atomic_set_and_get_wrapped_atomic_rw() {
             traits_tests::concurrency::atomic_set_and_get_wrapped_atomic_rw(
-                &gen_concurrency_test_vec(),
+                &mut gen_concurrency_test_vec(),
             );
         }
 
         #[test]
         fn atomic_setmany_and_getmany() {
-            traits_tests::concurrency::atomic_setmany_and_getmany(&gen_concurrency_test_vec());
+            traits_tests::concurrency::atomic_setmany_and_getmany(&mut gen_concurrency_test_vec());
         }
 
         #[test]
         fn atomic_setall_and_getall() {
-            traits_tests::concurrency::atomic_setall_and_getall(&gen_concurrency_test_vec());
+            traits_tests::concurrency::atomic_setall_and_getall(&mut gen_concurrency_test_vec());
         }
 
         #[test]
         fn atomic_iter_mut_and_iter() {
-            traits_tests::concurrency::atomic_iter_mut_and_iter(&gen_concurrency_test_vec());
+            traits_tests::concurrency::atomic_iter_mut_and_iter(&mut gen_concurrency_test_vec());
         }
     }
 }

--- a/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
+++ b/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
@@ -4,7 +4,6 @@ use super::{traits::*, Index};
 use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
 use leveldb::batch::WriteBatch;
 use serde::{de::DeserializeOwned, Serialize};
-use std::sync::Arc;
 
 /// A concurrency safe database-backed Vec with in memory read/write caching for all operations.
 #[derive(Debug, Clone)]
@@ -171,7 +170,7 @@ impl<T: Serialize + DeserializeOwned + Clone> RustyLevelDbVec<T> {
     }
 
     #[inline]
-    pub fn new(db: Arc<DB>, key_prefix: u8, name: &str) -> Self {
+    pub fn new(db: DB, key_prefix: u8, name: &str) -> Self {
         Self {
             inner: AtomicRw::from(RustyLevelDbVecPrivate::<T>::new(db, key_prefix, name)),
         }

--- a/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
+++ b/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
@@ -125,17 +125,29 @@ impl<T: Serialize + DeserializeOwned + Clone> StorageVec<T> for RustyLevelDbVec<
     }
 }
 
-impl<T: Serialize + DeserializeOwned> StorageVecRwLock<T> for RustyLevelDbVec<T> {
-    type LockedData = RustyLevelDbVecPrivate<T>;
-
+impl<T: Serialize + DeserializeOwned> RustyLevelDbVec<T> {
     #[inline]
-    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
+    pub(crate) fn write_lock(&self) -> AtomicRwWriteGuard<'_, RustyLevelDbVecPrivate<T>> {
         self.inner.lock_guard_mut()
     }
 
     #[inline]
-    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
+    pub(crate) fn read_lock(&self) -> AtomicRwReadGuard<'_, RustyLevelDbVecPrivate<T>> {
         self.inner.lock_guard()
+    }
+}
+
+impl<T: Serialize + DeserializeOwned> StorageVecRwLock<T> for RustyLevelDbVec<T> {
+    type LockedData = RustyLevelDbVecPrivate<T>;
+
+    #[inline]
+    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
+        Some(self.write_lock())
+    }
+
+    #[inline]
+    fn try_read_lock(&self) -> Option<AtomicRwReadGuard<'_, Self::LockedData>> {
+        Some(self.read_lock())
     }
 }
 

--- a/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
+++ b/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
@@ -1,11 +1,10 @@
 use super::super::level_db::DB;
 use super::rusty_leveldb_vec_private::RustyLevelDbVecPrivate;
 use super::{traits::*, Index};
-use crate::sync::AtomicRw;
+use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
 use leveldb::batch::WriteBatch;
 use serde::{de::DeserializeOwned, Serialize};
 use std::sync::Arc;
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 /// A concurrency safe database-backed Vec with in memory read/write caching for all operations.
 #[derive(Debug, Clone)]
@@ -130,12 +129,12 @@ impl<T: Serialize + DeserializeOwned> StorageVecRwLock<T> for RustyLevelDbVec<T>
     type LockedData = RustyLevelDbVecPrivate<T>;
 
     #[inline]
-    fn write_lock(&self) -> RwLockWriteGuard<'_, Self::LockedData> {
+    fn write_lock(&self) -> AtomicRwWriteGuard<'_, Self::LockedData> {
         self.inner.lock_guard_mut()
     }
 
     #[inline]
-    fn read_lock(&self) -> RwLockReadGuard<'_, Self::LockedData> {
+    fn read_lock(&self) -> AtomicRwReadGuard<'_, Self::LockedData> {
         self.inner.lock_guard()
     }
 }

--- a/twenty-first/src/storage/storage_vec/rusty_leveldb_vec_private.rs
+++ b/twenty-first/src/storage/storage_vec/rusty_leveldb_vec_private.rs
@@ -5,7 +5,6 @@ use itertools::Itertools;
 use leveldb::batch::WriteBatch;
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
 
 /// This is the private impl of RustyLevelDbVec.
 ///
@@ -20,7 +19,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct RustyLevelDbVecPrivate<T: Serialize + DeserializeOwned> {
     key_prefix: u8,
-    pub(super) db: Arc<DB>,
+    pub(super) db: DB,
     write_queue: VecDeque<WriteElement<T>>,
     length: Index,
     pub(super) cache: HashMap<Index, T>,
@@ -273,7 +272,7 @@ impl<T: Serialize + DeserializeOwned> RustyLevelDbVecPrivate<T> {
     }
 
     #[inline]
-    pub(crate) fn new(db: Arc<DB>, key_prefix: u8, name: &str) -> Self {
+    pub(crate) fn new(db: DB, key_prefix: u8, name: &str) -> Self {
         let length_key = Self::get_length_key(key_prefix);
         let length = match utils::get_u8_option(&db, &length_key, name) {
             Some(length_bytes) => utils::deserialize(&length_bytes),

--- a/twenty-first/src/storage/storage_vec/traits.rs
+++ b/twenty-first/src/storage/storage_vec/traits.rs
@@ -412,10 +412,10 @@ pub(in super::super) trait StorageVecRwLock<T> {
     type LockedData;
 
     /// obtain write lock over mutable data.
-    fn write_lock(&self) -> AtomicRwWriteGuard<Self::LockedData>;
+    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<Self::LockedData>>;
 
     /// obtain read lock over mutable data.
-    fn read_lock(&self) -> AtomicRwReadGuard<Self::LockedData>;
+    fn try_read_lock(&self) -> Option<AtomicRwReadGuard<Self::LockedData>>;
 }
 
 pub(in super::super) trait StorageVecIterMut<T>: StorageVec<T> {}

--- a/twenty-first/src/storage/storage_vec/traits.rs
+++ b/twenty-first/src/storage/storage_vec/traits.rs
@@ -5,7 +5,7 @@
 
 // use super::iterators::{ManyIterMut, StorageSetter};
 use super::{Index, ManyIterMut};
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+use crate::sync::{AtomicRwReadGuard, AtomicRwWriteGuard};
 
 // re-export to make life easier for users of our API.
 pub use lending_iterator::LendingIterator;
@@ -412,10 +412,10 @@ pub(in super::super) trait StorageVecRwLock<T> {
     type LockedData;
 
     /// obtain write lock over mutable data.
-    fn write_lock(&self) -> RwLockWriteGuard<Self::LockedData>;
+    fn write_lock(&self) -> AtomicRwWriteGuard<Self::LockedData>;
 
     /// obtain read lock over mutable data.
-    fn read_lock(&self) -> RwLockReadGuard<Self::LockedData>;
+    fn read_lock(&self) -> AtomicRwReadGuard<Self::LockedData>;
 }
 
 pub(in super::super) trait StorageVecIterMut<T>: StorageVec<T> {}

--- a/twenty-first/src/storage/storage_vec/traits.rs
+++ b/twenty-first/src/storage/storage_vec/traits.rs
@@ -50,13 +50,10 @@ pub trait StorageVec<T> {
     /// important to drop the iterator immediately after use.  Typical
     /// for-loop usage does this automatically.
     ///
-    /// If a write is attempted before the read lock is dropped, a deadlock
-    /// will occur.
-    ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// for (key, val) in vec.iter() {
     ///     println!("{key}: {val}")
@@ -65,22 +62,6 @@ pub trait StorageVec<T> {
     /// // write can proceed
     /// vec.set(5, 2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.iter();
-    /// while let Some((key, val)) = iter.next() {
-    ///     println!("{key}: {val}");
-    /// }
-    ///
-    /// // deadlock! This will wait for the write lock forever because iter is still holding read lock.
-    /// vec.set(5, 2);
-    /// ```
-    ///
-    /// note: any write op would deadlock, including `iter_mut()`, `many_iter_mut()`, `set_many()`, etc.
     #[inline]
     fn iter(&self) -> Box<dyn Iterator<Item = (Index, T)> + '_> {
         self.many_iter(0..self.len())
@@ -94,13 +75,10 @@ pub trait StorageVec<T> {
     /// important to drop the iterator immediately after use.  Typical
     /// for-loop usage does this automatically.
     ///
-    /// If a write is attempted before the read lock is dropped, a deadlock
-    /// will occur.
-    ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// for (val) in vec.iter_values() {
     ///     println!("{val}")
@@ -109,22 +87,6 @@ pub trait StorageVec<T> {
     /// // write can proceed
     /// let val = vec.push(2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.iter_values();
-    /// while let Some(val) = iter.next() {
-    ///     println!("{val}")
-    /// }
-    ///
-    /// // deadlock! This will wait for the write lock forever because iter is still holding read lock.
-    /// let val = vec.push(2);
-    /// ```
-    ///
-    /// note: any write op would deadlock, including `iter_mut()`, `many_iter_mut()`, `set_many()`, etc.
     #[inline]
     fn iter_values(&self) -> Box<dyn Iterator<Item = T> + '_> {
         self.many_iter_values(0..self.len())
@@ -140,13 +102,10 @@ pub trait StorageVec<T> {
     /// important to drop the iterator immediately after use.  Typical
     /// for-loop usage does this automatically.
     ///
-    /// If a write is attempted before the read lock is dropped, a deadlock
-    /// will occur.
-    ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// for (key, val) in vec.many_iter([3, 5, 7]) {
     ///     println!("{key}: {val}")
@@ -155,25 +114,9 @@ pub trait StorageVec<T> {
     /// // write can proceed
     /// vec.set(5, 2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.many_iter([3, 5, 7]);
-    /// while let Some((key, val)) = iter.next() {
-    ///     println!("{key}: {val}")
-    /// }
-    ///
-    /// // deadlock! This will wait for the write lock forever because iter is still holding read lock.
-    /// vec.set(5, 2);
-    /// ```
-    ///
-    /// note: any write op would deadlock, including `iter_mut()`, `many_iter_mut()`, `set_many()`, etc.
-    fn many_iter(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter<'a>(
+        &'a self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> Box<dyn Iterator<Item = (Index, T)> + '_>;
 
     /// get an iterator over elements matching indices
@@ -186,13 +129,10 @@ pub trait StorageVec<T> {
     /// important to drop the iterator immediately after use.  Typical
     /// for-loop usage does this automatically.
     ///
-    /// If a write is attempted before the read lock is dropped, a deadlock
-    /// will occur.
-    ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// for (val) in vec.many_iter_values([2, 5, 8]) {
     ///     println!("{val}")
@@ -201,31 +141,15 @@ pub trait StorageVec<T> {
     /// // write can proceed
     /// vec.set(5, 2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.many_iter_values([2, 5, 8]);
-    /// while let Some(val) = iter.next() {
-    ///     println!("{val}")
-    /// }
-    ///
-    /// // deadlock! This will wait for the write lock forever because iter is still holding read lock.
-    /// vec.set(5, 2);
-    /// ```
-    ///
-    /// note: any write op would deadlock, including `iter_mut()`, `many_iter_mut()`, `set_many()`, etc.
-    fn many_iter_values(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter_values<'a>(
+        &'a self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> Box<dyn Iterator<Item = T> + '_>;
 
     /// set a single element.
     ///
     /// note: The update is performed as a single atomic operation.
-    fn set(&self, index: Index, value: T);
+    fn set(&mut self, index: Index, value: T);
 
     /// set multiple elements.
     ///
@@ -236,7 +160,7 @@ pub trait StorageVec<T> {
     /// note: all updates are performed as a single atomic operation.
     ///       readers will see either the before or after state,
     ///       never an intermediate state.
-    fn set_many(&self, key_vals: impl IntoIterator<Item = (Index, T)>);
+    fn set_many(&mut self, key_vals: impl IntoIterator<Item = (Index, T)>);
 
     /// set elements from start to vals.count()
     ///
@@ -244,7 +168,7 @@ pub trait StorageVec<T> {
     ///       readers will see either the before or after state,
     ///       never an intermediate state.
     #[inline]
-    fn set_first_n(&self, vals: impl IntoIterator<Item = T>) {
+    fn set_first_n(&mut self, vals: impl IntoIterator<Item = T>) {
         self.set_many((0..).zip(vals));
     }
 
@@ -260,7 +184,7 @@ pub trait StorageVec<T> {
     /// note: casts the input value's length from usize to Index
     ///       so will panic if vals contains more than 2^32 items
     #[inline]
-    fn set_all(&self, vals: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = T>>) {
+    fn set_all(&mut self, vals: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = T>>) {
         let iter = vals.into_iter();
 
         assert!(
@@ -276,17 +200,17 @@ pub trait StorageVec<T> {
     /// pop an element from end of collection
     ///
     /// note: The update is performed as a single atomic operation.
-    fn pop(&self) -> Option<T>;
+    fn pop(&mut self) -> Option<T>;
 
     /// push an element to end of collection
     ///
     /// note: The update is performed as a single atomic operation.
-    fn push(&self, value: T);
+    fn push(&mut self, value: T);
 
     /// Removes all elements from the collection
     ///
     /// note: The update is performed as a single atomic operation.
-    fn clear(&self);
+    fn clear(&mut self);
 
     /// get a mutable iterator over all elements
     ///
@@ -297,14 +221,14 @@ pub trait StorageVec<T> {
     /// note: the returned (lending) iterator cannot be used in a for loop.  Use a
     ///       while loop instead.  See example below.
     ///
-    /// Important: The returned iterator holds a write lock over `StorageVecRwLock::LockedData`.
-    /// This write lock must be dropped before performing any read operation or the
-    /// code will deadlock.  See Deadlock Example.
+    /// Note: The returned iterator holds a write lock over `StorageVecRwLock::LockedData`.
+    /// This write lock must be dropped before performing any read operation.
+    /// This is enforced by the borrow-checker, which also prevents deadlocks.
     ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// {
     ///     let mut iter = vec.iter_mut();
@@ -316,25 +240,9 @@ pub trait StorageVec<T> {
     /// // read can proceed
     /// let val = vec.get(2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.iter_mut();
-    /// while let Some(mut setter) = iter.next() {
-    ///     setter.set(50);
-    /// }
-    ///
-    /// // deadlock! This will wait for the read lock forever because iter is still holding write lock.
-    /// let val = vec.get(2);
-    /// ```
-    ///
-    /// note: any read op would deadlock, including `iter()`, `many_iter()`, `get_many()`, etc.
     #[allow(private_bounds)]
     #[inline]
-    fn iter_mut(&self) -> ManyIterMut<Self, T>
+    fn iter_mut(&mut self) -> ManyIterMut<Self, T>
     where
         Self: Sized + StorageVecRwLock<T>,
     {
@@ -350,14 +258,14 @@ pub trait StorageVec<T> {
     /// note: the returned (lending) iterator cannot be used in a for loop.  Use a
     ///       while loop instead.  See example below.
     ///
-    /// Important: The returned iterator holds a write lock over `StorageVecRwLock::LockedData`.
-    /// This write lock must be dropped before performing any read operation or the
-    /// code will deadlock.  See Deadlock Example.
+    /// Note: The returned iterator holds a write lock over `StorageVecRwLock::LockedData`.
+    /// This write lock must be dropped before performing any read operation.
+    /// This is enforced by the borrow-checker, which also prevents deadlocks.
     ///
-    /// # Correct Example:
-    /// ```no_run
+    /// # Example:
+    /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<&str>::from(vec!["1","2","3","4","5","6","7","8","9"]);
+    /// # let mut vec = OrdinaryVec::<&str>::from(vec!["1","2","3","4","5","6","7","8","9"]);
     ///
     /// {
     ///     let mut iter = vec.many_iter_mut([2, 4, 6]);
@@ -369,27 +277,11 @@ pub trait StorageVec<T> {
     /// // read can proceed
     /// let val = vec.get(2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<&str>::from(vec!["1","2","3","4","5","6","7","8","9"]);
-    ///
-    /// let mut iter = vec.many_iter_mut([2, 4, 6]);
-    /// while let Some(mut setter) = iter.next() {
-    ///     setter.set("50");
-    /// }
-    ///
-    /// // deadlock! This will wait for the read lock forever because iter is still holding write lock.
-    /// let val = vec.get(2);
-    /// ```
-    ///
-    /// note: any read op would deadlock, including `iter()`, `many_iter()`, `get_many()`, etc.
     #[allow(private_bounds)]
     #[inline]
-    fn many_iter_mut(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter_mut<'a>(
+        &'a mut self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> ManyIterMut<Self, T>
     where
         Self: Sized + StorageVecRwLock<T>,
@@ -412,7 +304,7 @@ pub(in super::super) trait StorageVecRwLock<T> {
     type LockedData;
 
     /// obtain write lock over mutable data.
-    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<Self::LockedData>>;
+    fn try_write_lock(&mut self) -> Option<AtomicRwWriteGuard<Self::LockedData>>;
 
     /// obtain read lock over mutable data.
     fn try_read_lock(&self) -> Option<AtomicRwReadGuard<Self::LockedData>>;
@@ -429,7 +321,7 @@ pub(in crate::storage) mod tests {
         use super::*;
         use std::thread;
 
-        pub fn prepare_concurrency_test_vec(vec: &impl StorageVec<u64>) {
+        pub fn prepare_concurrency_test_vec(vec: &mut impl StorageVec<u64>) {
             vec.clear();
             for i in 0..400 {
                 vec.push(i);
@@ -440,8 +332,8 @@ pub(in crate::storage) mod tests {
         // for a type that impl's StorageVec.
         //
         // note: this test is expected to panic and calling test fn should be annotated with:
-        //  #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
-        pub fn non_atomic_set_and_get(vec: &(impl StorageVec<u64> + Send + Sync)) {
+        #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
+        pub fn non_atomic_set_and_get(vec: &mut (impl StorageVec<u64> + Send + Sync + Clone)) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
             let modified: Vec<u64> = orig.iter().map(|_| 50).collect();
@@ -470,13 +362,13 @@ pub(in crate::storage) mod tests {
                     let sets = s.spawn(|| {
                         // set values one by one, in reverse order than the reader.
                         for j in (0..vec.len()).rev() {
-                            vec.set(j, 50);
+                            vec.clone().set(j, 50);
                         }
                     });
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    vec.set_all(orig.clone());
+                    vec.clone().set_all(orig.clone());
                 }
             });
         }
@@ -485,9 +377,9 @@ pub(in crate::storage) mod tests {
         // (Arc<RwLock<..>>) is atomic if the lock is held across all write/read operations
         //
         // note: this test is expected to panic and calling test fn should be annotated with:
-        //  #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
+        #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
         pub fn non_atomic_set_and_get_wrapped_atomic_rw(
-            vec: &(impl StorageVec<u64> + Send + Sync),
+            vec: &mut (impl StorageVec<u64> + Send + Sync + Clone),
         ) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
@@ -522,22 +414,22 @@ pub(in crate::storage) mod tests {
                         // set values one by one.
                         for j in 0..atomic_vec.lock(|v| v.len()) {
                             // acquire write lock
-                            atomic_vec.lock_mut(|v| {
-                                v.set(j, 50);
-                            }); // release write lock
+                            atomic_vec.clone().lock_guard_mut().set(j, 50);
                         }
                     });
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    atomic_vec.lock_mut(|v| v.set_all(orig.clone()));
+                    atomic_vec.clone().lock_mut(|v| v.set_all(orig.clone()));
                 }
             });
         }
 
         // This test demonstrates/verifies that wrapping an impl StorageVec in an AtomicRw
         // (Arc<RwLock<..>>) is atomic if the lock is held across all write/read operations
-        pub fn atomic_set_and_get_wrapped_atomic_rw(vec: &(impl StorageVec<u64> + Send + Sync)) {
+        pub fn atomic_set_and_get_wrapped_atomic_rw(
+            vec: &mut (impl StorageVec<u64> + Send + Sync),
+        ) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
             let modified: Vec<u64> = orig.iter().map(|_| 50).collect();
@@ -566,7 +458,7 @@ pub(in crate::storage) mod tests {
                     });
 
                     let sets = s.spawn(|| {
-                        atomic_vec.lock_mut(|v| {
+                        atomic_vec.clone().lock_mut(|v| {
                             // acquire write lock
                             for j in 0..v.len() {
                                 // set values one by one.
@@ -577,12 +469,12 @@ pub(in crate::storage) mod tests {
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    atomic_vec.lock_mut(|v| v.set_all(orig.clone()));
+                    atomic_vec.clone().lock_mut(|v| v.set_all(orig.clone()));
                 }
             });
         }
 
-        pub fn atomic_setmany_and_getmany(vec: &(impl StorageVec<u64> + Send + Sync)) {
+        pub fn atomic_setmany_and_getmany(vec: &mut (impl StorageVec<u64> + Send + Sync + Clone)) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
             let modified: Vec<u64> = orig.iter().map(|_| 50).collect();
@@ -604,17 +496,18 @@ pub(in crate::storage) mod tests {
                     });
 
                     let sets = s.spawn(|| {
-                        vec.set_many(orig.iter().enumerate().map(|(k, _v)| (k as u64, 50u64)));
+                        vec.clone()
+                            .set_many(orig.iter().enumerate().map(|(k, _v)| (k as u64, 50u64)));
                     });
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    vec.set_all(orig.clone());
+                    vec.clone().set_all(orig.clone());
                 }
             });
         }
 
-        pub fn atomic_setall_and_getall(vec: &(impl StorageVec<u64> + Send + Sync)) {
+        pub fn atomic_setall_and_getall(vec: &mut (impl StorageVec<u64> + Send + Sync + Clone)) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
             let modified: Vec<u64> = orig.iter().map(|_| 50).collect();
@@ -634,19 +527,19 @@ pub(in crate::storage) mod tests {
                     });
 
                     let sets = s.spawn(|| {
-                        vec.set_all(orig.iter().map(|_| 50));
+                        vec.clone().set_all(orig.iter().map(|_| 50));
                     });
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    vec.set_all(orig.clone());
+                    vec.clone().set_all(orig.clone());
                 }
             });
         }
 
-        pub fn atomic_iter_mut_and_iter<T>(vec: &T)
+        pub fn atomic_iter_mut_and_iter<T>(vec: &mut T)
         where
-            T: StorageVec<u64> + StorageVecRwLock<u64> + Send + Sync,
+            T: StorageVec<u64> + StorageVecRwLock<u64> + Send + Sync + Clone,
             T::LockedData: StorageVecLockedData<u64>,
         {
             prepare_concurrency_test_vec(vec);
@@ -667,7 +560,8 @@ pub(in crate::storage) mod tests {
                     });
 
                     let sets = s.spawn(|| {
-                        let mut iter = vec.iter_mut();
+                        let mut vec_mut = vec.clone();
+                        let mut iter = vec_mut.iter_mut();
                         while let Some(mut setter) = iter.next() {
                             setter.set(50);
                         }
@@ -675,7 +569,7 @@ pub(in crate::storage) mod tests {
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    vec.set_all(orig.clone());
+                    vec.clone().set_all(orig.clone());
                 }
             });
         }

--- a/twenty-first/src/sync/atomic_mutex.rs
+++ b/twenty-first/src/sync/atomic_mutex.rs
@@ -1,4 +1,6 @@
 use super::traits::Atomic;
+use super::{LockAcquisition, LockCallbackFn, LockCallbackInfo, LockEvent, LockType};
+use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 /// An `Arc<Mutex<T>>` wrapper to make data thread-safe and easy to work with.
@@ -13,53 +15,198 @@ use std::sync::{Arc, Mutex, MutexGuard};
 /// atomic_car.lock(|c| println!("year: {}", c.year));
 /// atomic_car.lock_mut(|mut c| c.year = 2023);
 /// ```
-#[derive(Debug, Default, Clone)]
-pub struct AtomicMutex<T>(Arc<Mutex<T>>);
+///
+/// It is also possible to provide a name and callback fn
+/// during instantiation.  In this way, the application
+/// can easily trace lock acquisitions.
+///
+/// # Examples
+/// ```
+/// # use twenty_first::sync::{AtomicMutex, LockEvent, LockCallbackFn};
+/// struct Car {
+///     year: u16,
+/// };
+///
+/// pub fn log_lock_event(lock_event: LockEvent) {
+///     let (event, info, acquisition) =
+///     match lock_event {
+///         LockEvent::TryAcquire{info, acquisition} => ("TryAcquire", info, acquisition),
+///         LockEvent::Acquire{info, acquisition} => ("Acquire", info, acquisition),
+///         LockEvent::Release{info, acquisition} => ("Release", info, acquisition),
+///     };
+///
+///     println!(
+///         "{} lock `{}` of type `{}` for `{}` by\n\t|-- thread {}, `{:?}`",
+///         event,
+///         info.name().unwrap_or("?"),
+///         info.lock_type(),
+///         acquisition,
+///         std::thread::current().name().unwrap_or("?"),
+///         std::thread::current().id(),
+///     );
+/// }
+/// const LOG_LOCK_EVENT_CB: LockCallbackFn = log_lock_event;
+///
+/// let atomic_car = AtomicMutex::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
+/// atomic_car.lock(|c| {println!("year: {}", c.year)});
+/// atomic_car.lock_mut(|mut c| {c.year = 2023});
+/// ```
+///
+/// results in:
+/// ```text
+/// TryAcquire lock `car` of type `Mutex` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// Acquire lock `car` of type `Mutex` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// year: 2016
+/// Release lock `car` of type `Mutex` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// TryAcquire lock `car` of type `Mutex` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// Acquire lock `car` of type `Mutex` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// Release lock `car` of type `Mutex` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// ```
+#[derive(Debug)]
+pub struct AtomicMutex<T> {
+    inner: Arc<Mutex<T>>,
+    lock_callback_info: LockCallbackInfo,
+}
+
+impl<T: Default> Default for AtomicMutex<T> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, None, None),
+        }
+    }
+}
+
 impl<T> From<T> for AtomicMutex<T> {
     #[inline]
     fn from(t: T) -> Self {
-        Self(Arc::new(Mutex::new(t)))
+        Self {
+            inner: Arc::new(Mutex::new(t)),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, None, None),
+        }
+    }
+}
+impl<T> From<(T, Option<String>, Option<LockCallbackFn>)> for AtomicMutex<T> {
+    /// Create from an optional name and an optional callback function, which
+    /// is called when a lock event occurs.
+    #[inline]
+    fn from(v: (T, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(v.0)),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, v.1, v.2),
+        }
+    }
+}
+impl<T> From<(T, Option<&str>, Option<LockCallbackFn>)> for AtomicMutex<T> {
+    /// Create from a name ref and an optional callback function, which
+    /// is called when a lock event occurs.
+    #[inline]
+    fn from(v: (T, Option<&str>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(v.0)),
+            lock_callback_info: LockCallbackInfo::new(
+                LockType::Mutex,
+                v.1.map(|s| s.to_owned()),
+                v.2,
+            ),
+        }
+    }
+}
+
+impl<T> Clone for AtomicMutex<T> {
+    fn clone(&self) -> Self {
+        Self {
+            lock_callback_info: self.lock_callback_info.clone(),
+            inner: self.inner.clone(),
+        }
     }
 }
 
 impl<T> From<Mutex<T>> for AtomicMutex<T> {
     #[inline]
     fn from(t: Mutex<T>) -> Self {
-        Self(Arc::new(t))
+        Self {
+            inner: Arc::new(t),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, None, None),
+        }
+    }
+}
+impl<T> From<(Mutex<T>, Option<String>, Option<LockCallbackFn>)> for AtomicMutex<T> {
+    /// Create from an `Mutex<T>` plus an optional name
+    /// and an optional callback function, which is called
+    /// when a lock event occurs.
+    #[inline]
+    fn from(v: (Mutex<T>, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(v.0),
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, v.1, v.2),
+        }
     }
 }
 
 impl<T> TryFrom<AtomicMutex<T>> for Mutex<T> {
     type Error = Arc<Mutex<T>>;
-
-    #[inline]
     fn try_from(t: AtomicMutex<T>) -> Result<Mutex<T>, Self::Error> {
-        Arc::<Mutex<T>>::try_unwrap(t.0)
+        Arc::<Mutex<T>>::try_unwrap(t.inner)
     }
 }
 
 impl<T> From<Arc<Mutex<T>>> for AtomicMutex<T> {
     #[inline]
     fn from(t: Arc<Mutex<T>>) -> Self {
-        Self(t)
+        Self {
+            inner: t,
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, None, None),
+        }
+    }
+}
+impl<T> From<(Arc<Mutex<T>>, Option<String>, Option<LockCallbackFn>)> for AtomicMutex<T> {
+    /// Create from an `Arc<Mutex<T>>` plus an optional name and
+    /// an optional callback function, which is called when a lock
+    /// event occurs.
+    #[inline]
+    fn from(v: (Arc<Mutex<T>>, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: v.0,
+            lock_callback_info: LockCallbackInfo::new(LockType::Mutex, v.1, v.2),
+        }
     }
 }
 
 impl<T> From<AtomicMutex<T>> for Arc<Mutex<T>> {
     #[inline]
     fn from(t: AtomicMutex<T>) -> Self {
-        t.0
+        t.inner
     }
 }
 
 // note: we impl the Atomic trait methods here also so they
 // can be used without caller having to use the trait.
 impl<T> AtomicMutex<T> {
-    /// Acquire lock and return a `MutexGuard`
-    ///
-    /// note: this method is exactly the same as [`lock_guard_mut()`](Self::lock_guard_mut).
-    /// It exists only for compatibility with [`AtomicRw`](super::AtomicRw) so
-    /// they can be used interchangeably.
+    pub const fn const_new(
+        t: Arc<Mutex<T>>,
+        name: Option<String>,
+        lock_callback_fn: Option<LockCallbackFn>,
+    ) -> Self {
+        Self {
+            inner: t,
+            lock_callback_info: LockCallbackInfo {
+                lock_info_owned: crate::sync::shared::LockInfoOwned {
+                    name,
+                    lock_type: LockType::Mutex,
+                },
+                lock_callback_fn,
+            },
+        }
+    }
+
+    /// Acquire read lock and return an `AtomicMutexGuard`
     ///
     /// # Examples
     /// ```
@@ -68,13 +215,15 @@ impl<T> AtomicMutex<T> {
     ///     year: u16,
     /// };
     /// let atomic_car = AtomicMutex::from(Car{year: 2016});
-    /// atomic_car.lock_guard().year = 2022;
+    /// let year = atomic_car.lock_guard().year;
     /// ```
-    pub fn lock_guard(&self) -> MutexGuard<T> {
-        self.0.lock().expect("Mutex lock should succeed")
+    pub fn lock_guard(&self) -> AtomicMutexGuard<T> {
+        self.try_acquire_read_cb();
+        let guard = self.inner.lock().expect("Read lock should succeed");
+        AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Read)
     }
 
-    /// Acquire lock and return a `MutexGuard`
+    /// Acquire write lock and return an `AtomicMutexGuard`
     ///
     /// # Examples
     /// ```
@@ -85,13 +234,15 @@ impl<T> AtomicMutex<T> {
     /// let atomic_car = AtomicMutex::from(Car{year: 2016});
     /// atomic_car.lock_guard_mut().year = 2022;
     /// ```
-    pub fn lock_guard_mut(&self) -> MutexGuard<T> {
-        self.0.lock().expect("Mutex lock should succeed")
+    pub fn lock_guard_mut(&self) -> AtomicMutexGuard<T> {
+        self.try_acquire_write_cb();
+        let guard = self.inner.lock().expect("Write lock should succeed");
+        AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Write)
     }
 
-    /// Immutably access the data of type `T` in a closure and return a result
+    /// Immutably access the data of type `T` in a closure and possibly return a result of type `R`
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use twenty_first::sync::{AtomicMutex, traits::*};
     /// struct Car {
@@ -105,36 +256,42 @@ impl<T> AtomicMutex<T> {
     where
         F: FnOnce(&T) -> R,
     {
-        let mut lock = self.0.lock().expect("Write lock should succeed");
-        f(&mut lock)
+        self.try_acquire_read_cb();
+        let guard = self.inner.lock().expect("Read lock should succeed");
+        let my_guard =
+            AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Read);
+        f(&my_guard)
     }
 
-    /// Mutably access the data of type `T` in a closure and return a result
+    /// Mutably access the data of type `T` in a closure and possibly return a result of type `R`
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use twenty_first::sync::{AtomicMutex, traits::*};
     /// struct Car {
     ///     year: u16,
     /// };
     /// let atomic_car = AtomicMutex::from(Car{year: 2016});
-    /// atomic_car.lock_mut(|mut c| c.year = 2022);
+    /// atomic_car.lock_mut(|mut c| {c.year = 2022});
     /// let year = atomic_car.lock_mut(|mut c| {c.year = 2023; c.year});
     /// ```
     pub fn lock_mut<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
-        let mut lock = self.0.lock().expect("Write lock should succeed");
-        f(&mut lock)
+        self.try_acquire_write_cb();
+        let guard = self.inner.lock().expect("Write lock should succeed");
+        let mut my_guard =
+            AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Write);
+        f(&mut my_guard)
     }
 
     /// get copy of the locked value T (if T implements Copy).
     ///
     /// # Example
     /// ```
-    /// # use twenty_first::sync::{AtomicRw, traits::*};
-    /// let atomic_u64 = AtomicRw::from(25u64);
+    /// # use twenty_first::sync::{AtomicMutex, traits::*};
+    /// let atomic_u64 = AtomicMutex::from(25u64);
     /// let age = atomic_u64.get();
     /// ```
     #[inline]
@@ -149,8 +306,8 @@ impl<T> AtomicMutex<T> {
     ///
     /// # Example
     /// ```
-    /// # use twenty_first::sync::{AtomicRw, traits::*};
-    /// let atomic_bool = AtomicRw::from(false);
+    /// # use twenty_first::sync::{AtomicMutex, traits::*};
+    /// let atomic_bool = AtomicMutex::from(false);
     /// atomic_bool.set(true);
     /// ```
     #[inline]
@@ -160,9 +317,34 @@ impl<T> AtomicMutex<T> {
     {
         self.lock_mut(|v| *v = value)
     }
+
+    /// retrieve lock name if present, or None
+    #[inline]
+    pub fn name(&self) -> Option<&str> {
+        self.lock_callback_info.lock_info_owned.name.as_deref()
+    }
+
+    fn try_acquire_read_cb(&self) {
+        if let Some(cb) = self.lock_callback_info.lock_callback_fn {
+            cb(LockEvent::TryAcquire {
+                info: self.lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Read,
+            });
+        }
+    }
+
+    fn try_acquire_write_cb(&self) {
+        if let Some(cb) = self.lock_callback_info.lock_callback_fn {
+            cb(LockEvent::TryAcquire {
+                info: self.lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Write,
+            });
+        }
+    }
 }
 
 impl<T> Atomic<T> for AtomicMutex<T> {
+    #[inline]
     fn lock<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&T) -> R,
@@ -170,6 +352,7 @@ impl<T> Atomic<T> for AtomicMutex<T> {
         AtomicMutex::<T>::lock(self, f)
     }
 
+    #[inline]
     fn lock_mut<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
@@ -178,12 +361,66 @@ impl<T> Atomic<T> for AtomicMutex<T> {
     }
 }
 
+/// A wrapper for [MutexGuard](std::sync::MutexGuard) that
+/// can optionally call a callback to notify when the
+/// lock event occurs
+pub struct AtomicMutexGuard<'a, T> {
+    guard: MutexGuard<'a, T>,
+    lock_callback_info: &'a LockCallbackInfo,
+    acquisition: LockAcquisition,
+}
+
+impl<'a, T> AtomicMutexGuard<'a, T> {
+    fn new(
+        guard: MutexGuard<'a, T>,
+        lock_callback_info: &'a LockCallbackInfo,
+        acquisition: LockAcquisition,
+    ) -> Self {
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Acquire {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition,
+            });
+        }
+        Self {
+            guard,
+            lock_callback_info,
+            acquisition,
+        }
+    }
+}
+
+impl<'a, T> Drop for AtomicMutexGuard<'a, T> {
+    fn drop(&mut self) {
+        let lock_callback_info = self.lock_callback_info;
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Release {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: self.acquisition,
+            });
+        }
+    }
+}
+
+impl<'a, T> Deref for AtomicMutexGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<'a, T> DerefMut for AtomicMutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    // Verify (compile-time) that AtomicRw::lock() and ::lock_mut() accept mutable values.  (FnOnce)
+    // Verify (compile-time) that AtomicMutex::lock() and ::lock_mut() accept mutable values.  (FnMut)
     fn mutable_assignment() {
         let name = "Jim".to_string();
         let atomic_name = AtomicMutex::from(name);

--- a/twenty-first/src/sync/atomic_mutex.rs
+++ b/twenty-first/src/sync/atomic_mutex.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 /// struct Car {
 ///     year: u16,
 /// };
-/// let atomic_car = AtomicMutex::from(Car{year: 2016});
+/// let mut atomic_car = AtomicMutex::from(Car{year: 2016});
 /// atomic_car.lock(|c| println!("year: {}", c.year));
 /// atomic_car.lock_mut(|mut c| c.year = 2023);
 /// ```
@@ -47,7 +47,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 /// }
 /// const LOG_LOCK_EVENT_CB: LockCallbackFn = log_lock_event;
 ///
-/// let atomic_car = AtomicMutex::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
+/// let mut atomic_car = AtomicMutex::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
 /// atomic_car.lock(|c| {println!("year: {}", c.year)});
 /// atomic_car.lock_mut(|mut c| {c.year = 2023});
 /// ```
@@ -231,10 +231,10 @@ impl<T> AtomicMutex<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicMutex::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicMutex::from(Car{year: 2016});
     /// atomic_car.lock_guard_mut().year = 2022;
     /// ```
-    pub fn lock_guard_mut(&self) -> AtomicMutexGuard<T> {
+    pub fn lock_guard_mut(&mut self) -> AtomicMutexGuard<T> {
         self.try_acquire_write_cb();
         let guard = self.inner.lock().expect("Write lock should succeed");
         AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Write)
@@ -271,11 +271,11 @@ impl<T> AtomicMutex<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicMutex::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicMutex::from(Car{year: 2016});
     /// atomic_car.lock_mut(|mut c| {c.year = 2022});
     /// let year = atomic_car.lock_mut(|mut c| {c.year = 2023; c.year});
     /// ```
-    pub fn lock_mut<R, F>(&self, f: F) -> R
+    pub fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -307,11 +307,11 @@ impl<T> AtomicMutex<T> {
     /// # Example
     /// ```
     /// # use twenty_first::sync::{AtomicMutex, traits::*};
-    /// let atomic_bool = AtomicMutex::from(false);
+    /// let mut atomic_bool = AtomicMutex::from(false);
     /// atomic_bool.set(true);
     /// ```
     #[inline]
-    pub fn set(&self, value: T)
+    pub fn set(&mut self, value: T)
     where
         T: Copy,
     {
@@ -353,7 +353,7 @@ impl<T> Atomic<T> for AtomicMutex<T> {
     }
 
     #[inline]
-    fn lock_mut<R, F>(&self, f: F) -> R
+    fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -423,7 +423,7 @@ mod tests {
     // Verify (compile-time) that AtomicMutex::lock() and ::lock_mut() accept mutable values.  (FnMut)
     fn mutable_assignment() {
         let name = "Jim".to_string();
-        let atomic_name = AtomicMutex::from(name);
+        let mut atomic_name = AtomicMutex::from(name);
 
         let mut new_name: String = Default::default();
         atomic_name.lock(|n| new_name = n.to_string());

--- a/twenty-first/src/sync/atomic_rw.rs
+++ b/twenty-first/src/sync/atomic_rw.rs
@@ -1,4 +1,7 @@
+use super::shared::LockAcquisition;
 use super::traits::Atomic;
+use super::{LockCallbackFn, LockCallbackInfo, LockEvent, LockType};
+use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// An `Arc<RwLock<T>>` wrapper to make data thread-safe and easy to work with.
@@ -13,46 +16,174 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// atomic_car.lock(|c| println!("year: {}", c.year));
 /// atomic_car.lock_mut(|mut c| c.year = 2023);
 /// ```
-#[derive(Debug, Default)]
-pub struct AtomicRw<T>(Arc<RwLock<T>>);
+///
+/// It is also possible to provide a name and callback fn
+/// during instantiation.  In this way, the application
+/// can easily trace lock acquisitions.
+///
+/// # Examples
+/// ```
+/// # use twenty_first::sync::{AtomicRw, LockEvent, LockCallbackFn};
+/// struct Car {
+///     year: u16,
+/// };
+///
+/// pub fn log_lock_event(lock_event: LockEvent) {
+///     let (event, info, acquisition) =
+///     match lock_event {
+///         LockEvent::TryAcquire{info, acquisition} => ("TryAcquire", info, acquisition),
+///         LockEvent::Acquire{info, acquisition} => ("Acquire", info, acquisition),
+///         LockEvent::Release{info, acquisition} => ("Release", info, acquisition),
+///     };
+///
+///     println!(
+///         "{} lock `{}` of type `{}` for `{}` by\n\t|-- thread {}, `{:?}`",
+///         event,
+///         info.name().unwrap_or("?"),
+///         info.lock_type(),
+///         acquisition,
+///         std::thread::current().name().unwrap_or("?"),
+///         std::thread::current().id(),
+///     );
+/// }
+/// const LOG_LOCK_EVENT_CB: LockCallbackFn = log_lock_event;
+///
+/// let atomic_car = AtomicRw::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
+/// atomic_car.lock(|c| {println!("year: {}", c.year)});
+/// atomic_car.lock_mut(|mut c| {c.year = 2023});
+/// ```
+///
+/// results in:
+/// ```text
+/// TryAcquire lock `car` of type `RwLock` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// Acquire lock `car` of type `RwLock` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// year: 2016
+/// Release lock `car` of type `RwLock` for `Read` by
+///     |-- thread main, `ThreadId(1)`
+/// TryAcquire lock `car` of type `RwLock` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// Acquire lock `car` of type `RwLock` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// Release lock `car` of type `RwLock` for `Write` by
+///     |-- thread main, `ThreadId(1)`
+/// ```
+#[derive(Debug)]
+pub struct AtomicRw<T> {
+    inner: Arc<RwLock<T>>,
+    lock_callback_info: LockCallbackInfo,
+}
+
+impl<T: Default> Default for AtomicRw<T> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, None, None),
+        }
+    }
+}
+
 impl<T> From<T> for AtomicRw<T> {
     #[inline]
     fn from(t: T) -> Self {
-        Self(Arc::new(RwLock::new(t)))
+        Self {
+            inner: Arc::new(RwLock::new(t)),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, None, None),
+        }
+    }
+}
+impl<T> From<(T, Option<String>, Option<LockCallbackFn>)> for AtomicRw<T> {
+    /// Create from an optional name and an optional callback function, which
+    /// is called when a lock is event occurs.
+    #[inline]
+    fn from(v: (T, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(v.0)),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, v.1, v.2),
+        }
+    }
+}
+impl<T> From<(T, Option<&str>, Option<LockCallbackFn>)> for AtomicRw<T> {
+    /// Create from a name ref and an optional callback function, which
+    /// is called when a lock event occurs.
+    #[inline]
+    fn from(v: (T, Option<&str>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(v.0)),
+            lock_callback_info: LockCallbackInfo::new(
+                LockType::RwLock,
+                v.1.map(|s| s.to_owned()),
+                v.2,
+            ),
+        }
     }
 }
 
 impl<T> Clone for AtomicRw<T> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            lock_callback_info: self.lock_callback_info.clone(),
+            inner: self.inner.clone(),
+        }
     }
 }
 
 impl<T> From<RwLock<T>> for AtomicRw<T> {
     #[inline]
     fn from(t: RwLock<T>) -> Self {
-        Self(Arc::new(t))
+        Self {
+            inner: Arc::new(t),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, None, None),
+        }
+    }
+}
+impl<T> From<(RwLock<T>, Option<String>, Option<LockCallbackFn>)> for AtomicRw<T> {
+    /// Create from an `RwLock<T>` plus an optional name
+    /// and an optional callback function, which is called
+    /// when a lock event occurs.
+    #[inline]
+    fn from(v: (RwLock<T>, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: Arc::new(v.0),
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, v.1, v.2),
+        }
     }
 }
 
 impl<T> TryFrom<AtomicRw<T>> for RwLock<T> {
     type Error = Arc<RwLock<T>>;
     fn try_from(t: AtomicRw<T>) -> Result<RwLock<T>, Self::Error> {
-        Arc::<RwLock<T>>::try_unwrap(t.0)
+        Arc::<RwLock<T>>::try_unwrap(t.inner)
     }
 }
 
 impl<T> From<Arc<RwLock<T>>> for AtomicRw<T> {
     #[inline]
     fn from(t: Arc<RwLock<T>>) -> Self {
-        Self(t)
+        Self {
+            inner: t,
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, None, None),
+        }
+    }
+}
+impl<T> From<(Arc<RwLock<T>>, Option<String>, Option<LockCallbackFn>)> for AtomicRw<T> {
+    /// Create from an `Arc<RwLock<T>>` plus an optional name and
+    /// an optional callback function, which is called when a lock
+    /// event occurs.
+    #[inline]
+    fn from(v: (Arc<RwLock<T>>, Option<String>, Option<LockCallbackFn>)) -> Self {
+        Self {
+            inner: v.0,
+            lock_callback_info: LockCallbackInfo::new(LockType::RwLock, v.1, v.2),
+        }
     }
 }
 
 impl<T> From<AtomicRw<T>> for Arc<RwLock<T>> {
     #[inline]
     fn from(t: AtomicRw<T>) -> Self {
-        t.0
+        t.inner
     }
 }
 
@@ -70,8 +201,10 @@ impl<T> AtomicRw<T> {
     /// let atomic_car = AtomicRw::from(Car{year: 2016});
     /// let year = atomic_car.lock_guard().year;
     /// ```
-    pub fn lock_guard(&self) -> RwLockReadGuard<T> {
-        self.0.read().expect("Read lock should succeed")
+    pub fn lock_guard(&self) -> AtomicRwReadGuard<T> {
+        self.try_acquire_read_cb();
+        let guard = self.inner.read().expect("Read lock should succeed");
+        AtomicRwReadGuard::new(guard, &self.lock_callback_info)
     }
 
     /// Acquire write lock and return an `RwLockWriteGuard`
@@ -85,8 +218,10 @@ impl<T> AtomicRw<T> {
     /// let atomic_car = AtomicRw::from(Car{year: 2016});
     /// atomic_car.lock_guard_mut().year = 2022;
     /// ```
-    pub fn lock_guard_mut(&self) -> RwLockWriteGuard<T> {
-        self.0.write().expect("Write lock should succeed")
+    pub fn lock_guard_mut(&self) -> AtomicRwWriteGuard<T> {
+        self.try_acquire_write_cb();
+        let guard = self.inner.write().expect("Write lock should succeed");
+        AtomicRwWriteGuard::new(guard, &self.lock_callback_info)
     }
 
     /// Immutably access the data of type `T` in a closure and possibly return a result of type `R`
@@ -105,8 +240,10 @@ impl<T> AtomicRw<T> {
     where
         F: FnOnce(&T) -> R,
     {
-        let lock = self.0.read().expect("Read lock should succeed");
-        f(&lock)
+        self.try_acquire_read_cb();
+        let guard = self.inner.read().expect("Read lock should succeed");
+        let my_guard = AtomicRwReadGuard::new(guard, &self.lock_callback_info);
+        f(&my_guard)
     }
 
     /// Mutably access the data of type `T` in a closure and possibly return a result of type `R`
@@ -125,10 +262,20 @@ impl<T> AtomicRw<T> {
     where
         F: FnOnce(&mut T) -> R,
     {
-        let mut lock = self.0.write().expect("Write lock should succeed");
-        f(&mut lock)
+        self.try_acquire_write_cb();
+        let guard = self.inner.write().expect("Write lock should succeed");
+        let mut my_guard = AtomicRwWriteGuard::new(guard, &self.lock_callback_info);
+        f(&mut my_guard)
     }
 
+    /// get copy of the locked value T (if T implements Copy).
+    ///
+    /// # Example
+    /// ```
+    /// # use twenty_first::sync::{AtomicRw, traits::*};
+    /// let atomic_u64 = AtomicRw::from(25u64);
+    /// let age = atomic_u64.get();
+    /// ```
     #[inline]
     pub fn get(&self) -> T
     where
@@ -137,12 +284,44 @@ impl<T> AtomicRw<T> {
         self.lock(|v| *v)
     }
 
+    /// set the locked value T (if T implements Copy).
+    ///
+    /// # Example
+    /// ```
+    /// # use twenty_first::sync::{AtomicRw, traits::*};
+    /// let atomic_bool = AtomicRw::from(false);
+    /// atomic_bool.set(true);
+    /// ```
     #[inline]
     pub fn set(&self, value: T)
     where
         T: Copy,
     {
         self.lock_mut(|v| *v = value)
+    }
+
+    /// retrieve lock name if present, or None
+    #[inline]
+    pub fn name(&self) -> Option<&str> {
+        self.lock_callback_info.lock_info_owned.name.as_deref()
+    }
+
+    fn try_acquire_read_cb(&self) {
+        if let Some(cb) = self.lock_callback_info.lock_callback_fn {
+            cb(LockEvent::TryAcquire {
+                info: self.lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Read,
+            });
+        }
+    }
+
+    fn try_acquire_write_cb(&self) {
+        if let Some(cb) = self.lock_callback_info.lock_callback_fn {
+            cb(LockEvent::TryAcquire {
+                info: self.lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Write,
+            });
+        }
     }
 }
 
@@ -161,6 +340,96 @@ impl<T> Atomic<T> for AtomicRw<T> {
         F: FnOnce(&mut T) -> R,
     {
         AtomicRw::<T>::lock_mut(self, f)
+    }
+}
+
+/// A wrapper for [RwLockReadGuard](std::sync::RwLockReadGuard) that
+/// can optionally call a callback to notify when a
+/// lock event occurs.
+pub struct AtomicRwReadGuard<'a, T> {
+    guard: RwLockReadGuard<'a, T>,
+    lock_callback_info: &'a LockCallbackInfo,
+}
+
+impl<'a, T> AtomicRwReadGuard<'a, T> {
+    fn new(guard: RwLockReadGuard<'a, T>, lock_callback_info: &'a LockCallbackInfo) -> Self {
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Acquire {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Read,
+            });
+        }
+        Self {
+            guard,
+            lock_callback_info,
+        }
+    }
+}
+
+impl<'a, T> Drop for AtomicRwReadGuard<'a, T> {
+    fn drop(&mut self) {
+        let lock_callback_info = self.lock_callback_info;
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Release {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Read,
+            });
+        }
+    }
+}
+
+impl<'a, T> Deref for AtomicRwReadGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+/// A wrapper for [RwLockWriteGuard](std::sync::RwLockWriteGuard) that
+/// can optionally call a callback to notify when the
+/// a lock event occurs.
+pub struct AtomicRwWriteGuard<'a, T> {
+    guard: RwLockWriteGuard<'a, T>,
+    lock_callback_info: &'a LockCallbackInfo,
+}
+
+impl<'a, T> AtomicRwWriteGuard<'a, T> {
+    fn new(guard: RwLockWriteGuard<'a, T>, lock_callback_info: &'a LockCallbackInfo) -> Self {
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Acquire {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Write,
+            });
+        }
+        Self {
+            guard,
+            lock_callback_info,
+        }
+    }
+}
+
+impl<'a, T> Drop for AtomicRwWriteGuard<'a, T> {
+    fn drop(&mut self) {
+        let lock_callback_info = self.lock_callback_info;
+        if let Some(cb) = lock_callback_info.lock_callback_fn {
+            cb(LockEvent::Release {
+                info: lock_callback_info.lock_info_owned.as_lock_info(),
+                acquisition: LockAcquisition::Write,
+            });
+        }
+    }
+}
+
+impl<'a, T> Deref for AtomicRwWriteGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<'a, T> DerefMut for AtomicRwWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
     }
 }
 

--- a/twenty-first/src/sync/atomic_rw.rs
+++ b/twenty-first/src/sync/atomic_rw.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// struct Car {
 ///     year: u16,
 /// };
-/// let atomic_car = AtomicRw::from(Car{year: 2016});
+/// let mut atomic_car = AtomicRw::from(Car{year: 2016});
 /// atomic_car.lock(|c| println!("year: {}", c.year));
 /// atomic_car.lock_mut(|mut c| c.year = 2023);
 /// ```
@@ -48,7 +48,7 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// }
 /// const LOG_LOCK_EVENT_CB: LockCallbackFn = log_lock_event;
 ///
-/// let atomic_car = AtomicRw::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
+/// let mut atomic_car = AtomicRw::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
 /// atomic_car.lock(|c| {println!("year: {}", c.year)});
 /// atomic_car.lock_mut(|mut c| {c.year = 2023});
 /// ```
@@ -215,10 +215,10 @@ impl<T> AtomicRw<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicRw::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicRw::from(Car{year: 2016});
     /// atomic_car.lock_guard_mut().year = 2022;
     /// ```
-    pub fn lock_guard_mut(&self) -> AtomicRwWriteGuard<T> {
+    pub fn lock_guard_mut(&mut self) -> AtomicRwWriteGuard<T> {
         self.try_acquire_write_cb();
         let guard = self.inner.write().expect("Write lock should succeed");
         AtomicRwWriteGuard::new(guard, &self.lock_callback_info)
@@ -254,11 +254,11 @@ impl<T> AtomicRw<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicRw::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicRw::from(Car{year: 2016});
     /// atomic_car.lock_mut(|mut c| {c.year = 2022});
     /// let year = atomic_car.lock_mut(|mut c| {c.year = 2023; c.year});
     /// ```
-    pub fn lock_mut<R, F>(&self, f: F) -> R
+    pub fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -289,11 +289,11 @@ impl<T> AtomicRw<T> {
     /// # Example
     /// ```
     /// # use twenty_first::sync::{AtomicRw, traits::*};
-    /// let atomic_bool = AtomicRw::from(false);
+    /// let mut atomic_bool = AtomicRw::from(false);
     /// atomic_bool.set(true);
     /// ```
     #[inline]
-    pub fn set(&self, value: T)
+    pub fn set(&mut self, value: T)
     where
         T: Copy,
     {
@@ -335,7 +335,7 @@ impl<T> Atomic<T> for AtomicRw<T> {
     }
 
     #[inline]
-    fn lock_mut<R, F>(&self, f: F) -> R
+    fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -441,7 +441,7 @@ mod tests {
     // Verify (compile-time) that AtomicRw::lock() and ::lock_mut() accept mutable values.  (FnMut)
     fn mutable_assignment() {
         let name = "Jim".to_string();
-        let atomic_name = AtomicRw::from(name);
+        let mut atomic_name = AtomicRw::from(name);
 
         let mut new_name: String = Default::default();
         atomic_name.lock(|n| new_name = n.to_string());

--- a/twenty-first/src/sync/mod.rs
+++ b/twenty-first/src/sync/mod.rs
@@ -2,7 +2,11 @@
 
 mod atomic_mutex;
 mod atomic_rw;
+mod shared;
 pub mod traits;
 
 pub use atomic_mutex::AtomicMutex;
-pub use atomic_rw::AtomicRw;
+pub use atomic_rw::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
+pub use shared::{LockAcquisition, LockCallbackFn, LockEvent, LockInfo, LockType};
+
+use shared::LockCallbackInfo;

--- a/twenty-first/src/sync/shared.rs
+++ b/twenty-first/src/sync/shared.rs
@@ -1,0 +1,108 @@
+/// Indicates the lock's underlying type
+#[derive(Debug, Clone, Copy)]
+pub enum LockType {
+    Mutex,
+    RwLock,
+}
+
+impl std::fmt::Display for LockType {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mutex => write!(f, "Mutex"),
+            Self::RwLock => write!(f, "RwLock"),
+        }
+    }
+}
+
+/// Indicates how a lock was acquired.
+#[derive(Debug, Clone, Copy)]
+pub enum LockAcquisition {
+    Read,
+    Write,
+}
+
+impl std::fmt::Display for LockAcquisition {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read => write!(f, "Read"),
+            Self::Write => write!(f, "Write"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct LockInfoOwned {
+    pub name: Option<String>,
+    pub lock_type: LockType,
+}
+impl LockInfoOwned {
+    #[inline]
+    pub fn as_lock_info(&self) -> LockInfo<'_> {
+        LockInfo {
+            name: self.name.as_deref(),
+            lock_type: self.lock_type,
+        }
+    }
+}
+
+/// Contains metadata about a lock
+#[derive(Debug, Clone)]
+pub struct LockInfo<'a> {
+    name: Option<&'a str>,
+    lock_type: LockType,
+}
+impl<'a> LockInfo<'a> {
+    /// get the lock's name
+    #[inline]
+    pub fn name(&self) -> Option<&str> {
+        self.name
+    }
+
+    /// get the lock's type
+    #[inline]
+    pub fn lock_type(&self) -> LockType {
+        self.lock_type
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct LockCallbackInfo {
+    pub lock_info_owned: LockInfoOwned,
+    pub lock_callback_fn: Option<LockCallbackFn>,
+}
+impl LockCallbackInfo {
+    #[inline]
+    pub fn new(
+        lock_type: LockType,
+        name: Option<String>,
+        lock_callback_fn: Option<LockCallbackFn>,
+    ) -> Self {
+        Self {
+            lock_info_owned: LockInfoOwned { name, lock_type },
+            lock_callback_fn,
+        }
+    }
+}
+
+/// Represents an event (acquire/release) for a lock
+#[derive(Debug, Clone)]
+pub enum LockEvent<'a> {
+    TryAcquire {
+        info: LockInfo<'a>,
+        acquisition: LockAcquisition,
+    },
+    Acquire {
+        info: LockInfo<'a>,
+        acquisition: LockAcquisition,
+    },
+    Release {
+        info: LockInfo<'a>,
+        acquisition: LockAcquisition,
+    },
+}
+
+/// A callback fn for receiving [LockEvent] event
+/// each time a lock is acquired or released.
+pub type LockCallbackFn = fn(lock_event: LockEvent);

--- a/twenty-first/src/sync/traits.rs
+++ b/twenty-first/src/sync/traits.rs
@@ -25,11 +25,11 @@ pub trait Atomic<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicRw::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicRw::from(Car{year: 2016});
     /// atomic_car.lock_mut(|mut c| {c.year = 2022;});
     /// let year = atomic_car.lock_mut(|mut c| {c.year = 2023; c.year});
     /// ```
-    fn lock_mut<R, F>(&self, f: F) -> R
+    fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R;
 
@@ -54,11 +54,11 @@ pub trait Atomic<T> {
     /// # Example
     /// ```
     /// # use twenty_first::sync::{AtomicRw, traits::*};
-    /// let atomic_bool = AtomicRw::from(false);
+    /// let mut atomic_bool = AtomicRw::from(false);
     /// atomic_bool.set(true);
     /// ```
     #[inline]
-    fn set(&self, value: T)
+    fn set(&mut self, value: T)
     where
         T: Copy,
     {

--- a/twenty-first/src/test_shared/mmr.rs
+++ b/twenty-first/src/test_shared/mmr.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use itertools::Itertools;
 
@@ -21,7 +20,7 @@ use crate::utils::has_unique_elements;
 pub fn get_empty_rustyleveldb_ammr<H: AlgebraicHasher>() -> ArchivalMmr<H, RustyLevelDbVec<Digest>>
 {
     let db = DB::open_new_test_database(true, None, None, None).unwrap();
-    let pv = RustyLevelDbVec::new(Arc::new(db), 0, "AMMR for unit tests");
+    let pv = RustyLevelDbVec::new(db, 0, "AMMR for unit tests");
     ArchivalMmr::new(pv)
 }
 

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -318,7 +318,6 @@ impl<H: AlgebraicHasher> ArchivalMmr<H, RustyLevelDbVec<Digest>> {
 
 #[cfg(test)]
 mod mmr_test {
-    use std::sync::Arc;
 
     use super::*;
     use crate::shared_math::other::random_elements;
@@ -1028,8 +1027,7 @@ mod mmr_test {
     fn rust_leveldb_persist_test() {
         type H = blake3::Hasher;
 
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
-        let db = Arc::new(db);
+        let mut db = DB::open_new_test_database(true, None, None, None).unwrap();
         let persistent_vec_0 = RustyLevelDbVec::new(db.clone(), 0, "archival MMR for unit tests");
         let mut ammr0: ArchivalMmr<H, RustyLevelDbVec<Digest>> = ArchivalMmr::new(persistent_vec_0);
         let persistent_vec_1 = RustyLevelDbVec::new(db.clone(), 1, "archival MMR for unit tests");

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -619,7 +619,6 @@ mod accumulator_mmr_tests {
                         .clone()
                         .into_iter()
                         .zip(membership_proofs)
-                        .map(|(v, mp)| (v, mp))
                         .collect();
                     assert!(accumulator_mmr.verify_batch_update(
                         &expected_new_peaks_from_accumulator,

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -745,11 +745,7 @@ mod mmr_membership_proof_test {
         let mut updated_leaf_hashes = leaf_hashes;
         updated_leaf_hashes[2] = new_leaf2;
         updated_leaf_hashes[3] = new_leaf3;
-        for (_i, (mp, &leaf_hash)) in membership_proofs
-            .iter()
-            .zip(updated_leaf_hashes.iter())
-            .enumerate()
-        {
+        for (mp, &leaf_hash) in membership_proofs.iter().zip(&updated_leaf_hashes) {
             mp.verify(
                 &archival_mmr.get_peaks(),
                 leaf_hash,


### PR DESCRIPTION
note: This draft PR is based on branch `0_36_backports_mut_self_squashed` which is waiting to merge to master until triton-vm+tasm-lib+neptune-core are building with master again.

This adds a DbtMap type.  It is an experiment, as really we are creating a logical key/val subset within the full key/val set of LevelDB, and LevelDB provides no facilities for that, so it is awkward.   With this initial design/impl, DbtMap should only be used for small sets of values, probably less than 1000 entries.    Here is the comment from DbtMapInternal, with more detail:

```
Important!  This type should only be used for storing
a small number of values, eg under 1000, although there
is no fixed limit.

DbtMap is essentially creating a logical sub-set of key/val
pairs inside the full set, which is the LevelDB database.

In order to persist its list of known keys, DbtMap stores
that list in a single LevelDB key, which must be updated for
every insert or delete.

Additionally, DbtMap keeps a copy of the key-list in RAM,
which is loaded from the DB during initialization.

For this reason, this type is not suited to storing
huge numbers of entries.

So in this design, for a DbtMap with prefix `0` and values
`{(10,100), (20,200), (30,300)}`, the levelDB representation logically
looks like:
  0_kl: [10,20,30],
  0_10: 100,
  0_20: 200,
  0_30: 300

So the entire `0_kl` list must be updated for each insertion/removal.

An alternative design is possible where the DbtMap
keys are stored in an ascending list of LevelDB keys,
eg:
  0_kl_0: 10,
  0_kl_1: 20,
  0_kl_2: 30,
  0_10: 100,
  0_20: 200,
  0_30: 300

Here only a single small `0_kl_x` key needs to be added or removed
for each insertion/removal.

This design could scale better to large numbers of entries
but would be slower for read access without all keys
cached in RAM.
```

Really though, *both* designs are awkward as every insertion/removal requires two writes instead of one, and we require (up-to) double the space in the DB in order to store the key list.  But without a key-list, the only way to find "our" keys would be to iterate over the entire LevelDB, which doesn't seem a good option either.

So basically, this is not a good fit for LevelDB.
