### PR TITLE
Thv/fix scale 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,12 @@ bench-no-run:
 	$(info RUSTFLAGS is $(RUSTFLAGS))
 	cargo bench --no-run
 
+bench-publish:
+	cargo criterion --bench merkle_tree
+	cargo criterion --bench ntt_forward
+	cargo criterion --bench polynomial_coset
+	cargo criterion --bench polynomial_scale
+
 all: lint format build test bench-no-run
 
 help:

--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ While twenty-first's version is `0.x.y`, releasing a new version:
 
 1. Is the release backwards-compatible?
    Then the new version is `0.x.y+1`. Otherwise the new version is `0.x+1.0`.
-2. Create a commit that increases `version = "0.x.y"` in twenty-first/Cargo.toml.
-   The commit message should give a one-line summary of each release change.
-3. Have a `v0.x.y` [git tag][tag] on this commit created. (`git tag v0.x.y [sha]`, `git push upstream --tags`)
-4. Have this commit `cargo publish`ed on [crates.io][crates] and in GitHub [tags][tags].
+2. Checkout the last commit on Mjolnir, and run `make bench-publish`. Save the benchmark's result
+   and verify that there is no performance degredation.
+3. Create a commit that increases `version = "0.x.y"` in twenty-first/Cargo.toml.
+   The commit message should give a one-line summary of each release change. Include the benchmark
+   result at the bottom.
+4. Have a `v0.x.y` [git tag][tag] on this commit created. (`git tag v0.x.y [sha]`, `git push upstream --tags`)
+5. Have this commit `cargo publish`ed on [crates.io][crates] and in GitHub [tags][tags].
 
 [tag]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
 [tags]: https://github.com/Neptune-Crypto/twenty-first/tags

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -81,9 +81,13 @@ name = "merkle_tree_auth_structure_size"
 harness = false
 
 [[bench]]
-name = "zerofier"
+name = "polynomial_scale"
 harness = false
 
 [[bench]]
 name = "various_muls"
+harness = false
+
+[[bench]]
+name = "zerofier"
 harness = false

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -81,6 +81,10 @@ name = "merkle_tree_auth_structure_size"
 harness = false
 
 [[bench]]
+name = "polynomial_coset"
+harness = false
+
+[[bench]]
 name = "polynomial_scale"
 harness = false
 

--- a/twenty-first/benches/polynomial_coset.rs
+++ b/twenty-first/benches/polynomial_coset.rs
@@ -1,0 +1,133 @@
+use std::hint::black_box;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::measurement::WallTime;
+use criterion::BenchmarkGroup;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use twenty_first::math::b_field_element::BFieldElement;
+use twenty_first::math::other::random_elements;
+use twenty_first::math::polynomial::Polynomial;
+use twenty_first::math::traits::PrimitiveRootOfUnity;
+use twenty_first::math::x_field_element::XFieldElement;
+
+fn coset_functions(c: &mut Criterion) {
+    let mut group = c.benchmark_group("polynomial coset");
+
+    let sizes = [1 << 10, 1 << 17];
+
+    for size in sizes {
+        coset_evaluation_bfe_pol(
+            &mut group,
+            BenchmarkId::new("coset-evaluate bfe-pol", size),
+            size,
+        );
+    }
+
+    for size in sizes {
+        coset_evaluation_xfe_pol(
+            &mut group,
+            BenchmarkId::new("coset-evaluate xfe-pol", size),
+            size,
+        );
+    }
+
+    for size in sizes {
+        coset_interpolation_bfes(
+            &mut group,
+            BenchmarkId::new("coset-interpolate bfe-pol", size),
+            size,
+        );
+    }
+
+    for size in sizes {
+        coset_interpolation_xfes(
+            &mut group,
+            BenchmarkId::new("coset-interpolate xfe-pol", size),
+            size,
+        );
+    }
+
+    group.finish();
+}
+
+fn coset_evaluation_bfe_pol(
+    group: &mut BenchmarkGroup<WallTime>,
+    bench_id: BenchmarkId,
+    size: usize,
+) {
+    let bfe_pol: Polynomial<BFieldElement> = Polynomial::new(random_elements(size));
+    let offset = BFieldElement::generator();
+    let generator = BFieldElement::primitive_root_of_unity(size as u64).unwrap();
+
+    group.throughput(Throughput::Elements(size as u64));
+    group.bench_with_input(bench_id, &size, |b, _| {
+        b.iter(|| {
+            let _ = black_box(bfe_pol.fast_coset_evaluate(offset, generator, size));
+        })
+    });
+    group.sample_size(10);
+}
+
+fn coset_evaluation_xfe_pol(
+    group: &mut BenchmarkGroup<WallTime>,
+    bench_id: BenchmarkId,
+    size: usize,
+) {
+    let xfe_pol: Polynomial<XFieldElement> = Polynomial::new(random_elements(size));
+    let offset = BFieldElement::generator();
+    let generator = BFieldElement::primitive_root_of_unity(size as u64).unwrap();
+
+    group.throughput(Throughput::Elements(size as u64));
+    group.bench_with_input(bench_id, &size, |b, _| {
+        b.iter(|| {
+            let _ = black_box(xfe_pol.fast_coset_evaluate(offset, generator, size));
+        })
+    });
+    group.sample_size(10);
+}
+
+fn coset_interpolation_bfes(
+    group: &mut BenchmarkGroup<WallTime>,
+    bench_id: BenchmarkId,
+    size: usize,
+) {
+    let offset = BFieldElement::generator();
+    let generator = BFieldElement::primitive_root_of_unity(size as u64).unwrap();
+    let values: Vec<BFieldElement> = random_elements(size);
+
+    group.throughput(Throughput::Elements(size as u64));
+    group.bench_with_input(bench_id, &size, |b, _| {
+        b.iter(|| {
+            let _ = black_box(Polynomial::fast_coset_interpolate(
+                offset, generator, &values,
+            ));
+        })
+    });
+    group.sample_size(10);
+}
+
+fn coset_interpolation_xfes(
+    group: &mut BenchmarkGroup<WallTime>,
+    bench_id: BenchmarkId,
+    size: usize,
+) {
+    let offset = BFieldElement::generator();
+    let generator = BFieldElement::primitive_root_of_unity(size as u64).unwrap();
+    let values: Vec<XFieldElement> = random_elements(size);
+
+    group.throughput(Throughput::Elements(size as u64));
+    group.bench_with_input(bench_id, &size, |b, _| {
+        b.iter(|| {
+            let _ = black_box(Polynomial::fast_coset_interpolate(
+                offset, generator, &values,
+            ));
+        })
+    });
+    group.sample_size(10);
+}
+
+criterion_group!(benches, coset_functions);
+criterion_main!(benches);

