### PR TITLE
Fast Reduce

### DIFF
--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -121,3 +121,7 @@ harness = false
 [[bench]]
 name = "zerofier"
 harness = false
+
+[[bench]]
+name = "formal_power_series_inverse"
+harness = false

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -67,6 +67,10 @@ name = "evaluation"
 harness = false
 
 [[bench]]
+name = "poly_mod_reduce"
+harness = false
+
+[[bench]]
 name = "interpolation"
 harness = false
 

--- a/twenty-first/benches/evaluation.rs
+++ b/twenty-first/benches/evaluation.rs
@@ -2,8 +2,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-use criterion::Throughput;
-use rayon::prelude::*;
 
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
@@ -11,23 +9,32 @@ use twenty_first::prelude::*;
 criterion_main!(benches);
 criterion_group!(
     name = benches;
-    config = Criterion::default().sample_size(50);
-    targets = evaluation<{ 1 << 10 }>,
-              evaluation<{ 1 << 14 }>,
-              evaluation<{ 1 << 16 }>,
+    config = Criterion::default().sample_size(10);
+    targets = evaluation<{ 1 << 18 }, { 1 << 6 }>,
+              evaluation<{ 1 << 18 }, { 1 << 7 }>,
+              evaluation<{ 1 << 18 }, { 1 << 8 }>,
+              evaluation<{ 1 << 19 }, { 1 << 6 }>,
+              evaluation<{ 1 << 19 }, { 1 << 7 }>,
+              evaluation<{ 1 << 19 }, { 1 << 8 }>,
+              evaluation<{ 1 << 20 }, { 1 << 6 }>,
+              evaluation<{ 1 << 20 }, { 1 << 7 }>,
 );
 
