### PR TITLE
simplify `SpongeHasher` trait

### DIFF
--- a/twenty-first/src/prelude.rs
+++ b/twenty-first/src/prelude.rs
@@ -11,7 +11,7 @@ pub use crate::shared_math::traits::ModPowU32;
 pub use crate::shared_math::x_field_element;
 pub use crate::shared_math::x_field_element::XFieldElement;
 pub use crate::util_types::algebraic_hasher::AlgebraicHasher;
-pub use crate::util_types::algebraic_hasher::SpongeHasher;
+pub use crate::util_types::algebraic_hasher::Sponge;
 pub use crate::util_types::merkle_tree::CpuParallel;
 pub use crate::util_types::merkle_tree::MerkleTree;
 pub use crate::util_types::merkle_tree::MerkleTreeInclusionProof;

--- a/twenty-first/src/shared_math/tip5.rs
+++ b/twenty-first/src/shared_math/tip5.rs
@@ -23,38 +23,6 @@ pub const CAPACITY: usize = 6;
 pub const RATE: usize = 10;
 pub const NUM_ROUNDS: usize = 5;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, Arbitrary)]
-pub struct Tip5State {
-    pub state: [BFieldElement; STATE_SIZE],
-}
-
-impl Tip5State {
-    #[inline]
-    pub const fn new(domain: Domain) -> Self {
-        use Domain::*;
-
-        let mut state = [BFIELD_ZERO; STATE_SIZE];
-
-        match domain {
-            VariableLength => (),
-            FixedLength => {
-                let mut i = RATE;
-                while i < STATE_SIZE {
-                    state[i] = BFIELD_ONE;
-                    i += 1;
-                }
-            }
-        }
-
-        Self { state }
-    }
-}
-
-#[derive(
-    Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, GetSize, BFieldCodec, Arbitrary,
-)]
-pub struct Tip5 {}
-
 /// The lookup table with a high algebraic degree used in the TIP-5 permutation. To verify its
 /// correctness, see the test “lookup_table_is_correct.”
 pub const LOOKUP_TABLE: [u8; 256] = [
@@ -166,7 +134,34 @@ pub const MDS_MATRIX_FIRST_COLUMN: [i64; STATE_SIZE] = [
     26798, 17845,
 ];
 
+#[derive(
+    Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, GetSize, BFieldCodec, Arbitrary,
+)]
+pub struct Tip5 {
+    pub state: [BFieldElement; STATE_SIZE],
+}
+
 impl Tip5 {
+    #[inline]
+    pub const fn new(domain: Domain) -> Self {
+        use Domain::*;
+
+        let mut state = [BFIELD_ZERO; STATE_SIZE];
+
+        match domain {
+            VariableLength => (),
+            FixedLength => {
+                let mut i = RATE;
+                while i < STATE_SIZE {
+                    state[i] = BFIELD_ONE;
+                    i += 1;
+                }
+            }
+        }
+
+        Self { state }
+    }
+
     #[inline]
     pub const fn offset_fermat_cube_map(x: u16) -> u16 {
         let xx = (x + 1) as u64;
@@ -467,12 +462,12 @@ impl Tip5 {
 
     #[inline(always)]
     #[allow(dead_code)]
-    fn mds_cyclomul(state: &mut [BFieldElement; STATE_SIZE]) {
+    fn mds_cyclomul(&mut self) {
         let mut result = [BFieldElement::zero(); STATE_SIZE];
 
         let mut lo: [i64; STATE_SIZE] = [0; STATE_SIZE];
         let mut hi: [i64; STATE_SIZE] = [0; STATE_SIZE];
-        for (i, b) in state.iter().enumerate() {
+        for (i, b) in self.state.iter().enumerate() {
             hi[i] = (b.raw_u64() >> 32) as i64;
             lo[i] = (b.raw_u64() as u32) as i64;
         }
@@ -491,15 +486,15 @@ impl Tip5 {
                 res.wrapping_add(0u32.wrapping_sub(over as u32) as u64),
             );
         }
-        *state = result;
+        self.state = result;
     }
 
     #[inline(always)]
-    fn mds_generated(state: &mut [BFieldElement; STATE_SIZE]) {
+    fn mds_generated(&mut self) {
         let mut lo: [u64; STATE_SIZE] = [0; STATE_SIZE];
         let mut hi: [u64; STATE_SIZE] = [0; STATE_SIZE];
         for i in 0..STATE_SIZE {
-            let b = state[i].raw_u64();
+            let b = self.state[i].raw_u64();
             hi[i] = b >> 32;
             lo[i] = b & 0xffffffffu64;
         }
@@ -515,64 +510,51 @@ impl Tip5 {
 
             let (res, over) = s_lo.overflowing_add(s_hi * 0xffffffffu64);
 
-            state[r] = BFieldElement::from_raw_u64(if over { res + 0xffffffffu64 } else { res });
+            self.state[r] =
+                BFieldElement::from_raw_u64(if over { res + 0xffffffffu64 } else { res });
         }
     }
 
     #[inline(always)]
     #[allow(clippy::needless_range_loop)]
-    fn sbox_layer(state: &mut [BFieldElement; STATE_SIZE]) {
-        // lookup
-        // state.iter_mut().take(NUM_SPLIT_AND_LOOKUP).for_each(|s| {
-        //     Self::split_and_lookup(s);
-        // });
+    fn sbox_layer(&mut self) {
         for i in 0..NUM_SPLIT_AND_LOOKUP {
-            Self::split_and_lookup(&mut state[i]);
+            Self::split_and_lookup(&mut self.state[i]);
         }
 
-        // power
-        // for st in state.iter_mut().skip(NUM_SPLIT_AND_LOOKUP) {
-        //     let sq = *st * *st;
-        //     let qu = sq * sq;
-        //     *st *= sq * qu;
-        // }
         for i in NUM_SPLIT_AND_LOOKUP..STATE_SIZE {
-            let sq = state[i] * state[i];
+            let sq = self.state[i] * self.state[i];
             let qu = sq * sq;
-            state[i] *= sq * qu;
+            self.state[i] *= sq * qu;
         }
     }
 
     #[inline(always)]
-    fn round(sponge: &mut Tip5State, round_index: usize) {
-        Self::sbox_layer(&mut sponge.state);
-
-        // Self::mds_cyclomul(&mut sponge.state);
-        Self::mds_generated(&mut sponge.state);
-
+    fn round(&mut self, round_index: usize) {
+        self.sbox_layer();
+        self.mds_generated();
         for i in 0..STATE_SIZE {
-            sponge.state[i] += ROUND_CONSTANTS[round_index * STATE_SIZE + i];
+            self.state[i] += ROUND_CONSTANTS[round_index * STATE_SIZE + i];
         }
     }
 
-    // permutation
     #[inline(always)]
-    pub fn permutation(sponge: &mut Tip5State) {
+    pub fn permutation(&mut self) {
         for i in 0..NUM_ROUNDS {
-            Self::round(sponge, i);
+            self.round(i);
         }
     }
 
     /// Functionally equivalent to [`permutation`](Self::permutation). Returns the trace of
     /// applying the permutation; that is, the initial state of the sponge as well as its state
     /// after each round.
-    pub fn trace(sponge: &mut Tip5State) -> [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS] {
+    pub fn trace(&mut self) -> [[BFieldElement; STATE_SIZE]; 1 + NUM_ROUNDS] {
         let mut trace = [[BFIELD_ZERO; STATE_SIZE]; 1 + NUM_ROUNDS];
 
-        trace[0] = sponge.state;
+        trace[0] = self.state;
         for i in 0..NUM_ROUNDS {
-            Self::round(sponge, i);
-            trace[1 + i] = sponge.state;
+            self.round(i);
+            trace[1 + i] = self.state;
         }
 
         trace
@@ -582,13 +564,12 @@ impl Tip5 {
     /// Hash 10 elements, or two digests. There is no padding because
     /// the input length is fixed.
     pub fn hash_10(input: &[BFieldElement; 10]) -> [BFieldElement; DIGEST_LENGTH] {
-        let mut sponge = Tip5State::new(Domain::FixedLength);
+        let mut sponge = Self::new(Domain::FixedLength);
 
         // absorb once
         sponge.state[..10].copy_from_slice(input);
 
-        // apply permutation
-        Self::permutation(&mut sponge);
+        sponge.permutation();
 
         // squeeze once
         sponge.state[..DIGEST_LENGTH].try_into().unwrap()
@@ -597,11 +578,11 @@ impl Tip5 {
 
 impl AlgebraicHasher for Tip5 {
     fn hash_pair(left: Digest, right: Digest) -> Digest {
-        let mut sponge = Tip5State::new(Domain::FixedLength);
+        let mut sponge = Self::new(Domain::FixedLength);
         sponge.state[..DIGEST_LENGTH].copy_from_slice(&left.values());
         sponge.state[DIGEST_LENGTH..2 * DIGEST_LENGTH].copy_from_slice(&right.values());
 
-        Self::permutation(&mut sponge);
+        sponge.permutation();
 
         let digest_values = sponge.state[..DIGEST_LENGTH].try_into().unwrap();
         Digest::new(digest_values)
@@ -610,27 +591,25 @@ impl AlgebraicHasher for Tip5 {
 
 impl SpongeHasher for Tip5 {
     const RATE: usize = RATE;
-    type SpongeState = Tip5State;
+    type SpongeState = Self;
 
     fn init() -> Self::SpongeState {
-        Tip5State::new(Domain::VariableLength)
+        Self::new(Domain::VariableLength)
     }
 
     fn absorb(sponge: &mut Self::SpongeState, input: [BFieldElement; RATE]) {
-        // absorb
         sponge.state[..RATE]
             .iter_mut()
             .zip_eq(input.iter())
             .for_each(|(a, &b)| *a = b);
 
-        Tip5::permutation(sponge);
+        sponge.permutation();
     }
 
     fn squeeze(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE] {
-        // squeeze
         let produce: [BFieldElement; RATE] = (&sponge.state[..RATE]).try_into().unwrap();
 
-        Tip5::permutation(sponge);
+        sponge.permutation();
 
         produce
     }
@@ -640,10 +619,7 @@ impl SpongeHasher for Tip5 {
 pub(crate) mod tip5_tests {
     use std::ops::Mul;
 
-    use get_size::GetSize;
-    use itertools::Itertools;
     use num_traits::One;
-    use num_traits::Zero;
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use rand::thread_rng;
@@ -653,31 +629,26 @@ pub(crate) mod tip5_tests {
     use rayon::prelude::ParallelIterator;
     use test_strategy::proptest;
 
-    use crate::shared_math::b_field_element::BFieldElement;
-    use crate::shared_math::digest::DIGEST_LENGTH;
     use crate::shared_math::other::random_elements;
-    use crate::shared_math::tip5::Digest;
-    use crate::shared_math::tip5::Tip5;
-    use crate::shared_math::tip5::LOOKUP_TABLE;
-    use crate::shared_math::tip5::NUM_ROUNDS;
-    use crate::shared_math::tip5::ROUND_CONSTANTS;
-    use crate::shared_math::tip5::STATE_SIZE;
     use crate::shared_math::x_field_element::XFieldElement;
-    use crate::util_types::algebraic_hasher::AlgebraicHasher;
-    use crate::util_types::algebraic_hasher::SpongeHasher;
 
-    use super::Tip5State;
-    use super::RATE;
+    use super::*;
 
-    pub(crate) fn seed_tip5(sponge: &mut Tip5State) {
-        let mut rng = thread_rng();
-        let seed = rng.gen();
-        Tip5::absorb(sponge, seed);
+    impl Tip5 {
+        pub(crate) fn randomly_seeded() -> Self {
+            let mut sponge = Self::init();
+            let mut rng = thread_rng();
+            Tip5::absorb(&mut sponge, rng.gen());
+            sponge
+        }
     }
 
     #[test]
     fn get_size_test() {
-        assert!(Tip5 {}.get_size().is_zero());
+        assert_eq!(
+            STATE_SIZE * BFieldElement::zero().get_size(),
+            Tip5::randomly_seeded().get_size()
+        );
     }
 
     #[test]
@@ -925,51 +896,49 @@ pub(crate) mod tip5_tests {
 
     #[test]
     fn test_linearity_of_mds() {
-        let mds_procedure = Tip5::mds_cyclomul;
-        // let mds_procedure = Tip5::mds_noswap;
+        type SpongeState = [BFieldElement; STATE_SIZE];
+
+        let mds_procedure = |state| {
+            let mut sponge = Tip5 { state };
+            sponge.mds_cyclomul();
+            sponge.state
+        };
+
         let a: BFieldElement = random_elements(1)[0];
         let b: BFieldElement = random_elements(1)[0];
-        let mut u: [BFieldElement; STATE_SIZE] = random_elements(STATE_SIZE).try_into().unwrap();
-        let mut v: [BFieldElement; STATE_SIZE] = random_elements(STATE_SIZE).try_into().unwrap();
 
-        let mut w: [BFieldElement; STATE_SIZE] = u
-            .iter()
-            .zip(v.iter())
-            .map(|(uu, vv)| a * *uu + b * *vv)
-            .collect::<Vec<BFieldElement>>()
-            .try_into()
-            .unwrap();
+        let mul_procedure = |u: SpongeState, v: SpongeState| -> SpongeState {
+            let mul_result = u.iter().zip(&v).map(|(&uu, &vv)| a * uu + b * vv);
+            mul_result.collect_vec().try_into().unwrap()
+        };
 
-        mds_procedure(&mut u);
-        mds_procedure(&mut v);
-        mds_procedure(&mut w);
+        let u: SpongeState = random_elements(STATE_SIZE).try_into().unwrap();
+        let v: SpongeState = random_elements(STATE_SIZE).try_into().unwrap();
+        let w = mul_procedure(u, v);
 
-        let w_: [BFieldElement; STATE_SIZE] = u
-            .iter()
-            .zip(v.iter())
-            .map(|(uu, vv)| a * *uu + b * *vv)
-            .collect::<Vec<BFieldElement>>()
-            .try_into()
-            .unwrap();
+        let u = mds_procedure(u);
+        let v = mds_procedure(v);
+        let w = mds_procedure(w);
+
+        let w_ = mul_procedure(u, v);
 
         assert_eq!(w, w_);
     }
 
     #[test]
     fn test_mds_circulancy() {
-        let mut e1 = [BFieldElement::zero(); STATE_SIZE];
-        e1[0] = BFieldElement::one();
+        let mut sponge = Tip5::init();
+        sponge.state = [BFieldElement::zero(); STATE_SIZE];
+        sponge.state[0] = BFieldElement::one();
 
-        // let mds_procedure = Tip5::mds_al_kindi;
-        // let mds_procedure = Tip5::mds_cyclomul;
         let mds_procedure = Tip5::mds_generated;
 
-        mds_procedure(&mut e1);
+        mds_procedure(&mut sponge);
 
         let mut mat_first_row = [BFieldElement::zero(); STATE_SIZE];
-        mat_first_row[0] = e1[0];
-        for i in 1..STATE_SIZE {
-            mat_first_row[i] = e1[STATE_SIZE - i];
+        mat_first_row[0] = sponge.state[0];
+        for (i, first_row_elem) in mat_first_row.iter_mut().enumerate().skip(1) {
+            *first_row_elem = sponge.state[STATE_SIZE - i];
         }
 
         println!(
@@ -977,18 +946,21 @@ pub(crate) mod tip5_tests {
             mat_first_row.map(|b| b.value())
         );
 
-        let mut vec: [BFieldElement; STATE_SIZE] = random_elements(STATE_SIZE).try_into().unwrap();
+        let initial_state: [BFieldElement; STATE_SIZE] =
+            random_elements(STATE_SIZE).try_into().unwrap();
 
         let mut mv = [BFieldElement::zero(); STATE_SIZE];
         for i in 0..STATE_SIZE {
             for j in 0..STATE_SIZE {
-                mv[i] += mat_first_row[(STATE_SIZE - i + j) % STATE_SIZE] * vec[j];
+                mv[i] += mat_first_row[(STATE_SIZE - i + j) % STATE_SIZE] * initial_state[j];
             }
         }
 
-        mds_procedure(&mut vec);
+        let mut sponge_2 = Tip5::init();
+        sponge_2.state = initial_state;
+        mds_procedure(&mut sponge_2);
 
-        assert_eq!(vec, mv);
+        assert_eq!(sponge_2.state, mv);
     }
 
     #[test]
@@ -1024,8 +996,7 @@ pub(crate) mod tip5_tests {
 
     #[test]
     fn sample_scalars_test() {
-        let mut sponge = Tip5::init();
-        seed_tip5(&mut sponge);
+        let mut sponge = Tip5::randomly_seeded();
         let mut product = XFieldElement::one();
         for amount in 0..=4 {
             let scalars = Tip5::sample_scalars(&mut sponge, amount);
@@ -1040,30 +1011,28 @@ pub(crate) mod tip5_tests {
     #[test]
     fn test_mds_agree() {
         let mut rng = thread_rng();
-        // let vector: [i64; 16] = (0..16)
-        //     .map(|_| (rng.next_u64() & 0xffffffff) as i64)
-        //     .collect_vec()
-        //     .try_into()
-        //     .unwrap();
-        let vector: [BFieldElement; 16] = (0..16)
-            .map(|_| BFieldElement::new(rng.next_u64() % 10))
+        let initial_state: [BFieldElement; STATE_SIZE] = (0..STATE_SIZE)
+            .map(|_| BFieldElement::new(rng.gen_range(0..10)))
             .collect_vec()
             .try_into()
             .unwrap();
-        // let mut vector = [BFieldElement::zero(); 16];
-        // vector[0] = BFieldElement::one();
 
-        let mut cyclomul = vector;
-        Tip5::mds_cyclomul(&mut cyclomul);
-        let mut generated = vector;
-        Tip5::mds_generated(&mut generated);
+        let mut sponge_cyclomut = Tip5 {
+            state: initial_state,
+        };
+        let mut sponge_generated = Tip5 {
+            state: initial_state,
+        };
+
+        sponge_cyclomut.mds_cyclomul();
+        sponge_generated.mds_generated();
 
         assert_eq!(
-            cyclomul,
-            generated,
+            sponge_cyclomut,
+            sponge_generated,
             "cyclomul =/= generated\n{}\n{}",
-            cyclomul.map(|c| c.to_string()).join(","),
-            generated.map(|c| c.to_string()).join(",")
+            sponge_cyclomut.state.into_iter().join(","),
+            sponge_generated.state.into_iter().join(",")
         );
     }
 }

--- a/twenty-first/src/shared_math/tip5.rs
+++ b/twenty-first/src/shared_math/tip5.rs
@@ -636,7 +636,7 @@ pub(crate) mod tip5_tests {
         pub(crate) fn randomly_seeded() -> Self {
             let mut sponge = Self::init();
             let mut rng = thread_rng();
-            Tip5::absorb(&mut sponge, rng.gen());
+            sponge.absorb(rng.gen());
             sponge
         }
     }
@@ -868,8 +868,8 @@ pub(crate) mod tip5_tests {
 
     fn manual_hash_varlen(preimage: &[BFieldElement]) -> Digest {
         let mut sponge = Tip5::init();
-        Tip5::pad_and_absorb_all(&mut sponge, preimage);
-        let squeeze_result = Tip5::squeeze(&mut sponge);
+        sponge.pad_and_absorb_all(preimage);
+        let squeeze_result = sponge.squeeze();
 
         Digest::new((&squeeze_result[..DIGEST_LENGTH]).try_into().unwrap())
     }
@@ -929,9 +929,7 @@ pub(crate) mod tip5_tests {
         sponge.state = [BFieldElement::zero(); STATE_SIZE];
         sponge.state[0] = BFieldElement::one();
 
-        let mds_procedure = Tip5::mds_generated;
-
-        mds_procedure(&mut sponge);
+        sponge.mds_generated();
 
         let mut mat_first_row = [BFieldElement::zero(); STATE_SIZE];
         mat_first_row[0] = sponge.state[0];
@@ -956,7 +954,7 @@ pub(crate) mod tip5_tests {
 
         let mut sponge_2 = Tip5::init();
         sponge_2.state = initial_state;
-        mds_procedure(&mut sponge_2);
+        sponge_2.mds_generated();
 
         assert_eq!(sponge_2.state, mv);
     }
@@ -997,7 +995,7 @@ pub(crate) mod tip5_tests {
         let mut sponge = Tip5::randomly_seeded();
         let mut product = XFieldElement::one();
         for amount in 0..=4 {
-            let scalars = Tip5::sample_scalars(&mut sponge, amount);
+            let scalars = sponge.sample_scalars(amount);
             assert_eq!(amount, scalars.len());
             product *= scalars
                 .into_iter()

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -76,8 +76,8 @@ pub trait AlgebraicHasher: Sponge {
     /// - [Sponge::squeeze()] once.
     fn hash_varlen(input: &[BFieldElement]) -> Digest {
         let mut sponge = Self::init();
-        Self::pad_and_absorb_all(&mut sponge, input);
-        let produce: [BFieldElement; RATE] = Self::squeeze(&mut sponge);
+        sponge.pad_and_absorb_all(input);
+        let produce: [BFieldElement; RATE] = sponge.squeeze();
 
         Digest::new((&produce[..DIGEST_LENGTH]).try_into().unwrap())
     }
@@ -196,7 +196,7 @@ mod algebraic_hasher_tests {
 
     fn sample_indices_prop(max: u32, num_indices: usize) {
         let mut sponge = Tip5::randomly_seeded();
-        let indices = Tip5::sample_indices(&mut sponge, max, num_indices);
+        let indices = sponge.sample_indices(max, num_indices);
         assert_eq!(num_indices, indices.len());
         assert!(indices.into_iter().all(|index| index < max));
     }
@@ -226,7 +226,7 @@ mod algebraic_hasher_tests {
         let mut sponge = Tip5::randomly_seeded();
         let mut product = XFieldElement::one();
         for amount in amounts {
-            let scalars = Tip5::sample_scalars(&mut sponge, amount);
+            let scalars = sponge.sample_scalars(amount);
             assert_eq!(amount, scalars.len());
             product *= scalars
                 .into_iter()

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -1,80 +1,79 @@
 use std::fmt::Debug;
 use std::iter;
 
-use arbitrary::Arbitrary;
 use itertools::Itertools;
 
-use crate::shared_math::b_field_element::{BFieldElement, BFIELD_ONE, BFIELD_ZERO};
+use crate::shared_math::b_field_element::BFieldElement;
+use crate::shared_math::b_field_element::BFIELD_ONE;
+use crate::shared_math::b_field_element::BFIELD_ZERO;
 use crate::shared_math::bfield_codec::BFieldCodec;
-use crate::shared_math::digest::{Digest, DIGEST_LENGTH};
-use crate::shared_math::other::{is_power_of_two, roundup_nearest_multiple};
-use crate::shared_math::x_field_element::{XFieldElement, EXTENSION_DEGREE};
+use crate::shared_math::digest::Digest;
+use crate::shared_math::digest::DIGEST_LENGTH;
+use crate::shared_math::other::is_power_of_two;
+use crate::shared_math::other::roundup_nearest_multiple;
+use crate::shared_math::x_field_element::XFieldElement;
+use crate::shared_math::x_field_element::EXTENSION_DEGREE;
 
 pub const RATE: usize = 10;
 
 /// The hasher [Domain] differentiates between the modes of hashing.
 ///
-/// The main purpose of declaring the domain is to prevent collisions between
-/// different types of hashing by introducing defining differences in the way
-/// the hash function's internal state (e.g. a sponge state's capacity) is
-/// initialized.
+/// The main purpose of declaring the domain is to prevent collisions between different types of
+/// hashing by introducing defining differences in the way the hash function's internal state
+/// (e.g. a sponge state's capacity) is initialized.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Domain {
-    /// The `VariableLength` domain is used for hashing objects that potentially
-    /// serialize to more than [RATE] number of field elements.
+    /// The `VariableLength` domain is used for hashing objects that potentially serialize to more
+    /// than [`RATE`] number of field elements.
     VariableLength,
 
-    /// The `FixedLength` domain is used for hashing objects that always fit
-    /// within [RATE] number of fields elements, e.g. a pair of [Digest].
+    /// The `FixedLength` domain is used for hashing objects that always fit within [RATE] number
+    /// of fields elements, e.g. a pair of [Digest].
     FixedLength,
 }
 
-pub trait SpongeHasher: Clone + Debug + Default + Send + Sync {
+/// A [cryptographic sponge][sponge]. Should only be based on a cryptographic permutation, e.g.,
+/// [`Tip5`][tip5].
+///
+/// [sponge]: https://keccak.team/files/CSF-0.1.pdf
+/// [tip5]: crate::prelude::Tip5
+pub trait Sponge: Clone + Debug + Default + Send + Sync {
     const RATE: usize;
-    type SpongeState: Clone + Debug + Default + for<'a> Arbitrary<'a>;
 
-    /// Initialize a sponge state
-    fn init() -> Self::SpongeState;
+    fn init() -> Self;
 
-    /// Absorb an array of [RATE] field elements into the sponge's state, mutating it.
-    fn absorb(sponge: &mut Self::SpongeState, input: [BFieldElement; RATE]);
+    fn absorb(&mut self, input: [BFieldElement; RATE]);
 
-    /// Squeeze an array of [RATE] field elements out from the sponge's state, mutating it.
-    fn squeeze(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE];
+    fn squeeze(&mut self) -> [BFieldElement; RATE];
 
-    /// Chunk `input` into arrays of [RATE] elements and repeatedly [SpongeHasher::absorb()].
-    fn pad_and_absorb_all(sponge: &mut Self::SpongeState, input: &[BFieldElement]) {
-        // pad input with [1, 0, 0, ...] – padding is at least one element
+    fn pad_and_absorb_all(&mut self, input: &[BFieldElement]) {
+        // pad input with [1, 0, 0, …] – padding is at least one element
         let padded_length = roundup_nearest_multiple(input.len() + 1, RATE);
         let padding_iter = [BFIELD_ONE].iter().chain(iter::repeat(&BFIELD_ZERO));
         let padded_input = input.iter().chain(padding_iter).take(padded_length);
+
         for chunk in padded_input.chunks(RATE).into_iter() {
-            let absorb_elems: [BFieldElement; RATE] = chunk
-                .cloned()
-                .collect::<Vec<_>>()
-                .try_into()
-                .expect("a multiple of RATE elements");
-            Self::absorb(sponge, absorb_elems);
+            // the padded input has length some multiple of `RATE`
+            let absorb_elems = chunk.cloned().collect_vec().try_into().unwrap();
+            self.absorb(absorb_elems);
         }
     }
 }
 
-pub trait AlgebraicHasher: SpongeHasher {
-    /// Hash two [Digest]s into one.
+pub trait AlgebraicHasher: Sponge {
+    /// 2-to-1 hashing
     fn hash_pair(left: Digest, right: Digest) -> Digest;
 
-    /// Hash a `value: &T` to a [Digest].
-    ///
-    /// The `T` must implement BFieldCodec.
+    /// Thin wrapper around [`hash_varlen`](Self::hash_varlen).
     fn hash<T: BFieldCodec>(value: &T) -> Digest {
         Self::hash_varlen(&value.encode())
     }
 
-    /// Hash a variable-length sequence of [BFieldElement].
+    /// Hash a variable-length sequence of [`BFieldElement`].
     ///
     /// - Apply the correct padding
-    /// - [SpongeHasher::absorb_repeatedly()]
-    /// - [SpongeHasher::squeeze()] once.
+    /// - [Sponge::pad_and_absorb_all()]
+    /// - [Sponge::squeeze()] once.
     fn hash_varlen(input: &[BFieldElement]) -> Digest {
         let mut sponge = Self::init();
         Self::pad_and_absorb_all(&mut sponge, input);
@@ -83,27 +82,20 @@ pub trait AlgebraicHasher: SpongeHasher {
         Digest::new((&produce[..DIGEST_LENGTH]).try_into().unwrap())
     }
 
-    /// Produce `num_indices` random integer values in the range `[0, upper_bound)`.
-    ///
-    /// - The randomness depends on `state`.
-    /// - `upper_bound` must be a power of 2.
+    /// Produce `num_indices` random integer values in the range `[0, upper_bound)`. The
+    /// `upper_bound` must be a power of 2.
     ///
     /// This method uses von Neumann rejection sampling.
-    /// Specifically, if the top 32 bits of a BFieldElement are all
-    /// ones, then the bottom 32 bits are not uniformly distributed,
-    /// and so they are dropped. This method invokes squeeze until
+    /// Specifically, if the top 32 bits of a BFieldElement are all ones, then the bottom 32 bits
+    /// are not uniformly distributed, and so they are dropped. This method invokes squeeze until
     /// enough uniform u32s have been sampled.
-    fn sample_indices(
-        state: &mut Self::SpongeState,
-        upper_bound: u32,
-        num_indices: usize,
-    ) -> Vec<u32> {
+    fn sample_indices(&mut self, upper_bound: u32, num_indices: usize) -> Vec<u32> {
         debug_assert!(is_power_of_two(upper_bound));
         let mut indices = vec![];
         let mut squeezed_elements = vec![];
         while indices.len() != num_indices {
             if squeezed_elements.is_empty() {
-                squeezed_elements = Self::squeeze(state).into_iter().rev().collect_vec();
+                squeezed_elements = self.squeeze().into_iter().rev().collect_vec();
             }
             let element = squeezed_elements.pop().unwrap();
             if element != BFieldElement::new(BFieldElement::MAX) {
@@ -113,12 +105,13 @@ pub trait AlgebraicHasher: SpongeHasher {
         indices
     }
 
-    /// Produce `num_elements` random [XFieldElement] values.
+    /// Produce `num_elements` random [`XFieldElement`] values.
     ///
-    /// - The randomness depends on `state`.
+    /// If `num_elements` is not divisible by [`RATE`][rate], spill the remaining elements of the
+    /// last [`squeeze`][Sponge::squeeze].
     ///
-    /// If `num_elements` is not divisible by `RATE`, spill the remaining elements of the last `squeeze`.
-    fn sample_scalars(state: &mut Self::SpongeState, num_elements: usize) -> Vec<XFieldElement> {
+    /// [rate]: Sponge::RATE
+    fn sample_scalars(&mut self, num_elements: usize) -> Vec<XFieldElement> {
         let num_squeezes = (num_elements * EXTENSION_DEGREE + Self::RATE - 1) / Self::RATE;
         debug_assert!(
             num_elements * EXTENSION_DEGREE <= num_squeezes * Self::RATE,
@@ -127,7 +120,7 @@ pub trait AlgebraicHasher: SpongeHasher {
             num_squeezes * Self::RATE
         );
         (0..num_squeezes)
-            .flat_map(|_| Self::squeeze(state))
+            .flat_map(|_| self.squeeze())
             .collect_vec()
             .chunks(3)
             .take(num_elements)

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -146,7 +146,6 @@ mod algebraic_hasher_tests {
     use rand_distr::Distribution;
     use rand_distr::Standard;
 
-    use crate::prelude::tip5::tip5_tests::seed_tip5;
     use crate::shared_math::digest::DIGEST_LENGTH;
     use crate::shared_math::tip5::Tip5;
     use crate::shared_math::x_field_element::EXTENSION_DEGREE;
@@ -203,8 +202,7 @@ mod algebraic_hasher_tests {
     }
 
     fn sample_indices_prop(max: u32, num_indices: usize) {
-        let mut sponge = Tip5::init();
-        seed_tip5(&mut sponge);
+        let mut sponge = Tip5::randomly_seeded();
         let indices = Tip5::sample_indices(&mut sponge, max, num_indices);
         assert_eq!(num_indices, indices.len());
         assert!(indices.into_iter().all(|index| index < max));
@@ -232,8 +230,7 @@ mod algebraic_hasher_tests {
     #[test]
     fn sample_scalars_test() {
         let amounts = [0, 1, 2, 3, 4];
-        let mut sponge = Tip5::init();
-        seed_tip5(&mut sponge);
+        let mut sponge = Tip5::randomly_seeded();
         let mut product = XFieldElement::one();
         for amount in amounts {
             let scalars = Tip5::sample_scalars(&mut sponge, amount);

--- a/twenty-first/src/util_types/blake3_wrapper.rs
+++ b/twenty-first/src/util_types/blake3_wrapper.rs
@@ -1,64 +1,33 @@
-use arbitrary::Arbitrary;
-use arbitrary::Unstructured;
 use blake3::OUT_LEN;
 use num_traits::Zero;
-use twenty_first::shared_math::b_field_element::BFIELD_ONE;
 
 use crate::shared_math::b_field_element::BFieldElement;
 use crate::shared_math::digest::Digest;
-use crate::util_types::algebraic_hasher::{AlgebraicHasher, SpongeHasher, RATE};
+use crate::util_types::algebraic_hasher::AlgebraicHasher;
+use crate::util_types::algebraic_hasher::Sponge;
+use crate::util_types::algebraic_hasher::RATE;
 
-#[derive(Clone, Debug, Default)]
-pub struct Blake3State {
-    hasher: blake3::Hasher,
-}
-
-impl<'a> Arbitrary<'a> for Blake3State {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let bytes: [u8; 64] = u.arbitrary()?;
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(&bytes);
-        Ok(Self { hasher })
-    }
-}
-
-impl Blake3State {
-    pub fn new() -> Self {
-        let hasher = blake3::Hasher::new();
-        Self { hasher }
-    }
-
-    pub fn update(&mut self, element: BFieldElement) {
-        self.hasher.update(&element.value().to_be_bytes());
-    }
-
-    pub fn finalize(&mut self) -> blake3::Hash {
-        self.hasher.finalize()
-    }
-}
-
-impl SpongeHasher for blake3::Hasher {
+impl Sponge for blake3::Hasher {
     const RATE: usize = RATE;
-    type SpongeState = Blake3State;
 
-    fn init() -> Self::SpongeState {
-        Self::SpongeState::new()
+    fn init() -> Self {
+        blake3::Hasher::new()
     }
 
-    fn absorb(sponge: &mut Self::SpongeState, input: [BFieldElement; RATE]) {
+    fn absorb(&mut self, input: [BFieldElement; RATE]) {
         for elem in input {
-            sponge.update(elem);
+            self.update(&elem.value().to_be_bytes());
         }
     }
 
-    fn squeeze(sponge: &mut Self::SpongeState) -> [BFieldElement; RATE] {
-        let digest_a = from_blake3_digest(&sponge.finalize());
+    fn squeeze(&mut self) -> [BFieldElement; RATE] {
+        let digest_a = from_blake3_digest(&self.finalize());
 
-        // There's at most 256 bits of entropy in a blake3::Hash; we stretch
-        // this to fit RATE elements, even though it does not provide more
-        // security.
-        sponge.update(BFIELD_ONE);
-        let digest_b = from_blake3_digest(&sponge.finalize());
+        // There's at most 256 bits of entropy in a blake3::Hash; we stretch this to fit RATE
+        // elements, even though it does not provide more security.
+        let stretch_bytes = 1u64.to_be_bytes();
+        self.update(&stretch_bytes);
+        let digest_b = from_blake3_digest(&self.finalize());
 
         [digest_a.values(), digest_b.values()]
             .concat()


### PR DESCRIPTION
This is an implementation of the suggestion made [in this comment](https://github.com/Neptune-Crypto/twenty-first/pull/184#issuecomment-1914312403) on #184. Concretely, I propose to use `fn foo(&mut self, …)` in favor of `fn foo(the_thing: &mut TheThing, …)` wherever possible. This allows to write, for example, `self.squeeze()` as opposed to `Self::squeeze(&mut sponge_state)`.

Additionally, I propose to merge the unit struct `Tip5` with the state struct `Tip5State` under the rationale that they are very tightly coupled and we gain no benefit from pulling the two apart.[^blake]

Of note and probably of particular interest to @aszepieniec: I was unable to detect any performance change in `Tip5` across the 3 benchmarks I ran.

Other, minor points:

- rename `SpongeHasher` to `Sponge`
- improve documentation (includes deleting statements that always were or are now obvious from a function's signature)

[^blake]: This also holds for `Blake3` and `Blake3State`. However, I understand this to be legacy code and therefore of lesser interest.