--- a/twenty-first/benches/polynomial_scale.rs
+++ b/twenty-first/benches/polynomial_scale.rs
@@ -1,0 +1,106 @@
+use std::hint::black_box;
+
+use criterion::measurement::WallTime;
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use rand::random;
+use twenty_first::math::b_field_element::BFieldElement;
+use twenty_first::math::other::random_elements;
+use twenty_first::math::polynomial::Polynomial;
+use twenty_first::math::x_field_element::XFieldElement;
+
+fn various_scales(c: &mut Criterion) {
+    let mut group = c.benchmark_group("polynomial scale");
+
+    let sizes = [1 << 10, 1 << 17];
+
+    for size in sizes {
+        bfes_w_bfe(
+            &mut group,
+            BenchmarkId::new("scale bfe-pol with bfe", size),
+            size,
+        );
+    }
+
+    for size in sizes {
+        bfes_w_xfe(
+            &mut group,
+            BenchmarkId::new("scale bfe-pol with xfe", size),
+            size,
+        );
+    }
+
+    for size in sizes {
+        xfes_w_bfe(
+            &mut group,
+            BenchmarkId::new("scale xfe-pol with bfe", size),
+            size,
+        );
+    }
+
+    for size in sizes {
+        xfes_w_xfe(
+            &mut group,
+            BenchmarkId::new("scale xfe-pol with xfe", size),
+            size,
+        );
+    }
+
+    group.finish();
+}
+
+fn bfes_w_bfe(group: &mut BenchmarkGroup<WallTime>, bench_id: BenchmarkId, size: usize) {
+    let bfe_pol: Polynomial<BFieldElement> = Polynomial::new(random_elements(size));
+    let bfe: BFieldElement = random();
+
+    group.throughput(Throughput::Elements(size as u64));
+    group.bench_with_input(bench_id, &size, |b, _| {
+        b.iter(|| {
+            let _ = black_box(bfe_pol.bfe_scale(bfe));
+        })
+    });
+    group.sample_size(10);
+}
+
+fn bfes_w_xfe(group: &mut BenchmarkGroup<WallTime>, bench_id: BenchmarkId, size: usize) {
+    let bfe_pol: Polynomial<BFieldElement> = Polynomial::new(random_elements(size));
+    let xfe: XFieldElement = random();
+
+    group.throughput(Throughput::Elements(size as u64));
+    group.bench_with_input(bench_id, &size, |b, _| {
+        b.iter(|| {
+            let _ = black_box(bfe_pol.xfe_scale(xfe));
+        })
+    });
+    group.sample_size(10);
+}
+
+fn xfes_w_bfe(group: &mut BenchmarkGroup<WallTime>, bench_id: BenchmarkId, size: usize) {
+    let xfe_pol: Polynomial<XFieldElement> = Polynomial::new(random_elements(size));
+    let bfe: BFieldElement = random();
+
+    group.throughput(Throughput::Elements(size as u64));
+    group.bench_with_input(bench_id, &size, |b, _| {
+        b.iter(|| {
+            let _ = black_box(xfe_pol.bfe_scale(bfe));
+        })
+    });
+    group.sample_size(10);
+}
+
+fn xfes_w_xfe(group: &mut BenchmarkGroup<WallTime>, bench_id: BenchmarkId, size: usize) {
+    let xfe_pol: Polynomial<XFieldElement> = Polynomial::new(random_elements(size));
+    let xfe: XFieldElement = random();
+
+    group.throughput(Throughput::Elements(size as u64));
+    group.bench_with_input(bench_id, &size, |b, _| {
+        b.iter(|| {
+            let _ = black_box(xfe_pol.xfe_scale(xfe));
+        })
+    });
+    group.sample_size(10);
+}
+
+criterion_group!(benches, various_scales);
+criterion_main!(benches);

--- a/twenty-first/src/math/polynomial.rs
+++ b/twenty-first/src/math/polynomial.rs
@@ -133,11 +133,11 @@ where
     /// evaluating P(alpha * x).
     #[must_use]
     pub fn scale(&self, alpha: BFieldElement) -> Self {
-        let mut acc = FF::one();
+        let mut powers_of_alpha = BFieldElement::one();
         let mut return_coefficients = self.coefficients.clone();
         for elem in return_coefficients.iter_mut() {
-            *elem *= acc;
-            acc *= alpha;
+            *elem *= powers_of_alpha;
+            powers_of_alpha *= alpha;
         }
 
         Self::new(return_coefficients)


### PR DESCRIPTION
Fix performance degredation of `scale` and add benchmarks to run when a new version is published. 

Breaking change, as the `scale` method is renamed.