### PR TITLE
simplify field element construction

### DIFF
--- a/twenty-first/src/prelude.rs
+++ b/twenty-first/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use crate::amount::u32s::U32s;
+pub use crate::bfe;
 pub use crate::shared_math::b_field_element;
 pub use crate::shared_math::b_field_element::BFieldElement;
 pub use crate::shared_math::bfield_codec::BFieldCodec;
@@ -19,3 +20,4 @@ pub use crate::util_types::merkle_tree_maker::MerkleTreeMaker;
 pub use crate::util_types::mmr::archival_mmr::ArchivalMmr;
 pub use crate::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
 pub use crate::util_types::mmr::mmr_trait::Mmr;
+pub use crate::xfe;

--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -1297,4 +1297,9 @@ mod b_prime_field_element_test {
         let _ = bfe!(b);
         let _ = bfe!(b.0);
     }
+
+    #[proptest]
+    fn bfe_macro_produces_same_result_as_calling_new(value: u64) {
+        prop_assert_eq!(BFieldElement::new(value), bfe!(value));
+    }
 }

--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -84,6 +84,14 @@ static PRIMITIVE_ROOTS: phf::Map<u64, u64> = phf_map! {
 #[derive(Debug, Copy, Clone, Default, Hash, PartialEq, Eq)]
 pub struct BFieldElement(u64);
 
+/// Simplifies constructing [base field element][BFieldElement]s.
+#[macro_export]
+macro_rules! bfe {
+    ($value:expr) => {
+        BFieldElement::from($value)
+    };
+}
+
 impl GetSize for BFieldElement {
     fn get_stack_size() -> usize {
         std::mem::size_of::<Self>()
@@ -1279,5 +1287,14 @@ mod b_prime_field_element_test {
             v if v >= 0 => prop_assert_eq!(u64::try_from(v).unwrap(), bfe.value()),
             v => prop_assert_eq!(u64::try_from(-v).unwrap(), BFieldElement::P - bfe.value()),
         }
+    }
+
+    #[test]
+    fn bfe_macro_can_be_used() {
+        let b = bfe!(42);
+        let _ = bfe!(42u32);
+        let _ = bfe!(-1);
+        let _ = bfe!(b);
+        let _ = bfe!(b.0);
     }
 }

--- a/twenty-first/src/shared_math/b_field_element.rs
+++ b/twenty-first/src/shared_math/b_field_element.rs
@@ -131,7 +131,7 @@ impl Sum for BFieldElement {
 impl BFieldElement {
     pub const BYTES: usize = 8;
 
-    // 2^64 - 2^32 + 1
+    /// The base field's prime, _i.e._, 2^64 - 2^32 + 1.
     pub const P: u64 = 0xffff_ffff_0000_0001u64;
     pub const MAX: u64 = Self::P - 1;
 
@@ -323,6 +323,18 @@ impl FromStr for BFieldElement {
     }
 }
 
+impl From<u8> for BFieldElement {
+    fn from(value: u8) -> Self {
+        Self::new(value.into())
+    }
+}
+
+impl From<u16> for BFieldElement {
+    fn from(value: u16) -> Self {
+        Self::new(value.into())
+    }
+}
+
 impl From<u32> for BFieldElement {
     fn from(value: u32) -> Self {
         Self::new(value.into())
@@ -332,6 +344,15 @@ impl From<u32> for BFieldElement {
 impl From<u64> for BFieldElement {
     fn from(value: u64) -> Self {
         Self::new(value)
+    }
+}
+
+impl From<i32> for BFieldElement {
+    fn from(value: i32) -> Self {
+        match value {
+            v if v >= 0 => Self::new(v as u64),
+            v => -Self::new(-v as u64),
+        }
     }
 }
 
@@ -1248,6 +1269,15 @@ mod b_prime_field_element_test {
             let c = a * b;
             let expected = BFieldElement::new(18446744068340842497);
             assert_eq!(c, expected);
+        }
+    }
+
+    #[proptest]
+    fn conversion_from_i32_to_bfe_is_correct(value: i32) {
+        let bfe = BFieldElement::from(value);
+        match value {
+            v if v >= 0 => prop_assert_eq!(u64::try_from(v).unwrap(), bfe.value()),
+            v => prop_assert_eq!(u64::try_from(-v).unwrap(), BFieldElement::P - bfe.value()),
         }
     }
 }

--- a/twenty-first/src/shared_math/x_field_element.rs
+++ b/twenty-first/src/shared_math/x_field_element.rs
@@ -585,6 +585,7 @@ mod x_field_element_test {
     use proptest_arbitrary_interop::arb;
     use rand::random;
     use rand::thread_rng;
+    use test_strategy::proptest;
 
     use crate::bfe;
     use crate::shared_math::b_field_element::*;
@@ -1297,5 +1298,23 @@ mod x_field_element_test {
         let _ = xfe!([x.coefficients[0], x.coefficients[1], x.coefficients[2]]);
         let _ = xfe!(bfe!(42));
         let _ = xfe!([bfe!(42), bfe!(43), bfe!(44)]);
+    }
+
+    #[proptest]
+    fn xfe_macro_produces_same_result_as_calling_new(coeffs: [BFieldElement; EXTENSION_DEGREE]) {
+        let xfe = XFieldElement::new(coeffs);
+        prop_assert_eq!(xfe, xfe!(coeffs));
+    }
+
+    #[proptest]
+    fn xfe_macro_produces_same_result_as_calling_new_u64(coeffs: [u64; EXTENSION_DEGREE]) {
+        let xfe = XFieldElement::new_u64(coeffs);
+        prop_assert_eq!(xfe, xfe!(coeffs));
+    }
+
+    #[proptest]
+    fn xfe_macro_produces_same_result_as_calling_new_const(scalar: BFieldElement) {
+        let xfe = XFieldElement::new_const(scalar);
+        prop_assert_eq!(xfe, xfe!(scalar));
     }
 }

--- a/twenty-first/src/shared_math/x_field_element.rs
+++ b/twenty-first/src/shared_math/x_field_element.rs
@@ -44,6 +44,14 @@ pub struct XFieldElement {
     pub coefficients: [BFieldElement; EXTENSION_DEGREE],
 }
 
+/// Simplifies constructing [extension field element][XFieldElement]s.
+#[macro_export]
+macro_rules! xfe {
+    ($value:expr) => {
+        XFieldElement::from($value)
+    };
+}
+
 impl From<XFieldElement> for Digest {
     /// Interpret the `XFieldElement` as a [`Digest`]. No hashing is performed. This
     /// interpretation can be useful for the
@@ -578,6 +586,7 @@ mod x_field_element_test {
     use rand::random;
     use rand::thread_rng;
 
+    use crate::bfe;
     use crate::shared_math::b_field_element::*;
     use crate::shared_math::ntt::intt;
     use crate::shared_math::ntt::ntt;
@@ -1277,5 +1286,16 @@ mod x_field_element_test {
             Ok(_) => panic!("Should not be able to convert a random digest to an XFieldElement."),
             Err(_) => println!("Conversion of random digest to XFieldElement failed as expected."),
         }
+    }
+
+    #[test]
+    fn xfe_macro_can_be_used() {
+        let x = xfe!(42);
+        let _ = xfe!(42u32);
+        let _ = xfe!(-1);
+        let _ = xfe!(x);
+        let _ = xfe!([x.coefficients[0], x.coefficients[1], x.coefficients[2]]);
+        let _ = xfe!(bfe!(42));
+        let _ = xfe!([bfe!(42), bfe!(43), bfe!(44)]);
     }
 }

--- a/twenty-first/src/shared_math/x_field_element.rs
+++ b/twenty-first/src/shared_math/x_field_element.rs
@@ -76,15 +76,21 @@ impl Sum for XFieldElement {
     }
 }
 
-impl From<u32> for XFieldElement {
-    fn from(value: u32) -> Self {
-        XFieldElement::new_const(value.into())
+impl<T> From<T> for XFieldElement
+where
+    T: Into<BFieldElement>,
+{
+    fn from(value: T) -> Self {
+        Self::new_const(value.into())
     }
 }
 
-impl From<BFieldElement> for XFieldElement {
-    fn from(bfe: BFieldElement) -> Self {
-        bfe.lift()
+impl<T> From<[T; EXTENSION_DEGREE]> for XFieldElement
+where
+    T: Into<BFieldElement>,
+{
+    fn from(value: [T; EXTENSION_DEGREE]) -> Self {
+        Self::new(value.map(Into::into))
     }
 }
 
@@ -127,7 +133,8 @@ impl TryFrom<Vec<BFieldElement>> for XFieldElement {
     type Error = TryFromXFieldElementError;
 
     fn try_from(value: Vec<BFieldElement>) -> Result<Self, Self::Error> {
-        XFieldElement::try_from(value.as_ref())
+        let value_ref: &[BFieldElement] = &value;
+        XFieldElement::try_from(value_ref)
     }
 }
 


### PR DESCRIPTION
The main addition are the `bfe!` and `xfe!` macros.  They simplify construction of `BFieldElements` and `XFieldElements`, respectively.

Additionally,
- `BFieldElement::from` can now deal with `u8`, `u16`, and `i32`.
- `XFieldElement::from` can now deal with `T` and `[T; EXTENSION_DEGREE]` where `T` is any type that can be converted into a `BFieldElement`.