-fn evaluation<const SIZE: usize>(c: &mut Criterion) {
+fn evaluation<const SIZE: usize, const NUM_POINTS: usize>(c: &mut Criterion) {
     let log2_of_size = SIZE.ilog2();
-    let mut group = c.benchmark_group(format!("Various Evaluations in 2^{log2_of_size} Points"));
-    group.throughput(Throughput::Elements(u64::try_from(SIZE).unwrap()));
+    let mut group = c.benchmark_group(format!(
+        "Evaluation of degree-{} polynomial in {NUM_POINTS} Points",
+        SIZE - 1
+    ));
+    group.sample_size(10);
 
     let poly = Polynomial::new(random_elements(SIZE));
-    let eval_points: Vec<BFieldElement> = random_elements(SIZE);
+    let eval_points: Vec<BFieldElement> = random_elements(NUM_POINTS);
 
-    let id = BenchmarkId::new("Parallel", log2_of_size);
-    let par_eval = || -> Vec<_> { eval_points.par_iter().map(|&p| poly.evaluate(p)).collect() };
-    group.bench_function(id, |b| b.iter(par_eval));
+    let id = BenchmarkId::new("Iterative", log2_of_size);
+    group.bench_function(id, |b| {
+        b.iter(|| poly.iterative_batch_evaluate(&eval_points))
+    });
 
     // `vector_batch_evaluate` exists, but is super slow. Put it here if you plan to run benchmarks
     // during a coffee break.

--- a/twenty-first/benches/evaluation.rs
+++ b/twenty-first/benches/evaluation.rs
@@ -18,6 +18,7 @@ criterion_group!(
               evaluation<{ 1 << 19 }, { 1 << 8 }>,
               evaluation<{ 1 << 20 }, { 1 << 6 }>,
               evaluation<{ 1 << 20 }, { 1 << 7 }>,
+              evaluation<{ 1 << 20 }, { 1 << 8 }>,
 );
 
 fn evaluation<const SIZE: usize, const NUM_POINTS: usize>(c: &mut Criterion) {
@@ -42,7 +43,7 @@ fn evaluation<const SIZE: usize, const NUM_POINTS: usize>(c: &mut Criterion) {
     let id = BenchmarkId::new("Fast", log2_of_size);
     group.bench_function(id, |b| b.iter(|| poly.fast_evaluate(&eval_points)));
 
-    let id = BenchmarkId::new("Faster of the two", log2_of_size);
+    let id = BenchmarkId::new("Dispatcher", log2_of_size);
     group.bench_function(id, |b| b.iter(|| poly.batch_evaluate(&eval_points)));
 
     group.finish();

--- a/twenty-first/benches/evaluation.rs
+++ b/twenty-first/benches/evaluation.rs
@@ -27,7 +27,6 @@ fn evaluation<const SIZE: usize, const NUM_POINTS: usize>(c: &mut Criterion) {
         "Evaluation of degree-{} polynomial in {NUM_POINTS} Points",
         SIZE - 1
     ));
-    group.sample_size(10);
 
     let poly = Polynomial::new(random_elements(SIZE));
     let eval_points: Vec<BFieldElement> = random_elements(NUM_POINTS);

--- a/twenty-first/benches/evaluation.rs
+++ b/twenty-first/benches/evaluation.rs
@@ -40,8 +40,10 @@ fn evaluation<const SIZE: usize, const NUM_POINTS: usize>(c: &mut Criterion) {
     // `vector_batch_evaluate` exists, but is super slow. Put it here if you plan to run benchmarks
     // during a coffee break.
 
-    let id = BenchmarkId::new("Fast", log2_of_size);
-    group.bench_function(id, |b| b.iter(|| poly.fast_evaluate(&eval_points)));
+    let id = BenchmarkId::new("Divide-and-Conquer", log2_of_size);
+    group.bench_function(id, |b| {
+        b.iter(|| poly.divide_and_conquer_batch_evaluate(&eval_points))
+    });
 
     let id = BenchmarkId::new("Dispatcher", log2_of_size);
     group.bench_function(id, |b| b.iter(|| poly.batch_evaluate(&eval_points)));

--- a/twenty-first/benches/formal_power_series_inverse.rs
+++ b/twenty-first/benches/formal_power_series_inverse.rs
@@ -14,7 +14,7 @@ criterion_group!(
 );
 
 fn fpsi(c: &mut Criterion) {
-    let mut group = c.benchmark_group(format!("Formal power series ring inverse"));
+    let mut group = c.benchmark_group("Formal power series ring inverse".to_string());
 
     for log2_degree in 1..11 {
         let degree = (1 << log2_degree) - 1;

--- a/twenty-first/benches/formal_power_series_inverse.rs
+++ b/twenty-first/benches/formal_power_series_inverse.rs
@@ -14,7 +14,7 @@ criterion_group!(
 );
 
 fn fpsi(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Formal power series ring inverse".to_string());
+    let mut group = c.benchmark_group("Formal power series ring inverse");
 
     for log2_degree in 1..11 {
         let degree = (1 << log2_degree) - 1;

--- a/twenty-first/benches/formal_power_series_inverse.rs
+++ b/twenty-first/benches/formal_power_series_inverse.rs
@@ -24,7 +24,7 @@ fn fpsi(c: &mut Criterion) {
 
         let id = BenchmarkId::new("fpsi", format!("2^{log2_degree}"));
         group.bench_function(id, |b| {
-            b.iter(|| polynomial.formal_power_series_inverse(1 << (log2_degree + 1)))
+            b.iter(|| polynomial.formal_power_series_inverse_newton(1 << (log2_degree + 1)))
         });
     }
     group.finish();

--- a/twenty-first/benches/formal_power_series_inverse.rs
+++ b/twenty-first/benches/formal_power_series_inverse.rs
@@ -1,0 +1,31 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+
+use twenty_first::math::other::random_elements;
+use twenty_first::prelude::*;
+
+criterion_main!(benches);
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = fpsi,
+);
+
+fn fpsi(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("Formal power series ring inverse"));
+
+    for log2_degree in 1..11 {
+        let degree = (1 << log2_degree) - 1;
+
+        let coefficients: Vec<BFieldElement> = random_elements(1 + degree);
+        let polynomial = Polynomial::new(coefficients);
+
+        let id = BenchmarkId::new("fpsi", format!("2^{log2_degree}"));
+        group.bench_function(id, |b| {
+            b.iter(|| polynomial.formal_power_series_inverse(1 << (log2_degree + 1)))
+        });
+    }
+    group.finish();
+}

--- a/twenty-first/benches/interpolation.rs
+++ b/twenty-first/benches/interpolation.rs
@@ -31,7 +31,7 @@ fn interpolation<const SIZE: usize>(c: &mut Criterion) {
     let id = BenchmarkId::new("Fast", log2_of_size);
     group.bench_function(id, |b| b.iter(|| Polynomial::fast_interpolate(&xs, &ys)));
 
-    let id = BenchmarkId::new("Faster of the two", log2_of_size);
+    let id = BenchmarkId::new("Dispatcher", log2_of_size);
     group.bench_function(id, |b| b.iter(|| Polynomial::interpolate(&xs, &ys)));
 
     group.finish();

--- a/twenty-first/benches/poly_mod_reduce.rs
+++ b/twenty-first/benches/poly_mod_reduce.rs
@@ -1,0 +1,32 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+
+use twenty_first::math::other::random_elements;
+use twenty_first::prelude::*;
+
+criterion_main!(benches);
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(50);
+    targets = poly_mod_reduce<{ 1 << 14 }, {1<<4}>,
+        poly_mod_reduce<{ 1 << 14 }, {1<<6}>,
+        poly_mod_reduce<{ 1 << 14 }, {1<<8}>,
+);
+
+fn poly_mod_reduce<const SIZE_LHS: usize, const SIZE_RHS: usize>(c: &mut Criterion) {
+    let log2_of_size = SIZE_LHS.ilog2();
+    let mut group = c.benchmark_group(format!(
+        "Modular reduction of degree {} by degree {}",
+        SIZE_LHS - 1,
+        SIZE_RHS - 1
+    ));
+    let lhs = Polynomial::new(random_elements::<BFieldElement>(SIZE_LHS));
+    let rhs = Polynomial::new(random_elements::<BFieldElement>(SIZE_LHS));
+
+    let id = BenchmarkId::new("long division", log2_of_size);
+    group.bench_function(id, |b| b.iter(|| lhs.clone() % rhs.clone()));
+
+    group.finish();
+}

--- a/twenty-first/benches/poly_mod_reduce.rs
+++ b/twenty-first/benches/poly_mod_reduce.rs
@@ -3,7 +3,6 @@ use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 
-use num_traits::Zero;
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 
@@ -25,23 +24,20 @@ fn poly_mod_reduce<const SIZE_LHS: usize, const SIZE_RHS: usize>(c: &mut Criteri
         SIZE_LHS - 1,
         SIZE_RHS - 1
     ));
-    let mut remainder = Polynomial::zero();
-    group.sample_size(10);
     let lhs = Polynomial::new(random_elements::<BFieldElement>(SIZE_LHS));
     let rhs = Polynomial::new(random_elements::<BFieldElement>(SIZE_RHS));
 
     let id = BenchmarkId::new("long division", log2_of_size);
-    group.bench_function(id, |b| b.iter(|| remainder = lhs.clone() % rhs.clone()));
+    group.bench_function(id, |b| b.iter(|| lhs.clone() % rhs.clone()));
 
+    // despite its name, `.fast_divide()` is slow – ignore for big inputs
     if SIZE_LHS < 1 << 13 && SIZE_RHS < 1 << 13 {
         let id = BenchmarkId::new("fast division", log2_of_size);
-        group.bench_function(id, |b| {
-            b.iter(|| remainder = lhs.clone().fast_divide(&rhs).1)
-        });
+        group.bench_function(id, |b| b.iter(|| lhs.fast_divide(&rhs)));
     }
 
     let id = BenchmarkId::new("fast reduce", log2_of_size);
-    group.bench_function(id, |b| b.iter(|| remainder = lhs.clone().fast_reduce(&rhs)));
+    group.bench_function(id, |b| b.iter(|| lhs.fast_reduce(&rhs)));
 
     group.finish();
 }

--- a/twenty-first/benches/poly_mod_reduce.rs
+++ b/twenty-first/benches/poly_mod_reduce.rs
@@ -40,20 +40,8 @@ fn poly_mod_reduce<const SIZE_LHS: usize, const SIZE_RHS: usize>(c: &mut Criteri
         });
     }
 
-    let id = BenchmarkId::new("preprocessing step", SIZE_RHS.ilog2());
-    let mut preprocessed_modulus = rhs.preprocess_as_modulus();
-    group.bench_function(id, |b| {
-        b.iter(|| preprocessed_modulus = rhs.preprocess_as_modulus())
-    });
-
-    let id = BenchmarkId::new("preprocessed reduce", log2_of_size);
-    group.bench_function(id, |b| {
-        b.iter(|| {
-            remainder = lhs
-                .clone()
-                .reduce_by_preprocessed_modulus(&preprocessed_modulus)
-        })
-    });
+    let id = BenchmarkId::new("fast reduce", log2_of_size);
+    group.bench_function(id, |b| b.iter(|| remainder = lhs.clone().fast_reduce(&rhs)));
 
     group.finish();
 }

--- a/twenty-first/benches/poly_mod_reduce.rs
+++ b/twenty-first/benches/poly_mod_reduce.rs
@@ -10,9 +10,9 @@ criterion_main!(benches);
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(50);
-    targets = poly_mod_reduce<{ 1 << 14 }, {1<<4}>,
-        poly_mod_reduce<{ 1 << 14 }, {1<<6}>,
-        poly_mod_reduce<{ 1 << 14 }, {1<<8}>,
+    targets = poly_mod_reduce<{ 1 << 20 }, {1<<4}>,
+        poly_mod_reduce<{ 1 << 20 }, {1<<6}>,
+        poly_mod_reduce<{ 1 << 20 }, {1<<8}>,
 );
 
 fn poly_mod_reduce<const SIZE_LHS: usize, const SIZE_RHS: usize>(c: &mut Criterion) {

--- a/twenty-first/benches/poly_mod_reduce.rs
+++ b/twenty-first/benches/poly_mod_reduce.rs
@@ -28,5 +28,8 @@ fn poly_mod_reduce<const SIZE_LHS: usize, const SIZE_RHS: usize>(c: &mut Criteri
     let id = BenchmarkId::new("long division", log2_of_size);
     group.bench_function(id, |b| b.iter(|| lhs.clone() % rhs.clone()));
 
+    let id = BenchmarkId::new("fast division", log2_of_size);
+    group.bench_function(id, |b| b.iter(|| lhs.clone().fast_divide(&rhs).1));
+
     group.finish();
 }

--- a/twenty-first/benches/poly_mod_reduce.rs
+++ b/twenty-first/benches/poly_mod_reduce.rs
@@ -3,6 +3,7 @@ use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 
+use num_traits::Zero;
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 
@@ -10,9 +11,11 @@ criterion_main!(benches);
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(50);
-    targets = poly_mod_reduce<{ 1 << 15 }, {1<<4}>,
-              poly_mod_reduce<{ 1 << 15 }, {1<<6}>,
-              poly_mod_reduce<{ 1 << 15 }, {1<<8}>,
+    targets = poly_mod_reduce<{ 1 << 20 }, {1<<4}>,
+              poly_mod_reduce<{ 1 << 20 }, {1<<5}>,
+              poly_mod_reduce<{ 1 << 20 }, {1<<6}>,
+              poly_mod_reduce<{ 1 << 20 }, {1<<7}>,
+              poly_mod_reduce<{ 1 << 20 }, {1<<8}>,
 );
 
 fn poly_mod_reduce<const SIZE_LHS: usize, const SIZE_RHS: usize>(c: &mut Criterion) {
@@ -22,27 +25,33 @@ fn poly_mod_reduce<const SIZE_LHS: usize, const SIZE_RHS: usize>(c: &mut Criteri
         SIZE_LHS - 1,
         SIZE_RHS - 1
     ));
