### PR TITLE
replace `ModPowU32` etc with `Pow<T>`

### DIFF
--- a/twenty-first/src/prelude.rs
+++ b/twenty-first/src/prelude.rs
@@ -8,7 +8,6 @@ pub use crate::shared_math::tip5;
 pub use crate::shared_math::tip5::Digest;
 pub use crate::shared_math::tip5::Tip5;
 pub use crate::shared_math::traits::Inverse;
-pub use crate::shared_math::traits::ModPowU32;
 pub use crate::shared_math::x_field_element;
 pub use crate::shared_math::x_field_element::XFieldElement;
 pub use crate::util_types::algebraic_hasher::AlgebraicHasher;

--- a/twenty-first/src/shared_math/mpolynomial.rs
+++ b/twenty-first/src/shared_math/mpolynomial.rs
@@ -587,9 +587,7 @@ impl<FF: FiniteField> MPolynomial<FF> {
                 if k[i] == 0 {
                     continue;
                 }
-                // FIXME: We really don't want to cast to 'u32' here, but
-                // refactoring k: Vec<u32> is a bit of a task, too. See issue ...
-                prod *= point[i].mod_pow_u32(k[i] as u32);
+                prod *= point[i].pow(k[i]);
             }
             prod *= *v;
             acc += prod;

--- a/twenty-first/src/shared_math/polynomial.rs
+++ b/twenty-first/src/shared_math/polynomial.rs
@@ -1,6 +1,6 @@
 use crate::shared_math::ntt::{intt, ntt};
 use crate::shared_math::other::{log_2_floor, roundup_npo2};
-use crate::shared_math::traits::{FiniteField, ModPowU32};
+use crate::shared_math::traits::FiniteField;
 use crate::utils::has_unique_elements;
 use arbitrary::Arbitrary;
 use itertools::EitherOrBoth::{Both, Left, Right};
@@ -268,11 +268,15 @@ where
         root_order: usize,
     ) -> Self {
         assert!(
-            primitive_root.mod_pow_u32(root_order as u32).is_one(),
+            primitive_root
+                .mod_pow(root_order.try_into().unwrap())
+                .is_one(),
             "provided primitive root must have the provided power."
         );
         assert!(
-            !primitive_root.mod_pow_u32(root_order as u32 / 2).is_one(),
+            !primitive_root
+                .mod_pow((root_order / 2).try_into().unwrap())
+                .is_one(),
             "provided primitive root must be primitive in the right power."
         );
 
@@ -407,7 +411,7 @@ where
             "Domain and values lengths must match"
         );
         debug_assert_eq!(
-            primitive_root.mod_pow_u32(root_order as u32),
+            primitive_root.mod_pow(root_order.try_into().unwrap()),
             BFieldElement::one(),
             "Supplied element “primitive_root” must have supplied order.\
             Supplied element was: {primitive_root:?}\
@@ -474,7 +478,7 @@ where
         root_order: usize,
     ) -> Vec<Self> {
         debug_assert_eq!(
-            primitive_root.mod_pow_u32(root_order as u32),
+            primitive_root.mod_pow(root_order.try_into().unwrap()),
             BFieldElement::one(),
             "Supplied element “primitive_root” must have supplied order.\
             Supplied element was: {primitive_root:?}\

--- a/twenty-first/src/shared_math/traits.rs
+++ b/twenty-first/src/shared_math/traits.rs
@@ -1,9 +1,20 @@
-use num_traits::{One, Zero};
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::ops::Add;
+use std::ops::AddAssign;
+use std::ops::Div;
+use std::ops::Mul;
+use std::ops::MulAssign;
+use std::ops::Neg;
+use std::ops::Sub;
+use std::ops::SubAssign;
+
+use num_traits::One;
+use num_traits::Pow;
+use num_traits::Zero;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::fmt::{Debug, Display};
-use std::hash::Hash;
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 pub trait CyclicGroupGenerator
 where
@@ -33,16 +44,6 @@ where
     Self: Sized,
 {
     fn primitive_root_of_unity(n: u64) -> Option<Self>;
-}
-
-pub trait ModPowU64 {
-    #[must_use]
-    fn mod_pow_u64(&self, pow: u64) -> Self;
-}
-
-pub trait ModPowU32 {
-    #[must_use]
-    fn mod_pow_u32(&self, exp: u32) -> Self;
 }
 
 // We **cannot** use the std library From/Into traits as they cannot
@@ -79,7 +80,8 @@ pub trait FiniteField:
     + FromVecu8
     + New
     + CyclicGroupGenerator
-    + ModPowU32
+    + Pow<u8, Output = Self>
+    + Pow<u32, Output = Self>
     + PrimitiveRootOfUnity
     + Send
     + Sync


### PR DESCRIPTION
I prefer one generic `Pow<T>` trait over two non-generic `ModPowU32` and `ModPowU64` traits. This PR implements this preference using `num_traits::Pow`.