### PR TITLE
feat: Implement `BFieldCodec` for `Polynomial`

### DIFF
--- a/twenty-first/src/math/bfield_codec.rs
+++ b/twenty-first/src/math/bfield_codec.rs
@@ -380,20 +380,15 @@ pub enum PolynomialBFieldCodecError {
     #[error("trailing zeros in polynomial-encoding")]
     TrailingZerosInPolynomialEncoding,
 
-    #[error("inner decoding error: {0}")]
-    VectorEncodingError(BFieldCodecError),
+    #[error(transparent)]
+    VectorEncodingError(#[from] BFieldCodecError),
 }
 
 impl<T: BFieldCodec + FiniteField> BFieldCodec for Polynomial<T> {
     type Error = PolynomialBFieldCodecError;
 
     fn decode(sequence: &[BFieldElement]) -> Result<Box<Self>, Self::Error> {
-        let decoded_vec = match Vec::<T>::decode(sequence) {
-            Ok(decoded_vec) => decoded_vec,
-            Err(inner_err) => {
-                return Err(PolynomialBFieldCodecError::VectorEncodingError(inner_err))
-            }
-        };
+        let decoded_vec = Vec::<T>::decode(sequence)?;
 
         let encoding_contains_trailing_zeros = decoded_vec
             .last()


### PR DESCRIPTION
This implementation prevents and disallows trailing zeros in the coefficients list when the polynomial is encoded. This is done to ensure that the encoding of a polynomial is unique, and that proof streams containing polynomials become as simple and short as possible.

Motivated by:
<https://github.com/TritonVM/triton-vm/issues/268>

This closes #200.