+    let mut remainder = Polynomial::zero();
     group.sample_size(10);
     let lhs = Polynomial::new(random_elements::<BFieldElement>(SIZE_LHS));
     let rhs = Polynomial::new(random_elements::<BFieldElement>(SIZE_RHS));
 
     let id = BenchmarkId::new("long division", log2_of_size);
-    group.bench_function(id, |b| b.iter(|| lhs.clone() % rhs.clone()));
+    group.bench_function(id, |b| b.iter(|| remainder = lhs.clone() % rhs.clone()));
 
     if SIZE_LHS < 1 << 13 && SIZE_RHS < 1 << 13 {
         let id = BenchmarkId::new("fast division", log2_of_size);
-        group.bench_function(id, |b| b.iter(|| lhs.clone().fast_divide(&rhs).1));
+        group.bench_function(id, |b| {
+            b.iter(|| remainder = lhs.clone().fast_divide(&rhs).1)
+        });
     }
 
     let id = BenchmarkId::new("preprocessing step", SIZE_RHS.ilog2());
-    group.bench_function(id, |b| b.iter(|| rhs.structured_multiple()));
-    let structured_multiple = rhs.structured_multiple();
+    let mut preprocessed_modulus = rhs.preprocess_as_modulus();
+    group.bench_function(id, |b| {
+        b.iter(|| preprocessed_modulus = rhs.preprocess_as_modulus())
+    });
 
     let id = BenchmarkId::new("preprocessed reduce", log2_of_size);
     group.bench_function(id, |b| {
         b.iter(|| {
-            lhs.clone()
-                .reduce_with_structured_multiple(&rhs, &structured_multiple)
+            remainder = lhs
+                .clone()
+                .reduce_by_preprocessed_modulus(&preprocessed_modulus)
         })
     });
 

