### PR TITLE
evict interior mutability in storage.  (&self --> &mut self)

### DIFF
--- a/twenty-first/benches/db_dbtvec.rs
+++ b/twenty-first/benches/db_dbtvec.rs
@@ -101,7 +101,7 @@ mod write_100_entries {
         use super::*;
 
         fn push_impl(bencher: Bencher, persist: bool) {
-            let (mut storage, vector) = create_test_dbtvec();
+            let (mut storage, mut vector) = create_test_dbtvec();
 
             bencher.bench_local(|| {
                 for _i in 0..NUM_WRITE_ITEMS {
@@ -128,7 +128,7 @@ mod write_100_entries {
         use super::*;
 
         fn set_impl(bencher: Bencher, persist: bool) {
-            let (mut storage, vector) = create_test_dbtvec();
+            let (mut storage, mut vector) = create_test_dbtvec();
 
             for _i in 0..NUM_WRITE_ITEMS {
                 vector.push(value());
@@ -160,7 +160,7 @@ mod write_100_entries {
         use super::*;
 
         fn set_many_impl(bencher: Bencher, persist: bool) {
-            let (mut storage, vector) = create_test_dbtvec();
+            let (mut storage, mut vector) = create_test_dbtvec();
 
             for _ in 0..NUM_WRITE_ITEMS {
                 vector.push(vec![42]);
@@ -190,7 +190,7 @@ mod write_100_entries {
         use super::*;
 
         fn pop_impl(bencher: Bencher, persist: bool) {
-            let (mut storage, vector) = create_test_dbtvec();
+            let (mut storage, mut vector) = create_test_dbtvec();
 
             for _i in 0..NUM_WRITE_ITEMS {
                 vector.push(value());
@@ -225,7 +225,7 @@ mod read_100_entries {
     const NUM_READ_ITEMS: u64 = 100;
 
     fn get_impl(bencher: Bencher, num_each: usize, persisted: bool) {
-        let (mut storage, vector) = create_test_dbtvec();
+        let (mut storage, mut vector) = create_test_dbtvec();
 
         for _i in 0..NUM_READ_ITEMS {
             vector.push(value());
@@ -244,7 +244,7 @@ mod read_100_entries {
     }
 
     fn get_many_impl(bencher: Bencher, num_each: usize, persisted: bool) {
-        let (mut storage, vector) = create_test_dbtvec();
+        let (mut storage, mut vector) = create_test_dbtvec();
 
         for _i in 0..NUM_READ_ITEMS {
             vector.push(value());

--- a/twenty-first/benches/db_leveldb.rs
+++ b/twenty-first/benches/db_leveldb.rs
@@ -102,7 +102,7 @@ mod write_100_entries {
         use super::*;
 
         fn put(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -118,7 +118,7 @@ mod write_100_entries {
         }
 
         fn batch_put(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -136,7 +136,7 @@ mod write_100_entries {
         }
 
         fn batch_put_write(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -197,7 +197,7 @@ mod write_100_entries {
         use super::*;
 
         fn delete(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -217,7 +217,7 @@ mod write_100_entries {
         }
 
         fn batch_delete(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -244,7 +244,7 @@ mod write_100_entries {
         }
 
         fn batch_delete_write(bencher: Bencher, sync: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options_default(),
@@ -319,7 +319,7 @@ mod read_100_entries {
         use super::*;
 
         fn get(bencher: Bencher, num_reads: usize, cache: bool, verify_checksum: bool) {
-            let db = DB::open_new_test_database(
+            let mut db = DB::open_new_test_database(
                 true,
                 db_options(),
                 read_options(verify_checksum, cache),

--- a/twenty-first/benches/sync_atomic.rs
+++ b/twenty-first/benches/sync_atomic.rs
@@ -71,7 +71,7 @@ mod lock_mut {
 
         #[divan::bench]
         fn lock_guard_mut(bencher: Bencher) {
-            let atom = AtomicRw::from(true);
+            let mut atom = AtomicRw::from(true);
 
             bencher.bench_local(|| {
                 for _i in 0..NUM_ACQUIRES {

--- a/twenty-first/src/storage/database_array.rs
+++ b/twenty-first/src/storage/database_array.rs
@@ -32,7 +32,7 @@ impl<const N: IndexType, T: Serialize + DeserializeOwned + Default> DatabaseArra
     }
 
     /// set all key/val pairs in `indices_and_vals`
-    pub fn batch_set(&self, indices_and_vals: &[(IndexType, T)]) {
+    pub fn batch_set(&mut self, indices_and_vals: &[(IndexType, T)]) {
         let indices: Vec<IndexType> = indices_and_vals.iter().map(|(index, _)| *index).collect();
         assert!(
             indices.iter().all(|index| *index < N),
@@ -84,7 +84,6 @@ impl<const N: IndexType, T: Serialize + DeserializeOwned + Default> DatabaseArra
 
 #[cfg(test)]
 mod database_array_tests {
-    use super::super::level_db::DB;
     use super::*;
 
     #[test]

--- a/twenty-first/src/storage/database_array.rs
+++ b/twenty-first/src/storage/database_array.rs
@@ -51,7 +51,7 @@ impl<const N: IndexType, T: Serialize + DeserializeOwned + Default> DatabaseArra
 
     /// Set the value at index
     #[inline]
-    pub fn set(&self, index: IndexType, value: T) {
+    pub fn set(&mut self, index: IndexType, value: T) {
         assert!(
             N > index,
             "Cannot set outside of length. Length: {N}, index: {index}"
@@ -91,7 +91,7 @@ mod database_array_tests {
     fn init_and_default_values_test() {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
         assert_eq!(0u64, u64::default());
-        let db_array: DatabaseArray<101, u64> = DatabaseArray::new(db);
+        let mut db_array: DatabaseArray<101, u64> = DatabaseArray::new(db);
         assert_eq!(0u64, db_array.get(0));
         assert_eq!(0u64, db_array.get(100));
         assert_eq!(0u64, db_array.get(42));
@@ -127,7 +127,7 @@ mod database_array_tests {
     fn panic_on_index_out_of_range_length_one_set_test() {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
-        let db_array: DatabaseArray<50, u64> = DatabaseArray::new(db);
+        let mut db_array: DatabaseArray<50, u64> = DatabaseArray::new(db);
         db_array.set(90, 17);
     }
 }

--- a/twenty-first/src/storage/database_vector.rs
+++ b/twenty-first/src/storage/database_vector.rs
@@ -30,7 +30,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     ///
     /// This function will panic if the database write fails
     #[inline]
-    fn set_length(&self, length: IndexType) {
+    fn set_length(&mut self, length: IndexType) {
         let length = utils::serialize(&length);
         self.db
             .put_u8(&LENGTH_KEY, &length)
@@ -43,7 +43,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     ///
     /// This function will panic if the index is not found
     #[inline]
-    fn delete(&self, index: IndexType) {
+    fn delete(&mut self, index: IndexType) {
         self.db
             .delete(&index)
             .expect("Deleting element must succeed");
@@ -99,7 +99,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     /// # Panics
     ///
     /// This function will panic if the DB batch write fails
-    pub fn overwrite_with_vec(&self, new_vector: Vec<T>) {
+    pub fn overwrite_with_vec(&mut self, new_vector: Vec<T>) {
         let old_length = self.len();
         let new_length = new_vector.len() as IndexType;
         self.set_length(new_length);
@@ -130,7 +130,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     /// This function will panic if the new Vec is not empty.
     #[inline]
     pub fn new(db: DB) -> Self {
-        let ret = DatabaseVector {
+        let mut ret = DatabaseVector {
             db,
             _type: PhantomData,
         };
@@ -186,7 +186,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     ///
     /// This function will panic if any index is out of range
     /// or if any database write fails.
-    pub fn batch_set(&self, indices_and_vals: &[(IndexType, T)]) {
+    pub fn batch_set(&mut self, indices_and_vals: &[(IndexType, T)]) {
         let indices: Vec<IndexType> = indices_and_vals.iter().map(|(index, _)| *index).collect();
         let length = self.len();
         assert!(
@@ -245,7 +245,6 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
 
 #[cfg(test)]
 mod database_vector_tests {
-    use super::super::level_db::DB;
     use super::*;
 
     fn test_constructor() -> DatabaseVector<u64> {

--- a/twenty-first/src/storage/database_vector.rs
+++ b/twenty-first/src/storage/database_vector.rs
@@ -169,7 +169,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     /// This function will panic if index is out of range
     /// or if the database write fails.
     #[inline]
-    pub fn set(&self, index: IndexType, value: T) {
+    pub fn set(&mut self, index: IndexType, value: T) {
         debug_assert!(
             self.len() > index,
             "Cannot set outside of length. Length: {}, index: {}",
@@ -211,7 +211,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     /// This function will panic if get, delete, or
     /// set_length operations panic.
     #[inline]
-    pub fn pop(&self) -> Option<T> {
+    pub fn pop(&mut self) -> Option<T> {
         match self.len() {
             0 => None,
             length => {
@@ -229,7 +229,7 @@ impl<T: Serialize + DeserializeOwned> DatabaseVector<T> {
     ///
     /// This function will panic if the DB write fails
     #[inline]
-    pub fn push(&self, value: T) {
+    pub fn push(&mut self, value: T) {
         let length = self.len();
         let value_bytes = utils::serialize(&value);
         self.db.put(&length, &value_bytes).unwrap();
@@ -255,7 +255,7 @@ mod database_vector_tests {
 
     #[test]
     fn push_pop_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         assert_eq!(0, db_vector.len());
         assert!(db_vector.is_empty());
 
@@ -285,7 +285,7 @@ mod database_vector_tests {
 
     #[test]
     fn overwrite_with_vec_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         for _ in 0..10 {
             db_vector.push(17);
         }
@@ -306,7 +306,7 @@ mod database_vector_tests {
 
     #[test]
     fn batch_set_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         for _ in 0..100 {
             db_vector.push(17);
         }
@@ -327,7 +327,7 @@ mod database_vector_tests {
 
     #[test]
     fn push_many_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         for _ in 0..1000 {
             db_vector.push(17);
         }
@@ -345,7 +345,7 @@ mod database_vector_tests {
     #[should_panic = "Cannot get outside of length. Length: 1, index: 1"]
     #[test]
     fn panic_on_index_out_of_range_length_one_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         db_vector.push(5558999);
         db_vector.get(1);
     }
@@ -353,7 +353,7 @@ mod database_vector_tests {
     #[should_panic = "Cannot set outside of length. Length: 1, index: 1"]
     #[test]
     fn panic_on_index_out_of_range_length_one_set_test() {
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         db_vector.push(5558999);
         db_vector.set(1, 14);
     }
@@ -371,7 +371,7 @@ mod database_vector_tests {
     #[test]
     fn index_zero_test() {
         // Verify that index zero does not overwrite the stored length
-        let db_vector = test_constructor();
+        let mut db_vector = test_constructor();
         db_vector.push(17);
         assert_eq!(1, db_vector.len());
         assert_eq!(17u64, db_vector.get(0));

--- a/twenty-first/src/storage/level_db.rs
+++ b/twenty-first/src/storage/level_db.rs
@@ -21,7 +21,12 @@ use rand_distr::Alphanumeric;
 use std::path::Path;
 use std::sync::Arc;
 
-/// DB provides thread-safe access to LevelDB API.
+/// `DbIntMut` provides thread-safe access to LevelDB API with `&self` setters
+///
+/// Interior mutability is available without rust locks because the underlying
+/// C++ levelDB API is internally thread-safe.
+///
+/// If `&self` setters are not needed, prefer [`DB`] instead.
 //
 //  This also provides an abstraction layer which enables
 //  us to provide an API that is somewhat backwards compatible
@@ -30,7 +35,7 @@ use std::sync::Arc;
 //
 //  Do not add any public (mutable) fields to this struct.
 #[derive(Debug, Clone)]
-pub struct DB {
+pub struct DbIntMut {
     // note: these must be private and unchanged after creation.
 
     // This Option is needed for the Drop impl.  See comments there.
@@ -43,7 +48,7 @@ pub struct DB {
     write_options: WriteOptions,
 }
 
-impl DB {
+impl DbIntMut {
     /// Open a new database
     ///
     /// If the database is missing, the behaviour depends on `options.create_if_missing`.
@@ -151,7 +156,7 @@ impl DB {
         opt.create_if_missing = true;
         opt.error_if_exists = false;
 
-        let mut db = DB::open_with_options(path, &opt, read_opt, write_opt)?;
+        let mut db = Self::open_with_options(path, &opt, read_opt, write_opt)?;
         db.destroy_db_on_drop = destroy_db_on_drop;
         Ok(db)
     }
@@ -237,7 +242,7 @@ impl DB {
     }
 
     /// Wipe the database files, if existing.
-    fn destroy_db(&mut self) -> Result<(), std::io::Error> {
+    fn destroy_db(&self) -> Result<(), std::io::Error> {
         match self.path.exists() {
             true => std::fs::remove_dir_all(&self.path),
             false => Ok(()),
@@ -245,7 +250,7 @@ impl DB {
     }
 }
 
-impl Drop for DB {
+impl Drop for DbIntMut {
     #[inline]
     fn drop(&mut self) {
         if self.destroy_db_on_drop {
@@ -284,21 +289,21 @@ impl Drop for DB {
     }
 }
 
-// impl Batch for DB {
+// impl Batch for DbIntMut {
 //     #[inline]
 //     fn write(&self, options: &WriteOptions, batch: &WriteBatch) -> Result<(), DbError> {
 //         self.db.write(options, batch)
 //     }
 // }
 
-impl<'a> Compaction<'a> for DB {
+impl<'a> Compaction<'a> for DbIntMut {
     #[inline]
     fn compact(&self, start: &'a [u8], limit: &'a [u8]) {
         self.db.as_ref().unwrap().compact(start, limit)
     }
 }
 
-impl<'a> Iterable<'a> for DB {
+impl<'a> Iterable<'a> for DbIntMut {
     #[inline]
     fn iter(&'a self, options: &ReadOptions) -> Iterator<'a> {
         self.db.as_ref().unwrap().iter(options)
@@ -315,9 +320,214 @@ impl<'a> Iterable<'a> for DB {
     }
 }
 
-impl Snapshots for DB {
+impl Snapshots for DbIntMut {
     fn snapshot(&self) -> Snapshot {
         self.db.as_ref().unwrap().snapshot()
+    }
+}
+
+/// `DB` provides thread-safe access to LevelDB API with `&mut self` setters.
+///
+/// `DB` is a newtype wrapper for [`DbIntMut`] that hides the interior mutability
+/// of the underlying C++ levelDB API, which is internally thread-safe.
+///
+/// If interior mutability is needed, use [`DbIntMut`] instead.
+//
+//  This also provides an abstraction layer which enables
+//  us to provide an API that is somewhat backwards compatible
+//  with rusty-leveldb.  For example, our get() and put()
+//  do not require ReadOptions and WriteOptions param.
+#[derive(Debug, Clone)]
+pub struct DB(DbIntMut);
+
+impl DB {
+    /// Open a new database
+    ///
+    /// If the database is missing, the behaviour depends on `options.create_if_missing`.
+    /// The database will be created using the settings given in `options`.
+    #[inline]
+    pub fn open(name: &Path, options: &Options) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open(name, options)?))
+    }
+
+    /// Open a new database
+    ///
+    /// If the database is missing, the behaviour depends on `options.create_if_missing`.
+    /// The database will be created using the settings given in `options`.
+    #[inline]
+    pub fn open_with_options(
+        name: &Path,
+        options: &Options,
+        read_options: ReadOptions,
+        write_options: WriteOptions,
+    ) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open_with_options(
+            name,
+            options,
+            read_options,
+            write_options,
+        )?))
+    }
+
+    /// Open a new database with a custom comparator
+    ///
+    /// If the database is missing, the behaviour depends on `options.create_if_missing`.
+    /// The database will be created using the settings given in `options`.
+    ///
+    /// The comparator must implement a total ordering over the keyspace.
+    ///
+    /// For keys that implement Ord, consider the `OrdComparator`.
+    #[inline]
+    pub fn open_with_comparator<C: Comparator>(
+        name: &Path,
+        options: &Options,
+        comparator: C,
+    ) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open_with_comparator(
+            name, options, comparator,
+        )?))
+    }
+
+    /// Creates and opens a test database
+    ///
+    /// The database will be created in the system
+    /// temp directory with prefix "test-db-" followed
+    /// by a random string.
+    ///
+    /// if destroy_db_on_drop is true, the database on-disk
+    /// files will be wiped when the DB struct is dropped.
+    pub fn open_new_test_database(
+        destroy_db_on_drop: bool,
+        options: Option<Options>,
+        read_options: Option<ReadOptions>,
+        write_options: Option<WriteOptions>,
+    ) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open_new_test_database(
+            destroy_db_on_drop,
+            options,
+            read_options,
+            write_options,
+        )?))
+    }
+
+    /// Opens an existing (test?) database, with auto-destroy option.
+    ///
+    /// if destroy_db_on_drop is true, the database on-disk
+    /// files will be wiped when the DB struct is dropped.
+    /// This is usually useful only for unit-test purposes.
+    pub fn open_test_database(
+        path: &std::path::Path,
+        destroy_db_on_drop: bool,
+        options: Option<Options>,
+        read_options: Option<ReadOptions>,
+        write_options: Option<WriteOptions>,
+    ) -> Result<Self, DbError> {
+        Ok(Self(DbIntMut::open_test_database(
+            path,
+            destroy_db_on_drop,
+            options,
+            read_options,
+            write_options,
+        )?))
+    }
+
+    /// Set a key/val in the database
+    #[inline]
+    pub fn put(&mut self, key: &dyn IntoLevelDBKey, value: &[u8]) -> Result<(), DbError> {
+        self.0.put(key, value)
+    }
+
+    /// Set a key/val in the database, with key as bytes.
+    #[inline]
+    pub fn put_u8(&mut self, key: &[u8], value: &[u8]) -> Result<(), DbError> {
+        self.0.put_u8(key, value)
+    }
+
+    /// Get a value matching key from the database
+    #[inline]
+    pub fn get(&self, key: &dyn IntoLevelDBKey) -> Result<Option<Vec<u8>>, DbError> {
+        self.0.get(key)
+    }
+
+    /// Get a value matching key from the database, with key as bytes
+    #[inline]
+    pub fn get_u8(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DbError> {
+        self.0.get_u8(key)
+    }
+
+    /// Delete an entry matching key from the database
+    #[inline]
+    pub fn delete(&mut self, key: &dyn IntoLevelDBKey) -> Result<(), DbError> {
+        self.0.delete(key)
+    }
+
+    /// Delete an entry matching key from the database, with key as bytes
+    #[inline]
+    pub fn delete_u8(&mut self, key: &[u8]) -> Result<(), DbError> {
+        self.0.delete_u8(key)
+    }
+
+    /// Write the WriteBatch to database atomically
+    ///
+    /// The sync flag forces filesystem sync operation eg fsync
+    /// which will be slower than async writes, which are not
+    /// guaranteed to complete. See leveldb Docs.
+    pub fn write(&mut self, batch: &WriteBatch, sync: bool) -> Result<(), DbError> {
+        self.0.write(batch, sync)
+    }
+
+    /// Write [`WriteBatch`] to database atomically
+    ///
+    /// Sync behavior will be determined by the WriteOptions
+    /// supplied at `DB` creation.
+    pub fn write_auto(&mut self, batch: &WriteBatch) -> Result<(), DbError> {
+        self.0.write_auto(batch)
+    }
+
+    /// returns the directory path of the database files on disk.
+    #[inline]
+    pub fn path(&self) -> &std::path::PathBuf {
+        self.0.path()
+    }
+
+    /// returns `destroy_db_on_drop` setting
+    #[inline]
+    pub fn destroy_db_on_drop(&self) -> bool {
+        self.0.destroy_db_on_drop()
+    }
+
+    /// compacts the database file.  should be called periodically.
+    #[inline]
+    pub fn compact<'a>(&mut self, start: &'a [u8], limit: &'a [u8]) {
+        self.0.compact(start, limit)
+    }
+
+    /// Wipe the database files, if existing.
+    pub fn destroy_db(&mut self) -> Result<(), std::io::Error> {
+        self.0.destroy_db()
+    }
+}
+
+impl<'a> Iterable<'a> for DB {
+    #[inline]
+    fn iter(&'a self, options: &ReadOptions) -> Iterator<'a> {
+        self.0.iter(options)
+    }
+
+    #[inline]
+    fn keys_iter(&'a self, options: &ReadOptions) -> KeyIterator<'a> {
+        self.0.keys_iter(options)
+    }
+
+    #[inline]
+    fn value_iter(&'a self, options: &ReadOptions) -> ValueIterator<'a> {
+        self.0.value_iter(options)
+    }
+}
+
+impl Snapshots for DB {
+    fn snapshot(&self) -> Snapshot {
+        self.0.snapshot()
     }
 }
 
@@ -329,8 +539,8 @@ mod tests {
     #[test]
     fn level_db_close_and_reload() {
         // open new test database that will not be destroyed on close.
-        let db = DB::open_new_test_database(false, None, None, None).unwrap();
-        let db_path = db.path.clone();
+        let mut db = DB::open_new_test_database(false, None, None, None).unwrap();
+        let db_path = db.path().clone();
 
         let key = "answer-to-everything";
         let val = vec![42];
@@ -342,7 +552,7 @@ mod tests {
         assert!(db_path.exists());
 
         // open existing database that will be destroyed on close.
-        let db2 = DB::open_test_database(&db_path, true, None, None, None).unwrap();
+        let db2 = DbIntMut::open_test_database(&db_path, true, None, None, None).unwrap();
 
         let val2 = db2.get(&key).unwrap().unwrap();
         assert_eq!(val, val2);

--- a/twenty-first/src/storage/storage_schema/dbtsingleton.rs
+++ b/twenty-first/src/storage/storage_schema/dbtsingleton.rs
@@ -63,7 +63,7 @@ where
     }
 
     #[inline]
-    fn set(&self, t: V) {
+    fn set(&mut self, t: V) {
         self.inner.lock_mut(|inner| inner.set(t));
     }
 }
@@ -74,7 +74,7 @@ where
     V: Serialize + DeserializeOwned,
 {
     #[inline]
-    fn pull_queue(&self) -> Vec<WriteOperation> {
+    fn pull_queue(&mut self) -> Vec<WriteOperation> {
         self.inner.lock_mut(|inner| {
             if inner.current_value == inner.old_value {
                 vec![]
@@ -89,7 +89,7 @@ where
     }
 
     #[inline]
-    fn restore_or_new(&self) {
+    fn restore_or_new(&mut self) {
         self.inner.lock_mut(|inner| {
             inner.current_value = match inner.reader.get(inner.key.into()) {
                 Some(value) => value.into_any(),

--- a/twenty-first/src/storage/storage_schema/mod.rs
+++ b/twenty-first/src/storage/storage_schema/mod.rs
@@ -84,7 +84,7 @@ mod tests {
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
         assert_eq!(1, Arc::strong_count(&rusty_storage.schema.reader));
-        let singleton = rusty_storage
+        let mut singleton = rusty_storage
             .schema
             .new_singleton::<S>("singleton".to_owned());
         assert_eq!(2, Arc::strong_count(&rusty_storage.schema.reader));
@@ -142,7 +142,7 @@ mod tests {
         let db_path = db.path().clone();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -267,7 +267,7 @@ mod tests {
         let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
 
         let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
-        let new_vector = new_rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut new_vector = new_rusty_storage.schema.new_vec::<S>("test-vector");
 
         // initialize
         new_rusty_storage.restore_or_new();
@@ -345,7 +345,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -398,7 +398,7 @@ mod tests {
         // initialize storage
         let mut rusty_storage = SimpleRustyStorage::new(db);
         rusty_storage.restore_or_new();
-        let vector = rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
         // Generate initial index/value pairs.
         const TEST_LIST_LENGTH: u8 = 105;
@@ -481,7 +481,7 @@ mod tests {
         // initialize storage
         let mut rusty_storage = SimpleRustyStorage::new(db);
         rusty_storage.restore_or_new();
-        let vector = rusty_storage.schema.new_vec::<S>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<S>("test-vector");
 
         // Generate initial index/value pairs.
         const TEST_LIST_LENGTH: u8 = 105;
@@ -547,7 +547,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let persisted_vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut persisted_vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // Insert 1000 elements
         let mut rng = rand::thread_rng();
@@ -650,7 +650,7 @@ mod tests {
         let db_path = db.path().clone();
         let mut rusty_storage = SimpleRustyStorage::new(db);
         let vector1 = rusty_storage.schema.new_vec::<u64>("test-vector1");
-        let singleton = rusty_storage
+        let mut singleton = rusty_storage
             .schema
             .new_singleton::<u64>("singleton-1".to_owned());
 
@@ -683,9 +683,9 @@ mod tests {
         let db_path = db.path().clone();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector1 = rusty_storage.schema.new_vec::<S>("test-vector1");
-        let vector2 = rusty_storage.schema.new_vec::<S>("test-vector2");
-        let singleton = rusty_storage
+        let mut vector1 = rusty_storage.schema.new_vec::<S>("test-vector1");
+        let mut vector2 = rusty_storage.schema.new_vec::<S>("test-vector2");
+        let mut singleton = rusty_storage
             .schema
             .new_singleton::<S>("singleton".to_owned());
 
@@ -789,7 +789,7 @@ mod tests {
         let new_db = DB::open_test_database(&db_path, true, None, None, None).unwrap();
         let mut new_rusty_storage = SimpleRustyStorage::new(new_db);
         let new_vector1 = new_rusty_storage.schema.new_vec::<S>("test-vector1");
-        let new_vector2 = new_rusty_storage.schema.new_vec::<S>("test-vector2");
+        let mut new_vector2 = new_rusty_storage.schema.new_vec::<S>("test-vector2");
         new_rusty_storage.restore_or_new();
         let new_singleton = new_rusty_storage
             .schema
@@ -867,7 +867,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -885,7 +885,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -903,7 +903,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -920,7 +920,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -937,7 +937,7 @@ mod tests {
         let db = DB::open_new_test_database(true, None, None, None).unwrap();
 
         let mut rusty_storage = SimpleRustyStorage::new(db);
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // initialize
         rusty_storage.restore_or_new();
@@ -956,7 +956,7 @@ mod tests {
         // initialize storage
         let mut rusty_storage = SimpleRustyStorage::new(db);
         rusty_storage.restore_or_new();
-        let vector = rusty_storage.schema.new_vec::<u64>("test-vector");
+        let mut vector = rusty_storage.schema.new_vec::<u64>("test-vector");
 
         // Generate initial index/value pairs.
         const TEST_LIST_LENGTH: u64 = 105;
@@ -1037,37 +1037,39 @@ mod tests {
             #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
             #[test]
             fn non_atomic_set_and_get() {
-                traits_tests::concurrency::non_atomic_set_and_get(&gen_concurrency_test_vec());
+                traits_tests::concurrency::non_atomic_set_and_get(&mut gen_concurrency_test_vec());
             }
 
             #[test]
             #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
             fn non_atomic_set_and_get_wrapped_atomic_rw() {
                 traits_tests::concurrency::non_atomic_set_and_get_wrapped_atomic_rw(
-                    &gen_concurrency_test_vec(),
+                    &mut gen_concurrency_test_vec(),
                 );
             }
 
             #[test]
             fn atomic_set_and_get_wrapped_atomic_rw() {
                 traits_tests::concurrency::atomic_set_and_get_wrapped_atomic_rw(
-                    &gen_concurrency_test_vec(),
+                    &mut gen_concurrency_test_vec(),
                 );
             }
 
             #[test]
             fn atomic_setmany_and_getmany() {
-                traits_tests::concurrency::atomic_setmany_and_getmany(&gen_concurrency_test_vec());
+                traits_tests::concurrency::atomic_setmany_and_getmany(
+                    &mut gen_concurrency_test_vec(),
+                );
             }
 
             #[test]
             fn atomic_setall_and_getall() {
-                traits_tests::concurrency::atomic_setall_and_getall(&gen_concurrency_test_vec());
+                traits_tests::concurrency::atomic_setall_and_getall(&mut gen_concurrency_test_vec());
             }
 
             #[test]
             fn atomic_iter_mut_and_iter() {
-                traits_tests::concurrency::atomic_iter_mut_and_iter(&gen_concurrency_test_vec());
+                traits_tests::concurrency::atomic_iter_mut_and_iter(&mut gen_concurrency_test_vec());
             }
         }
 
@@ -1082,7 +1084,7 @@ mod tests {
                 storage.schema.create_tables_rw(|schema| {
                     (0..num)
                         .map(|_i| {
-                            let singleton = schema.new_singleton::<u64>("singleton".to_owned());
+                            let mut singleton = schema.new_singleton::<u64>("singleton".to_owned());
                             singleton.set(25);
                             singleton
                         })
@@ -1097,7 +1099,8 @@ mod tests {
 
                 (0..num)
                     .map(|_i| {
-                        let singleton = storage.schema.new_singleton::<u64>("singleton".to_owned());
+                        let mut singleton =
+                            storage.schema.new_singleton::<u64>("singleton".to_owned());
                         singleton.set(25);
                         singleton
                     })
@@ -1175,9 +1178,9 @@ mod tests {
                         // This is our writer thread
                         let sets = s.spawn(|| {
                             // start locked write ops
-                            table_singletons.lock_mut(|tables| {
+                            table_singletons.clone().lock_mut(|tables| {
                                 // iterate tables backwards from reader to find inconsistencies faster.
-                                for singleton in tables.iter().rev() {
+                                for singleton in tables.iter_mut().rev() {
                                     singleton.set(modified);
                                 }
                             }); // <--- end locked write ops
@@ -1188,7 +1191,7 @@ mod tests {
                         println!("--- Both threads (reader, writer) finished. restart. ---");
 
                         // start locked write ops
-                        table_singletons.lock_mut(|tables| {
+                        table_singletons.clone().lock_mut(|tables| {
                             for singleton in tables.iter_mut() {
                                 singleton.set(orig);
                             }
@@ -1224,6 +1227,7 @@ mod tests {
             #[test]
             pub fn non_atomic_multi_table_set_and_get() {
                 let singletons = gen_non_atomic_test_singleton(2);
+
                 let orig = singletons[0].get();
                 let modified = orig * 2;
 
@@ -1260,7 +1264,7 @@ mod tests {
 
                         let sets = s.spawn(|| {
                             // iterate tables backwards from reader to find inconsistencies faster.
-                            for singleton in singletons.iter().rev() {
+                            for singleton in singletons.clone().iter_mut().rev() {
                                 singleton.set(modified);
                             }
                         });
@@ -1269,7 +1273,7 @@ mod tests {
 
                         println!("--- threads finished. restart. ---");
 
-                        for singleton in singletons.iter() {
+                        for singleton in singletons.clone().iter_mut() {
                             singleton.set(orig);
                         }
                     });
@@ -1288,7 +1292,7 @@ mod tests {
                 storage.schema.create_tables_rw(|schema| {
                     (0..num)
                         .map(|i| {
-                            let vec =
+                            let mut vec =
                                 schema.new_vec::<u64>(&format!("atomicity-test-vector #{}", i));
                             for j in 0u64..300 {
                                 vec.push(j);
@@ -1306,7 +1310,7 @@ mod tests {
 
                 (0..num)
                     .map(|i| {
-                        let vec = rusty_storage
+                        let mut vec = rusty_storage
                             .schema
                             .new_vec::<u64>(&format!("atomicity-test-vector #{}", i));
                         for j in 0u64..300 {
@@ -1395,9 +1399,9 @@ mod tests {
                         // This is our writer thread
                         let sets = s.spawn(|| {
                             // start locked write ops
-                            table_vecs.lock_mut(|tables| {
+                            table_vecs.clone().lock_mut(|tables| {
                                 // iterate tables backwards from reader to find inconsistencies faster.
-                                for vec in tables.iter().rev() {
+                                for vec in tables.iter_mut().rev() {
                                     vec.set_many(
                                         orig.iter().enumerate().map(|(k, _v)| (k as u64, 50u64)),
                                     );
@@ -1410,7 +1414,7 @@ mod tests {
                         println!("--- Both threads (reader, writer) finished. restart. ---");
 
                         // start locked write ops
-                        table_vecs.lock_mut(|tables| {
+                        table_vecs.clone().lock_mut(|tables| {
                             for vec in tables.iter_mut() {
                                 vec.set_all(orig.clone());
                             }
@@ -1489,7 +1493,7 @@ mod tests {
 
                         let sets = s.spawn(|| {
                             // iterate tables backwards from reader to find inconsistencies faster.
-                            for vec in vecs.iter().rev() {
+                            for vec in vecs.clone().iter_mut().rev() {
                                 vec.set_many(
                                     orig.iter().enumerate().map(|(k, _v)| (k as u64, 50u64)),
                                 );
@@ -1500,7 +1504,7 @@ mod tests {
 
                         println!("--- threads finished. restart. ---");
 
-                        for vec in vecs.iter() {
+                        for vec in vecs.clone().iter_mut() {
                             vec.set_all(orig.clone());
                         }
                     });

--- a/twenty-first/src/storage/storage_schema/schema.rs
+++ b/twenty-first/src/storage/storage_schema/schema.rs
@@ -47,7 +47,7 @@ use std::{fmt::Display, sync::Arc};
 ///
 /// storage.restore_or_new();  // populate tables.
 ///
-/// let atomic_tables = Arc::new(RwLock::new(tables));
+/// let mut atomic_tables = Arc::new(RwLock::new(tables));
 /// let mut lock = atomic_tables.write().unwrap();
 /// lock.0.push(5);
 /// lock.1.push("Sally".into());
@@ -73,7 +73,7 @@ use std::{fmt::Display, sync::Arc};
 /// # let db = level_db::DB::open_new_test_database(true, None, None, None).unwrap();
 /// let mut storage = SimpleRustyStorage::new(db);
 ///
-/// let atomic_tables = storage.schema.create_tables_rw(|s| {
+/// let mut atomic_tables = storage.schema.create_tables_rw(|s| {
 ///     (
 ///         s.new_vec::<u16>("ages"),
 ///         s.new_vec::<String>("names"),
@@ -139,21 +139,23 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
         V: Serialize + DeserializeOwned,
         DbtVec<V>: DbTable + Send + Sync,
     {
-        self.tables.lock_mut(|tables| {
-            assert!(tables.len() < 255);
-            let reader = self.reader.clone();
-            let key_prefix = tables.len() as u8;
-            let lock_name = format!(
-                "{}-DbtVec - {}",
-                self.tables.name().unwrap_or("DbtSchema"),
-                name
-            );
-            let vector =
-                DbtVec::<V>::new(reader, key_prefix, name, lock_name, self.lock_callback_fn);
+        let lock_name = format!(
+            "{}-DbtVec - {}",
+            self.tables.name().unwrap_or("DbtSchema"),
+            name
+        );
 
-            tables.push(Box::new(vector.clone()));
-            vector
-        })
+        let mut tables = self.tables.lock_guard_mut();
+        assert!(tables.len() < 255);
+        let reader = self.reader.clone();
+        let key_prefix = tables.len() as u8;
+        let vector = DbtVec::<V>::new(reader, key_prefix, name, lock_name, self.lock_callback_fn);
+
+        // note: this clone only bumps internal ref-count.
+        let elem = Box::new(vector.clone());
+
+        tables.push(elem);
+        vector
     }
 
     // possible future extension
@@ -207,7 +209,7 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     /// # let db = level_db::DB::open_new_test_database(true, None, None, None).unwrap();
     /// let mut storage = SimpleRustyStorage::new(db);
     ///
-    /// let atomic_tables = storage.schema.create_tables_rw(|s| {
+    /// let mut atomic_tables = storage.schema.create_tables_rw(|s| {
     ///     (
     ///         s.new_vec::<u16>("ages"),
     ///         s.new_vec::<String>("names"),
@@ -246,7 +248,7 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     /// # let db = level_db::DB::open_new_test_database(true, None, None, None).unwrap();
     /// let mut storage = SimpleRustyStorage::new(db);
     ///
-    /// let atomic_tables = storage.schema.create_tables_mutex(|s| {
+    /// let mut atomic_tables = storage.schema.create_tables_mutex(|s| {
     ///     (
     ///         s.new_vec::<u16>("ages"),
     ///         s.new_vec::<String>("names"),
@@ -289,7 +291,7 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     /// storage.restore_or_new();  // populate tables.
     ///
     /// let tables = (ages, names, proceed);
-    /// let atomic_tables = storage.schema.atomic_rw(tables);
+    /// let mut atomic_tables = storage.schema.atomic_rw(tables);
     ///
     /// // these writes happen atomically.
     /// atomic_tables.lock_mut(|tables| {
@@ -320,7 +322,7 @@ impl<Reader: StorageReader + 'static + Sync + Send> DbtSchema<Reader> {
     /// storage.restore_or_new();  // populate tables.
     ///
     /// let tables = (ages, names, proceed);
-    /// let atomic_tables = storage.schema.atomic_mutex(tables);
+    /// let mut atomic_tables = storage.schema.atomic_mutex(tables);
     ///
     /// // these writes happen atomically.
     /// atomic_tables.lock_mut(|tables| {

--- a/twenty-first/src/storage/storage_schema/traits.rs
+++ b/twenty-first/src/storage/storage_schema/traits.rs
@@ -9,9 +9,9 @@ pub use crate::leveldb::database::key::IntoLevelDBKey;
 /// Defines table interface for types used by [`super::DbtSchema`]
 pub trait DbTable {
     /// Retrieve all unwritten operations and empty write-queue
-    fn pull_queue(&self) -> Vec<WriteOperation>;
+    fn pull_queue(&mut self) -> Vec<WriteOperation>;
     /// Restore existing table if present, else create a new one
-    fn restore_or_new(&self);
+    fn restore_or_new(&mut self);
 }
 
 /// Defines storage singleton for types created by [`super::DbtSchema`]
@@ -23,7 +23,7 @@ where
     fn get(&self) -> T;
 
     /// Set value
-    fn set(&self, t: T);
+    fn set(&mut self, t: T);
 }
 
 /// Defines storage reader interface

--- a/twenty-first/src/storage/storage_vec/ordinary_vec.rs
+++ b/twenty-first/src/storage/storage_vec/ordinary_vec.rs
@@ -15,7 +15,7 @@ impl<T> From<Vec<T>> for OrdinaryVec<T> {
 
 impl<T> OrdinaryVec<T> {
     #[inline]
-    pub(crate) fn write_lock(&self) -> AtomicRwWriteGuard<'_, OrdinaryVecPrivate<T>> {
+    pub(crate) fn write_lock(&mut self) -> AtomicRwWriteGuard<'_, OrdinaryVecPrivate<T>> {
         self.0.lock_guard_mut()
     }
 
@@ -29,7 +29,7 @@ impl<T> StorageVecRwLock<T> for OrdinaryVec<T> {
     type LockedData = OrdinaryVecPrivate<T>;
 
     #[inline]
-    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
+    fn try_write_lock(&mut self) -> Option<AtomicRwWriteGuard<'_, Self::LockedData>> {
         Some(self.write_lock())
     }
 
@@ -55,9 +55,9 @@ impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
         self.read_lock().get(index)
     }
 
-    fn many_iter(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter<'a>(
+        &'a self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> Box<dyn Iterator<Item = (Index, T)> + '_> {
         // note: this lock is moved into the iterator closure and is not
         //       released until caller drops the returned iterator
@@ -74,9 +74,9 @@ impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
         }))
     }
 
-    fn many_iter_values(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter_values<'a>(
+        &'a self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> Box<dyn Iterator<Item = T> + '_> {
         // note: this lock is moved into the iterator closure and is not
         //       released until caller drops the returned iterator
@@ -94,28 +94,28 @@ impl<T: Clone> StorageVec<T> for OrdinaryVec<T> {
     }
 
     #[inline]
-    fn set(&self, index: Index, value: T) {
+    fn set(&mut self, index: Index, value: T) {
         // note: on 32 bit systems, this could panic.
         self.write_lock().set(index, value);
     }
 
     #[inline]
-    fn set_many(&self, key_vals: impl IntoIterator<Item = (Index, T)>) {
+    fn set_many(&mut self, key_vals: impl IntoIterator<Item = (Index, T)>) {
         self.write_lock().set_many(key_vals);
     }
 
     #[inline]
-    fn pop(&self) -> Option<T> {
+    fn pop(&mut self) -> Option<T> {
         self.write_lock().pop()
     }
 
     #[inline]
-    fn push(&self, value: T) {
+    fn push(&mut self, value: T) {
         self.write_lock().push(value);
     }
 
     #[inline]
-    fn clear(&self) {
+    fn clear(&mut self) {
         self.write_lock().clear();
     }
 }
@@ -135,37 +135,37 @@ mod tests {
         #[test]
         #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
         fn non_atomic_set_and_get() {
-            traits_tests::concurrency::non_atomic_set_and_get(&gen_concurrency_test_vec());
+            traits_tests::concurrency::non_atomic_set_and_get(&mut gen_concurrency_test_vec());
         }
 
         #[test]
         #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
         fn non_atomic_set_and_get_wrapped_atomic_rw() {
             traits_tests::concurrency::non_atomic_set_and_get_wrapped_atomic_rw(
-                &gen_concurrency_test_vec(),
+                &mut gen_concurrency_test_vec(),
             );
         }
 
         #[test]
         fn atomic_set_and_get_wrapped_atomic_rw() {
             traits_tests::concurrency::atomic_set_and_get_wrapped_atomic_rw(
-                &gen_concurrency_test_vec(),
+                &mut gen_concurrency_test_vec(),
             );
         }
 
         #[test]
         fn atomic_setmany_and_getmany() {
-            traits_tests::concurrency::atomic_setmany_and_getmany(&gen_concurrency_test_vec());
+            traits_tests::concurrency::atomic_setmany_and_getmany(&mut gen_concurrency_test_vec());
         }
 
         #[test]
         fn atomic_setall_and_getall() {
-            traits_tests::concurrency::atomic_setall_and_getall(&gen_concurrency_test_vec());
+            traits_tests::concurrency::atomic_setall_and_getall(&mut gen_concurrency_test_vec());
         }
 
         #[test]
         fn atomic_iter_mut_and_iter() {
-            traits_tests::concurrency::atomic_iter_mut_and_iter(&gen_concurrency_test_vec());
+            traits_tests::concurrency::atomic_iter_mut_and_iter(&mut gen_concurrency_test_vec());
         }
     }
 }

--- a/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
+++ b/twenty-first/src/storage/storage_vec/rusty_leveldb_vec.rs
@@ -4,7 +4,6 @@ use super::{traits::*, Index};
 use crate::sync::{AtomicRw, AtomicRwReadGuard, AtomicRwWriteGuard};
 use leveldb::batch::WriteBatch;
 use serde::{de::DeserializeOwned, Serialize};
-use std::sync::Arc;
 
 /// A concurrency safe database-backed Vec with in memory read/write caching for all operations.
 #[derive(Debug, Clone)]
@@ -171,7 +170,7 @@ impl<T: Serialize + DeserializeOwned + Clone> RustyLevelDbVec<T> {
     }
 
     #[inline]
-    pub fn new(db: Arc<DB>, key_prefix: u8, name: &str) -> Self {
+    pub fn new(db: DB, key_prefix: u8, name: &str) -> Self {
         Self {
             inner: AtomicRw::from(RustyLevelDbVecPrivate::<T>::new(db, key_prefix, name)),
         }

--- a/twenty-first/src/storage/storage_vec/rusty_leveldb_vec_private.rs
+++ b/twenty-first/src/storage/storage_vec/rusty_leveldb_vec_private.rs
@@ -5,7 +5,6 @@ use itertools::Itertools;
 use leveldb::batch::WriteBatch;
 use serde::{de::DeserializeOwned, Serialize};
 use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
 
 /// This is the private impl of RustyLevelDbVec.
 ///
@@ -20,7 +19,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct RustyLevelDbVecPrivate<T: Serialize + DeserializeOwned> {
     key_prefix: u8,
-    pub(super) db: Arc<DB>,
+    pub(super) db: DB,
     write_queue: VecDeque<WriteElement<T>>,
     length: Index,
     pub(super) cache: HashMap<Index, T>,
@@ -273,7 +272,7 @@ impl<T: Serialize + DeserializeOwned> RustyLevelDbVecPrivate<T> {
     }
 
     #[inline]
-    pub(crate) fn new(db: Arc<DB>, key_prefix: u8, name: &str) -> Self {
+    pub(crate) fn new(db: DB, key_prefix: u8, name: &str) -> Self {
         let length_key = Self::get_length_key(key_prefix);
         let length = match utils::get_u8_option(&db, &length_key, name) {
             Some(length_bytes) => utils::deserialize(&length_bytes),

--- a/twenty-first/src/storage/storage_vec/traits.rs
+++ b/twenty-first/src/storage/storage_vec/traits.rs
@@ -50,13 +50,10 @@ pub trait StorageVec<T> {
     /// important to drop the iterator immediately after use.  Typical
     /// for-loop usage does this automatically.
     ///
-    /// If a write is attempted before the read lock is dropped, a deadlock
-    /// will occur.
-    ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// for (key, val) in vec.iter() {
     ///     println!("{key}: {val}")
@@ -65,22 +62,6 @@ pub trait StorageVec<T> {
     /// // write can proceed
     /// vec.set(5, 2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.iter();
-    /// while let Some((key, val)) = iter.next() {
-    ///     println!("{key}: {val}");
-    /// }
-    ///
-    /// // deadlock! This will wait for the write lock forever because iter is still holding read lock.
-    /// vec.set(5, 2);
-    /// ```
-    ///
-    /// note: any write op would deadlock, including `iter_mut()`, `many_iter_mut()`, `set_many()`, etc.
     #[inline]
     fn iter(&self) -> Box<dyn Iterator<Item = (Index, T)> + '_> {
         self.many_iter(0..self.len())
@@ -94,13 +75,10 @@ pub trait StorageVec<T> {
     /// important to drop the iterator immediately after use.  Typical
     /// for-loop usage does this automatically.
     ///
-    /// If a write is attempted before the read lock is dropped, a deadlock
-    /// will occur.
-    ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// for (val) in vec.iter_values() {
     ///     println!("{val}")
@@ -109,22 +87,6 @@ pub trait StorageVec<T> {
     /// // write can proceed
     /// let val = vec.push(2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.iter_values();
-    /// while let Some(val) = iter.next() {
-    ///     println!("{val}")
-    /// }
-    ///
-    /// // deadlock! This will wait for the write lock forever because iter is still holding read lock.
-    /// let val = vec.push(2);
-    /// ```
-    ///
-    /// note: any write op would deadlock, including `iter_mut()`, `many_iter_mut()`, `set_many()`, etc.
     #[inline]
     fn iter_values(&self) -> Box<dyn Iterator<Item = T> + '_> {
         self.many_iter_values(0..self.len())
@@ -140,13 +102,10 @@ pub trait StorageVec<T> {
     /// important to drop the iterator immediately after use.  Typical
     /// for-loop usage does this automatically.
     ///
-    /// If a write is attempted before the read lock is dropped, a deadlock
-    /// will occur.
-    ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// for (key, val) in vec.many_iter([3, 5, 7]) {
     ///     println!("{key}: {val}")
@@ -155,25 +114,9 @@ pub trait StorageVec<T> {
     /// // write can proceed
     /// vec.set(5, 2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.many_iter([3, 5, 7]);
-    /// while let Some((key, val)) = iter.next() {
-    ///     println!("{key}: {val}")
-    /// }
-    ///
-    /// // deadlock! This will wait for the write lock forever because iter is still holding read lock.
-    /// vec.set(5, 2);
-    /// ```
-    ///
-    /// note: any write op would deadlock, including `iter_mut()`, `many_iter_mut()`, `set_many()`, etc.
-    fn many_iter(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter<'a>(
+        &'a self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> Box<dyn Iterator<Item = (Index, T)> + '_>;
 
     /// get an iterator over elements matching indices
@@ -186,13 +129,10 @@ pub trait StorageVec<T> {
     /// important to drop the iterator immediately after use.  Typical
     /// for-loop usage does this automatically.
     ///
-    /// If a write is attempted before the read lock is dropped, a deadlock
-    /// will occur.
-    ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// for (val) in vec.many_iter_values([2, 5, 8]) {
     ///     println!("{val}")
@@ -201,31 +141,15 @@ pub trait StorageVec<T> {
     /// // write can proceed
     /// vec.set(5, 2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.many_iter_values([2, 5, 8]);
-    /// while let Some(val) = iter.next() {
-    ///     println!("{val}")
-    /// }
-    ///
-    /// // deadlock! This will wait for the write lock forever because iter is still holding read lock.
-    /// vec.set(5, 2);
-    /// ```
-    ///
-    /// note: any write op would deadlock, including `iter_mut()`, `many_iter_mut()`, `set_many()`, etc.
-    fn many_iter_values(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter_values<'a>(
+        &'a self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> Box<dyn Iterator<Item = T> + '_>;
 
     /// set a single element.
     ///
     /// note: The update is performed as a single atomic operation.
-    fn set(&self, index: Index, value: T);
+    fn set(&mut self, index: Index, value: T);
 
     /// set multiple elements.
     ///
@@ -236,7 +160,7 @@ pub trait StorageVec<T> {
     /// note: all updates are performed as a single atomic operation.
     ///       readers will see either the before or after state,
     ///       never an intermediate state.
-    fn set_many(&self, key_vals: impl IntoIterator<Item = (Index, T)>);
+    fn set_many(&mut self, key_vals: impl IntoIterator<Item = (Index, T)>);
 
     /// set elements from start to vals.count()
     ///
@@ -244,7 +168,7 @@ pub trait StorageVec<T> {
     ///       readers will see either the before or after state,
     ///       never an intermediate state.
     #[inline]
-    fn set_first_n(&self, vals: impl IntoIterator<Item = T>) {
+    fn set_first_n(&mut self, vals: impl IntoIterator<Item = T>) {
         self.set_many((0..).zip(vals));
     }
 
@@ -260,7 +184,7 @@ pub trait StorageVec<T> {
     /// note: casts the input value's length from usize to Index
     ///       so will panic if vals contains more than 2^32 items
     #[inline]
-    fn set_all(&self, vals: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = T>>) {
+    fn set_all(&mut self, vals: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = T>>) {
         let iter = vals.into_iter();
 
         assert!(
@@ -276,17 +200,17 @@ pub trait StorageVec<T> {
     /// pop an element from end of collection
     ///
     /// note: The update is performed as a single atomic operation.
-    fn pop(&self) -> Option<T>;
+    fn pop(&mut self) -> Option<T>;
 
     /// push an element to end of collection
     ///
     /// note: The update is performed as a single atomic operation.
-    fn push(&self, value: T);
+    fn push(&mut self, value: T);
 
     /// Removes all elements from the collection
     ///
     /// note: The update is performed as a single atomic operation.
-    fn clear(&self);
+    fn clear(&mut self);
 
     /// get a mutable iterator over all elements
     ///
@@ -297,14 +221,14 @@ pub trait StorageVec<T> {
     /// note: the returned (lending) iterator cannot be used in a for loop.  Use a
     ///       while loop instead.  See example below.
     ///
-    /// Important: The returned iterator holds a write lock over `StorageVecRwLock::LockedData`.
-    /// This write lock must be dropped before performing any read operation or the
-    /// code will deadlock.  See Deadlock Example.
+    /// Note: The returned iterator holds a write lock over `StorageVecRwLock::LockedData`.
+    /// This write lock must be dropped before performing any read operation.
+    /// This is enforced by the borrow-checker, which also prevents deadlocks.
     ///
-    /// # Correct Example:
+    /// # Example:
     /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
+    /// # let mut vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
     ///
     /// {
     ///     let mut iter = vec.iter_mut();
@@ -316,25 +240,9 @@ pub trait StorageVec<T> {
     /// // read can proceed
     /// let val = vec.get(2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<u32>::from(vec![1,2,3,4,5,6,7,8,9]);
-    ///
-    /// let mut iter = vec.iter_mut();
-    /// while let Some(mut setter) = iter.next() {
-    ///     setter.set(50);
-    /// }
-    ///
-    /// // deadlock! This will wait for the read lock forever because iter is still holding write lock.
-    /// let val = vec.get(2);
-    /// ```
-    ///
-    /// note: any read op would deadlock, including `iter()`, `many_iter()`, `get_many()`, etc.
     #[allow(private_bounds)]
     #[inline]
-    fn iter_mut(&self) -> ManyIterMut<Self, T>
+    fn iter_mut(&mut self) -> ManyIterMut<Self, T>
     where
         Self: Sized + StorageVecRwLock<T>,
     {
@@ -350,14 +258,14 @@ pub trait StorageVec<T> {
     /// note: the returned (lending) iterator cannot be used in a for loop.  Use a
     ///       while loop instead.  See example below.
     ///
-    /// Important: The returned iterator holds a write lock over `StorageVecRwLock::LockedData`.
-    /// This write lock must be dropped before performing any read operation or the
-    /// code will deadlock.  See Deadlock Example.
+    /// Note: The returned iterator holds a write lock over `StorageVecRwLock::LockedData`.
+    /// This write lock must be dropped before performing any read operation.
+    /// This is enforced by the borrow-checker, which also prevents deadlocks.
     ///
-    /// # Correct Example:
-    /// ```no_run
+    /// # Example:
+    /// ```
     /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<&str>::from(vec!["1","2","3","4","5","6","7","8","9"]);
+    /// # let mut vec = OrdinaryVec::<&str>::from(vec!["1","2","3","4","5","6","7","8","9"]);
     ///
     /// {
     ///     let mut iter = vec.many_iter_mut([2, 4, 6]);
@@ -369,27 +277,11 @@ pub trait StorageVec<T> {
     /// // read can proceed
     /// let val = vec.get(2);
     /// ```
-    ///
-    /// # Deadlock Example:
-    /// ```no_run
-    /// # use twenty_first::storage::storage_vec::{OrdinaryVec, traits::*};
-    /// # let vec = OrdinaryVec::<&str>::from(vec!["1","2","3","4","5","6","7","8","9"]);
-    ///
-    /// let mut iter = vec.many_iter_mut([2, 4, 6]);
-    /// while let Some(mut setter) = iter.next() {
-    ///     setter.set("50");
-    /// }
-    ///
-    /// // deadlock! This will wait for the read lock forever because iter is still holding write lock.
-    /// let val = vec.get(2);
-    /// ```
-    ///
-    /// note: any read op would deadlock, including `iter()`, `many_iter()`, `get_many()`, etc.
     #[allow(private_bounds)]
     #[inline]
-    fn many_iter_mut(
-        &self,
-        indices: impl IntoIterator<Item = Index> + 'static,
+    fn many_iter_mut<'a>(
+        &'a mut self,
+        indices: impl IntoIterator<Item = Index> + 'a,
     ) -> ManyIterMut<Self, T>
     where
         Self: Sized + StorageVecRwLock<T>,
@@ -412,7 +304,7 @@ pub(in super::super) trait StorageVecRwLock<T> {
     type LockedData;
 
     /// obtain write lock over mutable data.
-    fn try_write_lock(&self) -> Option<AtomicRwWriteGuard<Self::LockedData>>;
+    fn try_write_lock(&mut self) -> Option<AtomicRwWriteGuard<Self::LockedData>>;
 
     /// obtain read lock over mutable data.
     fn try_read_lock(&self) -> Option<AtomicRwReadGuard<Self::LockedData>>;
@@ -429,7 +321,7 @@ pub(in crate::storage) mod tests {
         use super::*;
         use std::thread;
 
-        pub fn prepare_concurrency_test_vec(vec: &impl StorageVec<u64>) {
+        pub fn prepare_concurrency_test_vec(vec: &mut impl StorageVec<u64>) {
             vec.clear();
             for i in 0..400 {
                 vec.push(i);
@@ -440,8 +332,8 @@ pub(in crate::storage) mod tests {
         // for a type that impl's StorageVec.
         //
         // note: this test is expected to panic and calling test fn should be annotated with:
-        //  #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
-        pub fn non_atomic_set_and_get(vec: &(impl StorageVec<u64> + Send + Sync)) {
+        #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
+        pub fn non_atomic_set_and_get(vec: &mut (impl StorageVec<u64> + Send + Sync + Clone)) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
             let modified: Vec<u64> = orig.iter().map(|_| 50).collect();
@@ -470,13 +362,13 @@ pub(in crate::storage) mod tests {
                     let sets = s.spawn(|| {
                         // set values one by one, in reverse order than the reader.
                         for j in (0..vec.len()).rev() {
-                            vec.set(j, 50);
+                            vec.clone().set(j, 50);
                         }
                     });
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    vec.set_all(orig.clone());
+                    vec.clone().set_all(orig.clone());
                 }
             });
         }
@@ -485,9 +377,9 @@ pub(in crate::storage) mod tests {
         // (Arc<RwLock<..>>) is atomic if the lock is held across all write/read operations
         //
         // note: this test is expected to panic and calling test fn should be annotated with:
-        //  #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
+        #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: Any { .. }")]
         pub fn non_atomic_set_and_get_wrapped_atomic_rw(
-            vec: &(impl StorageVec<u64> + Send + Sync),
+            vec: &mut (impl StorageVec<u64> + Send + Sync + Clone),
         ) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
@@ -522,22 +414,22 @@ pub(in crate::storage) mod tests {
                         // set values one by one.
                         for j in 0..atomic_vec.lock(|v| v.len()) {
                             // acquire write lock
-                            atomic_vec.lock_mut(|v| {
-                                v.set(j, 50);
-                            }); // release write lock
+                            atomic_vec.clone().lock_guard_mut().set(j, 50);
                         }
                     });
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    atomic_vec.lock_mut(|v| v.set_all(orig.clone()));
+                    atomic_vec.clone().lock_mut(|v| v.set_all(orig.clone()));
                 }
             });
         }
 
         // This test demonstrates/verifies that wrapping an impl StorageVec in an AtomicRw
         // (Arc<RwLock<..>>) is atomic if the lock is held across all write/read operations
-        pub fn atomic_set_and_get_wrapped_atomic_rw(vec: &(impl StorageVec<u64> + Send + Sync)) {
+        pub fn atomic_set_and_get_wrapped_atomic_rw(
+            vec: &mut (impl StorageVec<u64> + Send + Sync),
+        ) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
             let modified: Vec<u64> = orig.iter().map(|_| 50).collect();
@@ -566,7 +458,7 @@ pub(in crate::storage) mod tests {
                     });
 
                     let sets = s.spawn(|| {
-                        atomic_vec.lock_mut(|v| {
+                        atomic_vec.clone().lock_mut(|v| {
                             // acquire write lock
                             for j in 0..v.len() {
                                 // set values one by one.
@@ -577,12 +469,12 @@ pub(in crate::storage) mod tests {
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    atomic_vec.lock_mut(|v| v.set_all(orig.clone()));
+                    atomic_vec.clone().lock_mut(|v| v.set_all(orig.clone()));
                 }
             });
         }
 
-        pub fn atomic_setmany_and_getmany(vec: &(impl StorageVec<u64> + Send + Sync)) {
+        pub fn atomic_setmany_and_getmany(vec: &mut (impl StorageVec<u64> + Send + Sync + Clone)) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
             let modified: Vec<u64> = orig.iter().map(|_| 50).collect();
@@ -604,17 +496,18 @@ pub(in crate::storage) mod tests {
                     });
 
                     let sets = s.spawn(|| {
-                        vec.set_many(orig.iter().enumerate().map(|(k, _v)| (k as u64, 50u64)));
+                        vec.clone()
+                            .set_many(orig.iter().enumerate().map(|(k, _v)| (k as u64, 50u64)));
                     });
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    vec.set_all(orig.clone());
+                    vec.clone().set_all(orig.clone());
                 }
             });
         }
 
-        pub fn atomic_setall_and_getall(vec: &(impl StorageVec<u64> + Send + Sync)) {
+        pub fn atomic_setall_and_getall(vec: &mut (impl StorageVec<u64> + Send + Sync + Clone)) {
             prepare_concurrency_test_vec(vec);
             let orig = vec.get_all();
             let modified: Vec<u64> = orig.iter().map(|_| 50).collect();
@@ -634,19 +527,19 @@ pub(in crate::storage) mod tests {
                     });
 
                     let sets = s.spawn(|| {
-                        vec.set_all(orig.iter().map(|_| 50));
+                        vec.clone().set_all(orig.iter().map(|_| 50));
                     });
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    vec.set_all(orig.clone());
+                    vec.clone().set_all(orig.clone());
                 }
             });
         }
 
-        pub fn atomic_iter_mut_and_iter<T>(vec: &T)
+        pub fn atomic_iter_mut_and_iter<T>(vec: &mut T)
         where
-            T: StorageVec<u64> + StorageVecRwLock<u64> + Send + Sync,
+            T: StorageVec<u64> + StorageVecRwLock<u64> + Send + Sync + Clone,
             T::LockedData: StorageVecLockedData<u64>,
         {
             prepare_concurrency_test_vec(vec);
@@ -667,7 +560,8 @@ pub(in crate::storage) mod tests {
                     });
 
                     let sets = s.spawn(|| {
-                        let mut iter = vec.iter_mut();
+                        let mut vec_mut = vec.clone();
+                        let mut iter = vec_mut.iter_mut();
                         while let Some(mut setter) = iter.next() {
                             setter.set(50);
                         }
@@ -675,7 +569,7 @@ pub(in crate::storage) mod tests {
                     gets.join().unwrap();
                     sets.join().unwrap();
 
-                    vec.set_all(orig.clone());
+                    vec.clone().set_all(orig.clone());
                 }
             });
         }

--- a/twenty-first/src/sync/atomic_mutex.rs
+++ b/twenty-first/src/sync/atomic_mutex.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 /// struct Car {
 ///     year: u16,
 /// };
-/// let atomic_car = AtomicMutex::from(Car{year: 2016});
+/// let mut atomic_car = AtomicMutex::from(Car{year: 2016});
 /// atomic_car.lock(|c| println!("year: {}", c.year));
 /// atomic_car.lock_mut(|mut c| c.year = 2023);
 /// ```
@@ -47,7 +47,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 /// }
 /// const LOG_LOCK_EVENT_CB: LockCallbackFn = log_lock_event;
 ///
-/// let atomic_car = AtomicMutex::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
+/// let mut atomic_car = AtomicMutex::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
 /// atomic_car.lock(|c| {println!("year: {}", c.year)});
 /// atomic_car.lock_mut(|mut c| {c.year = 2023});
 /// ```
@@ -231,10 +231,10 @@ impl<T> AtomicMutex<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicMutex::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicMutex::from(Car{year: 2016});
     /// atomic_car.lock_guard_mut().year = 2022;
     /// ```
-    pub fn lock_guard_mut(&self) -> AtomicMutexGuard<T> {
+    pub fn lock_guard_mut(&mut self) -> AtomicMutexGuard<T> {
         self.try_acquire_write_cb();
         let guard = self.inner.lock().expect("Write lock should succeed");
         AtomicMutexGuard::new(guard, &self.lock_callback_info, LockAcquisition::Write)
@@ -271,11 +271,11 @@ impl<T> AtomicMutex<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicMutex::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicMutex::from(Car{year: 2016});
     /// atomic_car.lock_mut(|mut c| {c.year = 2022});
     /// let year = atomic_car.lock_mut(|mut c| {c.year = 2023; c.year});
     /// ```
-    pub fn lock_mut<R, F>(&self, f: F) -> R
+    pub fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -307,11 +307,11 @@ impl<T> AtomicMutex<T> {
     /// # Example
     /// ```
     /// # use twenty_first::sync::{AtomicMutex, traits::*};
-    /// let atomic_bool = AtomicMutex::from(false);
+    /// let mut atomic_bool = AtomicMutex::from(false);
     /// atomic_bool.set(true);
     /// ```
     #[inline]
-    pub fn set(&self, value: T)
+    pub fn set(&mut self, value: T)
     where
         T: Copy,
     {
@@ -353,7 +353,7 @@ impl<T> Atomic<T> for AtomicMutex<T> {
     }
 
     #[inline]
-    fn lock_mut<R, F>(&self, f: F) -> R
+    fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -423,7 +423,7 @@ mod tests {
     // Verify (compile-time) that AtomicMutex::lock() and ::lock_mut() accept mutable values.  (FnMut)
     fn mutable_assignment() {
         let name = "Jim".to_string();
-        let atomic_name = AtomicMutex::from(name);
+        let mut atomic_name = AtomicMutex::from(name);
 
         let mut new_name: String = Default::default();
         atomic_name.lock(|n| new_name = n.to_string());

--- a/twenty-first/src/sync/atomic_rw.rs
+++ b/twenty-first/src/sync/atomic_rw.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// struct Car {
 ///     year: u16,
 /// };
-/// let atomic_car = AtomicRw::from(Car{year: 2016});
+/// let mut atomic_car = AtomicRw::from(Car{year: 2016});
 /// atomic_car.lock(|c| println!("year: {}", c.year));
 /// atomic_car.lock_mut(|mut c| c.year = 2023);
 /// ```
@@ -48,7 +48,7 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// }
 /// const LOG_LOCK_EVENT_CB: LockCallbackFn = log_lock_event;
 ///
-/// let atomic_car = AtomicRw::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
+/// let mut atomic_car = AtomicRw::<Car>::from((Car{year: 2016}, Some("car"), Some(LOG_LOCK_EVENT_CB)));
 /// atomic_car.lock(|c| {println!("year: {}", c.year)});
 /// atomic_car.lock_mut(|mut c| {c.year = 2023});
 /// ```
@@ -215,10 +215,10 @@ impl<T> AtomicRw<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicRw::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicRw::from(Car{year: 2016});
     /// atomic_car.lock_guard_mut().year = 2022;
     /// ```
-    pub fn lock_guard_mut(&self) -> AtomicRwWriteGuard<T> {
+    pub fn lock_guard_mut(&mut self) -> AtomicRwWriteGuard<T> {
         self.try_acquire_write_cb();
         let guard = self.inner.write().expect("Write lock should succeed");
         AtomicRwWriteGuard::new(guard, &self.lock_callback_info)
@@ -254,11 +254,11 @@ impl<T> AtomicRw<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicRw::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicRw::from(Car{year: 2016});
     /// atomic_car.lock_mut(|mut c| {c.year = 2022});
     /// let year = atomic_car.lock_mut(|mut c| {c.year = 2023; c.year});
     /// ```
-    pub fn lock_mut<R, F>(&self, f: F) -> R
+    pub fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -289,11 +289,11 @@ impl<T> AtomicRw<T> {
     /// # Example
     /// ```
     /// # use twenty_first::sync::{AtomicRw, traits::*};
-    /// let atomic_bool = AtomicRw::from(false);
+    /// let mut atomic_bool = AtomicRw::from(false);
     /// atomic_bool.set(true);
     /// ```
     #[inline]
-    pub fn set(&self, value: T)
+    pub fn set(&mut self, value: T)
     where
         T: Copy,
     {
@@ -335,7 +335,7 @@ impl<T> Atomic<T> for AtomicRw<T> {
     }
 
     #[inline]
-    fn lock_mut<R, F>(&self, f: F) -> R
+    fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -441,7 +441,7 @@ mod tests {
     // Verify (compile-time) that AtomicRw::lock() and ::lock_mut() accept mutable values.  (FnMut)
     fn mutable_assignment() {
         let name = "Jim".to_string();
-        let atomic_name = AtomicRw::from(name);
+        let mut atomic_name = AtomicRw::from(name);
 
         let mut new_name: String = Default::default();
         atomic_name.lock(|n| new_name = n.to_string());

--- a/twenty-first/src/sync/traits.rs
+++ b/twenty-first/src/sync/traits.rs
@@ -25,11 +25,11 @@ pub trait Atomic<T> {
     /// struct Car {
     ///     year: u16,
     /// };
-    /// let atomic_car = AtomicRw::from(Car{year: 2016});
+    /// let mut atomic_car = AtomicRw::from(Car{year: 2016});
     /// atomic_car.lock_mut(|mut c| {c.year = 2022;});
     /// let year = atomic_car.lock_mut(|mut c| {c.year = 2023; c.year});
     /// ```
-    fn lock_mut<R, F>(&self, f: F) -> R
+    fn lock_mut<R, F>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R;
 
@@ -54,11 +54,11 @@ pub trait Atomic<T> {
     /// # Example
     /// ```
     /// # use twenty_first::sync::{AtomicRw, traits::*};
-    /// let atomic_bool = AtomicRw::from(false);
+    /// let mut atomic_bool = AtomicRw::from(false);
     /// atomic_bool.set(true);
     /// ```
     #[inline]
-    fn set(&self, value: T)
+    fn set(&mut self, value: T)
     where
         T: Copy,
     {

--- a/twenty-first/src/test_shared/mmr.rs
+++ b/twenty-first/src/test_shared/mmr.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use itertools::Itertools;
 
@@ -21,7 +20,7 @@ use crate::utils::has_unique_elements;
 pub fn get_empty_rustyleveldb_ammr<H: AlgebraicHasher>() -> ArchivalMmr<H, RustyLevelDbVec<Digest>>
 {
     let db = DB::open_new_test_database(true, None, None, None).unwrap();
-    let pv = RustyLevelDbVec::new(Arc::new(db), 0, "AMMR for unit tests");
+    let pv = RustyLevelDbVec::new(db, 0, "AMMR for unit tests");
     ArchivalMmr::new(pv)
 }
 

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -322,7 +322,6 @@ impl<H: AlgebraicHasher> ArchivalMmr<H, RustyLevelDbVec<Digest>> {
 
 #[cfg(test)]
 mod mmr_test {
-    use std::sync::Arc;
 
     use itertools::*;
     use leveldb::iterator::Iterable;
@@ -1060,8 +1059,7 @@ mod mmr_test {
     fn rust_leveldb_persist_test() {
         type H = blake3::Hasher;
 
-        let db = DB::open_new_test_database(true, None, None, None).unwrap();
-        let db = Arc::new(db);
+        let mut db = DB::open_new_test_database(true, None, None, None).unwrap();
         let persistent_vec_0 = RustyLevelDbVec::new(db.clone(), 0, "archival MMR for unit tests");
         let mut ammr0: ArchivalMmr<H, RustyLevelDbVec<Digest>> = ArchivalMmr::new(persistent_vec_0);
         let persistent_vec_1 = RustyLevelDbVec::new(db.clone(), 1, "archival MMR for unit tests");


### PR DESCRIPTION
<strike>This is a draft PR until triton-vm and tasm-lib are made compatible with twenty-first (master).   At that time, I will rebase this on master.</strike>.   rebased.  ready for review.

---

The basic premise is to have methods take `&mut self` instead of `&self`, most everywhere (in `storage` and also `neptune-core`).

The rationale is that `&self` hides where mutations are occurring, and this propagates up the call-chain.  So it can look like a fn is immutable, but really it is mutating something 3 calls down.

This does not change any functionality or behavior.   But it does change the public API.

https://github.com/Neptune-Crypto/neptune-core/pull/91 <strike>depends on</strike> complements this.