### PR TITLE
Allow repeated sponge-absorption without mutating a list

### DIFF
--- a/twenty-first/src/shared_math/tip5.rs
+++ b/twenty-first/src/shared_math/tip5.rs
@@ -921,7 +921,7 @@ mod tip5_tests {
             let hash_varlen_digest = Tip5::hash_varlen(&preimage);
 
             let mut sponge = Tip5::init();
-            Tip5::pad_and_absorb_repeatedly(&mut sponge, &preimage);
+            Tip5::pad_and_absorb_all(&mut sponge, &preimage);
             let squeeze_result = Tip5::squeeze_once(&mut sponge);
             let digest_through_pad_squeeze_absorb =
                 Digest::new((&squeeze_result[..DIGEST_LENGTH]).try_into().unwrap());
@@ -936,7 +936,7 @@ mod tip5_tests {
         let hash_varlen_digest = Tip5::hash_varlen(&preimage);
 
         let mut sponge = Tip5::init();
-        Tip5::pad_and_absorb_repeatedly(&mut sponge, &preimage);
+        Tip5::pad_and_absorb_all(&mut sponge, &preimage);
         let squeeze_result = Tip5::squeeze_once(&mut sponge);
         let digest_through_pad_squeeze_absorb =
             Digest::new((&squeeze_result[..DIGEST_LENGTH]).try_into().unwrap());

--- a/twenty-first/src/shared_math/tip5.rs
+++ b/twenty-first/src/shared_math/tip5.rs
@@ -3,16 +3,20 @@ use bfieldcodec_derive::BFieldCodec;
 use get_size::GetSize;
 use itertools::Itertools;
 use num_traits::Zero;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 
-use crate::shared_math::b_field_element::{BFieldElement, BFIELD_ONE, BFIELD_ZERO};
-pub use crate::shared_math::digest::{Digest, DIGEST_LENGTH};
-
-use crate::util_types::algebraic_hasher::{AlgebraicHasher, Domain, SpongeHasher};
-
+use crate::shared_math::b_field_element::BFieldElement;
+use crate::shared_math::b_field_element::BFIELD_ONE;
+use crate::shared_math::b_field_element::BFIELD_ZERO;
+pub use crate::shared_math::digest::Digest;
+pub use crate::shared_math::digest::DIGEST_LENGTH;
 use crate::shared_math::mds::generated_function;
 use crate::shared_math::x_field_element::XFieldElement;
 use crate::shared_math::x_field_element::EXTENSION_DEGREE;
+use crate::util_types::algebraic_hasher::AlgebraicHasher;
+use crate::util_types::algebraic_hasher::Domain;
+use crate::util_types::algebraic_hasher::SpongeHasher;
 
 pub const STATE_SIZE: usize = 16;
 pub const NUM_SPLIT_AND_LOOKUP: usize = 4;
@@ -619,7 +623,7 @@ impl AlgebraicHasher for Tip5 {
         let num_squeezes = (num_elements + xfes_per_squeeze - 1) / xfes_per_squeeze;
         (0..num_squeezes)
             .flat_map(|_| {
-                Self::squeeze_once(state)
+                Self::squeeze(state)
                     .into_iter()
                     .take(xfes_per_squeeze * EXTENSION_DEGREE)
                     .collect_vec()
@@ -640,7 +644,7 @@ impl SpongeHasher for Tip5 {
         Tip5State::new(Domain::VariableLength)
     }
 
-    fn absorb_once(sponge: &mut Self::SpongeState, input: &[BFieldElement; RATE]) {
+    fn absorb(sponge: &mut Self::SpongeState, input: [BFieldElement; RATE]) {
         // absorb
         sponge.state[..RATE]
             .iter_mut()
@@ -650,7 +654,7 @@ impl SpongeHasher for Tip5 {
         Tip5::permutation(sponge);
     }
 
-    fn squeeze_once(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE] {
+    fn squeeze(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE] {
         // squeeze
         let produce: [BFieldElement; RATE] = (&sponge.state[..RATE]).try_into().unwrap();
 
@@ -661,16 +665,20 @@ impl SpongeHasher for Tip5 {
 }
 
 #[cfg(test)]
-mod tip5_tests {
+pub(crate) mod tip5_tests {
+    use std::ops::Mul;
 
     use get_size::GetSize;
     use itertools::Itertools;
     use num_traits::One;
     use num_traits::Zero;
+    use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use rand::thread_rng;
+    use rand::Rng;
     use rand::RngCore;
-    use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+    use rayon::prelude::IntoParallelIterator;
+    use rayon::prelude::ParallelIterator;
     use test_strategy::proptest;
 
     use crate::shared_math::b_field_element::BFieldElement;
@@ -685,10 +693,15 @@ mod tip5_tests {
     use crate::shared_math::x_field_element::XFieldElement;
     use crate::util_types::algebraic_hasher::AlgebraicHasher;
     use crate::util_types::algebraic_hasher::SpongeHasher;
-    use std::ops::Mul;
 
     use super::Tip5State;
     use super::RATE;
+
+    pub(crate) fn seed_tip5(sponge: &mut Tip5State) {
+        let mut rng = thread_rng();
+        let seed = rng.gen();
+        Tip5::absorb(sponge, seed);
+    }
 
     #[test]
     fn get_size_test() {
@@ -912,35 +925,30 @@ mod tip5_tests {
         );
     }
 
+    fn manual_hash_varlen(preimage: &[BFieldElement]) -> Digest {
+        let mut sponge = Tip5::init();
+        Tip5::pad_and_absorb_all(&mut sponge, preimage);
+        let squeeze_result = Tip5::squeeze(&mut sponge);
+
+        Digest::new((&squeeze_result[..DIGEST_LENGTH]).try_into().unwrap())
+    }
+
     #[test]
     fn hash_var_len_equivalence_corner_cases() {
-        // Verify that `hash_var_len` is equivalent
-        // to pad + repeated absorb + squeeze once
-        for preimage_length in [0, 1, 2, 3, 4, 5, 6, 9, 10, 11] {
-            let preimage = random_elements(preimage_length);
+        for preimage_length in 0..=11 {
+            let preimage = vec![BFieldElement::new(42); preimage_length];
             let hash_varlen_digest = Tip5::hash_varlen(&preimage);
 
-            let mut sponge = Tip5::init();
-            Tip5::pad_and_absorb_all(&mut sponge, &preimage);
-            let squeeze_result = Tip5::squeeze_once(&mut sponge);
-            let digest_through_pad_squeeze_absorb =
-                Digest::new((&squeeze_result[..DIGEST_LENGTH]).try_into().unwrap());
+            let digest_through_pad_squeeze_absorb = manual_hash_varlen(&preimage);
             assert_eq!(digest_through_pad_squeeze_absorb, hash_varlen_digest);
         }
     }
 
     #[proptest]
     fn hash_var_len_equivalence(#[strategy(arb())] preimage: Vec<BFieldElement>) {
-        // Verify that `hash_var_len` is equivalent
-        // to pad + repeated absorb + squeeze once
         let hash_varlen_digest = Tip5::hash_varlen(&preimage);
-
-        let mut sponge = Tip5::init();
-        Tip5::pad_and_absorb_all(&mut sponge, &preimage);
-        let squeeze_result = Tip5::squeeze_once(&mut sponge);
-        let digest_through_pad_squeeze_absorb =
-            Digest::new((&squeeze_result[..DIGEST_LENGTH]).try_into().unwrap());
-        assert_eq!(digest_through_pad_squeeze_absorb, hash_varlen_digest);
+        let digest_through_pad_squeeze_absorb = manual_hash_varlen(&preimage);
+        prop_assert_eq!(digest_through_pad_squeeze_absorb, hash_varlen_digest);
     }
 
     #[test]
@@ -1042,25 +1050,12 @@ mod tip5_tests {
         }
     }
 
-    fn seed_tip5(sponge: &mut Tip5State) {
-        let mut rng = thread_rng();
-        Tip5::absorb_once(
-            sponge,
-            &(0..RATE)
-                .map(|_| BFieldElement::new(rng.next_u64()))
-                .collect_vec()
-                .try_into()
-                .unwrap(),
-        );
-    }
-
     #[test]
     fn sample_scalars_test() {
-        let amounts = [0, 1, 2, 3, 4];
         let mut sponge = Tip5::init();
         seed_tip5(&mut sponge);
         let mut product = XFieldElement::one();
-        for amount in amounts {
+        for amount in 0..=4 {
             let scalars = Tip5::sample_scalars(&mut sponge, amount);
             assert_eq!(amount, scalars.len());
             product *= scalars

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -59,7 +59,7 @@ pub trait SpongeHasher: Clone + Debug + Default + Send + Sync {
         }
     }
 
-    fn pad_and_absorb_repeatedly(sponge: &mut Self::SpongeState, input: &[BFieldElement]) {
+    fn pad_and_absorb_all(sponge: &mut Self::SpongeState, input: &[BFieldElement]) {
         // calculate padded length; padding is at least one element
         // pad input with [1, 0, 0, ...]
         let padded_length = roundup_nearest_multiple(input.len() + 1, RATE);
@@ -86,7 +86,7 @@ pub trait AlgebraicHasher: SpongeHasher {
     /// - [SpongeHasher::squeeze()] once.
     fn hash_varlen(input: &[BFieldElement]) -> Digest {
         let mut sponge = Self::init();
-        Self::pad_and_absorb_repeatedly(&mut sponge, input);
+        Self::pad_and_absorb_all(&mut sponge, input);
         let produce: [BFieldElement; RATE] = Self::squeeze_once(&mut sponge);
 
         Digest::new((&produce[..DIGEST_LENGTH]).try_into().unwrap())

--- a/twenty-first/src/util_types/blake3_wrapper.rs
+++ b/twenty-first/src/util_types/blake3_wrapper.rs
@@ -45,13 +45,13 @@ impl SpongeHasher for blake3::Hasher {
         Self::SpongeState::new()
     }
 
-    fn absorb(sponge: &mut Self::SpongeState, input: &[BFieldElement; RATE]) {
+    fn absorb_once(sponge: &mut Self::SpongeState, input: &[BFieldElement; RATE]) {
         for &elem in input.iter() {
             sponge.update(elem);
         }
     }
 
-    fn squeeze(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE] {
+    fn squeeze_once(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE] {
         let digest_a = from_blake3_digest(&sponge.finalize());
 
         // There's at most 256 bits of entropy in a blake3::Hash; we stretch

--- a/twenty-first/src/util_types/blake3_wrapper.rs
+++ b/twenty-first/src/util_types/blake3_wrapper.rs
@@ -45,13 +45,13 @@ impl SpongeHasher for blake3::Hasher {
         Self::SpongeState::new()
     }
 
-    fn absorb_once(sponge: &mut Self::SpongeState, input: &[BFieldElement; RATE]) {
-        for &elem in input.iter() {
+    fn absorb(sponge: &mut Self::SpongeState, input: [BFieldElement; RATE]) {
+        for elem in input {
             sponge.update(elem);
         }
     }
 
-    fn squeeze_once(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE] {
+    fn squeeze(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE] {
         let digest_a = from_blake3_digest(&sponge.finalize());
 
         // There's at most 256 bits of entropy in a blake3::Hash; we stretch


### PR DESCRIPTION
Also renames two `SpongeHasher` trait functions.

This closes #183.