--- a/twenty-first/src/math/ntt.rs
+++ b/twenty-first/src/math/ntt.rs
@@ -55,7 +55,7 @@ pub fn ntt<FF: FiniteField + MulAssign<BFieldElement>>(
     // `n` must be a power of 2, or be zero
     debug_assert!(
         n == 1 << log_2_of_n || n == 0 && log_2_of_n == 0,
-        "2^log2(n) == n || n == 0 && log_2_of_n == 0 must evaluate to true"
+        "2^log2(n) == n || n == 0 && log_2_of_n == 0 must evaluate to true, but n was {n} and log_2_of_n was {log_2_of_n}"
     );
 
     // `omega` must be a primitive root of unity of order `n`

--- a/twenty-first/src/math/polynomial.rs
+++ b/twenty-first/src/math/polynomial.rs
@@ -822,11 +822,8 @@ where
         let mut f_ntt = vec![divisor_lc_inv; last_domain_length];
 
         let rev_divisor = reverse(divisor);
-        let mut rev_divisor_ntt = [
-            rev_divisor.coefficients.clone(),
-            vec![FF::from(0); last_domain_length - rev_divisor.coefficients.len()],
-        ]
-        .concat();
+        let mut rev_divisor_ntt = rev_divisor.coefficients.clone();
+        rev_divisor_ntt.resize(last_domain_length, FF::from(0));
         ntt(&mut rev_divisor_ntt, last_omega, log_last_domain_length);
 
         for _ in 0..num_rounds {

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -626,7 +626,7 @@ mod accumulator_mmr_tests {
             let new_leafs: Vec<Digest> = random_elements(mutated_leaf_count);
             let mut terminal_leafs: Vec<Digest> = initial_leaf_digests;
             for (i, new_leaf) in mutated_leaf_indices.iter().zip(new_leafs.iter()) {
-                terminal_leafs[*i as usize] = new_leaf.to_owned();
+                new_leaf.clone_into(&mut terminal_leafs[*i as usize]);
             }
 
             // Calculate the leafs digests associated with the membership proofs, as they look


### PR DESCRIPTION
This PR
 - Use clever math to accelerate modular reduction of one polynomial by another, especially when the modulus has much lower degree.
 - Test the introduced methods.
 - Integrate the fast modular reduction into the batch evaluation dispatcher pipeline, resulting in faster batch evaluation.
 - Separate the parallel from sequential code paths.