### PR TITLE
fix: Digest::try_from() returns NotCanonical error

### DIFF
--- a/twenty-first/src/error.rs
+++ b/twenty-first/src/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 pub use crate::math::bfield_codec::BFieldCodecError;
 use crate::prelude::tip5::DIGEST_LENGTH;
 use crate::prelude::x_field_element::EXTENSION_DEGREE;
+use crate::prelude::BFieldElement;
 pub use crate::util_types::merkle_tree::MerkleTreeError;
 
 #[derive(Debug, Clone, Eq, PartialEq, Error)]
@@ -39,7 +40,7 @@ pub enum TryFromDigestError {
     #[error("invalid `BFieldElement`")]
     InvalidBFieldElement(#[from] ParseBFieldElementError),
 
-    #[error("Not Canonical. ({0})")]
+    #[error("non-canonical {0} >= {} == `BFieldElement::P`", BFieldElement::P)]
     NotCanonical(u64),
 
     #[error("overflow converting to Digest")]

--- a/twenty-first/src/error.rs
+++ b/twenty-first/src/error.rs
@@ -39,13 +39,16 @@ pub enum TryFromDigestError {
     #[error("invalid `BFieldElement`")]
     InvalidBFieldElement(#[from] ParseBFieldElementError),
 
+    #[error("Not Canonical. ({0})")]
+    NotCanonical(u64),
+
     #[error("overflow converting to Digest")]
     Overflow,
 }
 
 #[derive(Debug, Clone, PartialEq, Error)]
 #[non_exhaustive]
-pub enum FromHexDigestError {
+pub enum TryFromHexDigestError {
     #[error("hex decoding error")]
     HexDecode(#[from] hex::FromHexError),
 

--- a/twenty-first/src/math/b_field_element.rs
+++ b/twenty-first/src/math/b_field_element.rs
@@ -366,6 +366,11 @@ impl BFieldElement {
     pub fn raw_u64(&self) -> u64 {
         self.0
     }
+
+    #[inline]
+    pub const fn is_canonical(x: u64) -> bool {
+        x < Self::P
+    }
 }
 
 impl fmt::Display for BFieldElement {


### PR DESCRIPTION
Addresses #195.

Any attempt to instantiate a Digest from bytes or a string with embedded non-canonical u64 values now results in an error.

Note that it is still possible to instantiate a Digest from BFieldElements that were created from non-canonical u64. Maybe that's ok...?

Changes:
 * adds TryFromDigestError::NotCanonical
 * adds BFieldElement::is_canonical()
 * Digest::from_str() returns NotCanonical error
 * Digest::try_from(bytes) returns NotCanonical error
 * adds Digest test try_from_bytes_not_canonical()
 * adds Digest test from_str_not_canonical()
 * adds Canonical test in digest_from_invalid_hex_errors()

--------

Commentary:

I am not entirely happy with this solution/pr for two reasons:

1. it only partially addresses the issue. It remains possible to bypass the canonical checks by instantiating Digest from BFieldElements directly.  That feels wrong to me (leaky abstraction), but maybe it's actually Ok.   opinions welcome.
2. It seems cleaner to perform the canonical check(s) inside BFieldElement rather than Digest methods.

regarding (2) I initially started with this approach, and impl'd TryFrom bytes for BFieldElement.   This required getting rid of `impl From bytes for BFieldElement`.  That was fine as it doesn't seem to be used.  However, the `TryFrom bytes` is only a partial solution as BFieldElement still has a bunch of `impl From` for u64, u128, i32 etc as well as `impl FromStr`.   I felt I was likely to cause downstream breakage changing all these to `TryFrom` and also it was becoming a bigger project than anticipated, so I backed off.   I still feel that is the most correct fix if we really want to enforce the canonical check.   I pushed an [alternative branch](https://github.com/dan-da/twenty-first/tree/195_bfe_not_canonical_pr_alt) with this approach.

However, for basic bytes/string serialization, the present PR suffices, is smaller, and I verified that downstream neptune crates have no build errors.  I believe this is also closer to what was discussed/proposed in #125.

Another consideration is that its possible we might be instantiating Digest(s) from non-canonical BFieldElement inputs somewhere in the neptune stack.  So adding a check inside BFieldElement would have potential to break some logic (not just syntax).  I'm unsure how likely this is or not.

At this point we could merge this PR as-is, or pursue the other branch/approach.  I don't have a strong preference and am open to suggestions/feedback.

a final note:  Digest also has a TryFrom BigUint.  I looked at it, but it wasn't immediately clear to me if a canonical check is needed or exactly how to do it, so I didn't touch it.  That might be another leak.