### PR TITLE
revisit `BFieldElement`'s to / from native endian bytes

### DIFF
--- a/twenty-first/src/math/b_field_element.rs
+++ b/twenty-first/src/math/b_field_element.rs
@@ -292,11 +292,13 @@ impl BFieldElement {
         acc
     }
 
-    /// Convert a `BFieldElement` from a byte slice in native endianness.
-    pub fn from_ne_bytes(bytes: &[u8]) -> BFieldElement {
-        let mut bytes_copied: [u8; 8] = [0; 8];
-        bytes_copied.copy_from_slice(bytes);
-        BFieldElement::new(u64::from_ne_bytes(bytes_copied))
+    pub fn to_ne_bytes(&self) -> [u8; 8] {
+        self.value().to_ne_bytes()
+    }
+
+    /// Convert a `BFieldElement` from a byte array in native endianness.
+    pub fn from_ne_bytes(bytes: [u8; 8]) -> BFieldElement {
+        BFieldElement::new(u64::from_ne_bytes(bytes))
     }
 
     /// Montgomery reduction
@@ -703,6 +705,12 @@ mod b_prime_field_element_test {
         let serialized = serde_json::to_string(&bfe).unwrap();
         let deserialized: BFieldElement = serde_json::from_str(&serialized).unwrap();
         prop_assert_eq!(bfe, deserialized);
+    }
+
+    #[proptest]
+    fn serialization_and_deserialization_to_and_from_bytes_is_identity(bfe: BFieldElement) {
+        let bfe_again = BFieldElement::from_ne_bytes(bfe.to_ne_bytes());
+        prop_assert_eq!(bfe, bfe_again);
     }
 
     #[proptest]


### PR DESCRIPTION
This PR fixes the following issues with current conversion from “native” endian bytes to base field elements:

- Make the function infallible. Before, if the passed-in slice was of the incorrect length, the function would panic – see [`.copy_from_slice()`](https://doc.rust-lang.org/std/primitive.slice.html#method.copy_from_slice). This behavior was not documented.
- Add a reciprocal method to get a “native” endianess byte array from a base field element.
- Test the behavior.

All that said, I think there are potential footguns regarding cross-platform support lingering here. I would argue we should drop “native” endianness in favor of either little or big endian representation, or maybe drop all of that since we already have `from_raw_bytes()` and `.raw_bytes()`.