### PR TITLE
Use `num_traits::Const{Zero, One}`

### DIFF
--- a/twenty-first/src/amount/u32s.rs
+++ b/twenty-first/src/amount/u32s.rs
@@ -9,6 +9,7 @@ use std::ops::Sub;
 
 use get_size::GetSize;
 use num_bigint::BigUint;
+use num_traits::ConstZero;
 use num_traits::One;
 use num_traits::Zero;
 use rand::Rng;
@@ -136,7 +137,7 @@ impl<const N: usize> From<BigUint> for U32s<N> {
 
 impl<const N: usize> From<U32s<N>> for [BFieldElement; N] {
     fn from(value: U32s<N>) -> Self {
-        let mut ret = [BFieldElement::zero(); N];
+        let mut ret = [BFieldElement::ZERO; N];
         for (&value_elem, ret_elem) in value.values.iter().zip(ret.iter_mut()) {
             *ret_elem = value_elem.into();
         }

--- a/twenty-first/src/math/bfield_codec.rs
+++ b/twenty-first/src/math/bfield_codec.rs
@@ -9,8 +9,8 @@ use std::slice::Iter;
 // an explicit dependency on `bfieldcodec_derive` to their Cargo.toml.
 pub use bfieldcodec_derive::BFieldCodec;
 use itertools::Itertools;
-use num_traits::One;
-use num_traits::Zero;
+use num_traits::ConstOne;
+use num_traits::ConstZero;
 use thiserror::Error;
 
 use crate::bfe_vec;
@@ -310,8 +310,8 @@ impl<T: BFieldCodec> BFieldCodec for Option<T> {
 
     fn encode(&self) -> Vec<BFieldElement> {
         match self {
-            None => vec![BFieldElement::zero()],
-            Some(t) => [vec![BFieldElement::one()], t.encode()].concat(),
+            None => vec![BFieldElement::ZERO],
+            Some(t) => [vec![BFieldElement::ONE], t.encode()].concat(),
         }
     }
 
@@ -538,6 +538,8 @@ impl<T> BFieldCodec for PhantomData<T> {
 
 #[cfg(test)]
 mod tests {
+    use num_traits::ConstZero;
+    use num_traits::Zero;
     use proptest::collection::size_range;
     use proptest::collection::vec;
     use proptest::prelude::*;
@@ -743,7 +745,7 @@ mod tests {
         let encoded = polynomial.encode();
         polynomial
             .coefficients
-            .extend(vec![BFieldElement::zero(); num_leading_zeros]);
+            .extend(vec![BFieldElement::ZERO; num_leading_zeros]);
         let poly_w_leading_zeros_encoded = polynomial.encode();
         prop_assert_eq!(encoded, poly_w_leading_zeros_encoded);
     }
@@ -830,6 +832,7 @@ mod tests {
     #[cfg(test)]
     pub mod derive_tests {
         use arbitrary::Arbitrary;
+        use num_traits::Zero;
 
         use crate::math::digest::Digest;
         use crate::math::tip5::Tip5;

--- a/twenty-first/src/math/bfield_codec.rs
+++ b/twenty-first/src/math/bfield_codec.rs
@@ -758,7 +758,7 @@ mod tests {
         let encoded = polynomial.encode();
         polynomial
             .coefficients
-            .extend(vec![XFieldElement::zero(); num_leading_zeros]);
+            .extend(vec![XFieldElement::ZERO; num_leading_zeros]);
         let poly_w_leading_zeros_encoded = polynomial.encode();
         prop_assert_eq!(encoded, poly_w_leading_zeros_encoded);
     }

--- a/twenty-first/src/math/digest.rs
+++ b/twenty-first/src/math/digest.rs
@@ -6,6 +6,7 @@ use bfieldcodec_derive::BFieldCodec;
 use get_size::GetSize;
 use itertools::Itertools;
 use num_bigint::BigUint;
+use num_traits::ConstZero;
 use num_traits::Zero;
 use rand::Rng;
 use rand_distr::Distribution;
@@ -19,7 +20,6 @@ use crate::error::ParseBFieldElementError;
 use crate::error::TryFromDigestError;
 use crate::error::TryFromHexDigestError;
 use crate::math::b_field_element::BFieldElement;
-use crate::math::b_field_element::BFIELD_ZERO;
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
 
 pub const DIGEST_LENGTH: usize = 5;
@@ -74,7 +74,7 @@ impl Digest {
 
 impl Default for Digest {
     fn default() -> Self {
-        Self([BFIELD_ZERO; DIGEST_LENGTH])
+        Self([BFieldElement::ZERO; DIGEST_LENGTH])
     }
 }
 
@@ -193,7 +193,7 @@ impl TryFrom<BigUint> for Digest {
 
     fn try_from(value: BigUint) -> Result<Self, Self::Error> {
         let mut remaining = value;
-        let mut digest_innards = [BFIELD_ZERO; DIGEST_LENGTH];
+        let mut digest_innards = [BFieldElement::ZERO; DIGEST_LENGTH];
         let modulus: BigUint = BFieldElement::P.into();
         for digest_element in digest_innards.iter_mut() {
             let element = u64::try_from(remaining.clone() % modulus.clone()).unwrap();
@@ -230,7 +230,7 @@ impl Digest {
     /// way to hash a digest in the virtual machine.
     #[deprecated(since = "0.42.0", note = "use `AlgebraicHasher::hash_pair` instead")]
     pub fn hash<H: AlgebraicHasher>(self) -> Digest {
-        H::hash_pair(self, Digest::new([BFieldElement::zero(); DIGEST_LENGTH]))
+        H::hash_pair(self, Digest::new([BFieldElement::ZERO; DIGEST_LENGTH]))
     }
 
     /// Encode digest as hex
@@ -286,8 +286,9 @@ pub(crate) mod digest_tests {
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
 
-    use super::*;
     use crate::prelude::*;
+
+    use super::*;
 
     impl ProptestArbitrary for Digest {
         type Parameters = ();
@@ -527,7 +528,6 @@ pub(crate) mod digest_tests {
     }
 
     mod hex_test {
-
         use super::*;
 
         pub(super) fn hex_examples() -> Vec<(Digest, &'static str)> {

--- a/twenty-first/src/math/lattice.rs
+++ b/twenty-first/src/math/lattice.rs
@@ -4,6 +4,7 @@ use std::ops::Mul;
 use std::ops::Sub;
 
 use itertools::Itertools;
+use num_traits::ConstZero;
 use num_traits::Zero;
 use rayon::prelude::IntoParallelIterator;
 use rayon::prelude::ParallelIterator;
@@ -237,7 +238,7 @@ impl CyclotomicRingElement {
 
     pub fn sample_uniform(randomness: &[u8]) -> CyclotomicRingElement {
         debug_assert!(randomness.len() >= 9 * 64);
-        let mut coefficients = [BFieldElement::zero(); 64];
+        let mut coefficients = [BFieldElement::ZERO; 64];
         for i in 0..64 {
             let mut acc = 0u128;
             for j in 0..9 {
@@ -306,7 +307,7 @@ impl Mul for CyclotomicRingElement {
         let mut rhs_coeffs = rhs.coefficients;
         coset_ntt_noswap_64(&mut lhs_coeffs);
         coset_ntt_noswap_64(&mut rhs_coeffs);
-        let mut out_coeffs = [BFieldElement::zero(); 64];
+        let mut out_coeffs = [BFieldElement::ZERO; 64];
         for i in 0..64 {
             out_coeffs[i] = lhs_coeffs[i] * rhs_coeffs[i];
         }
@@ -320,17 +321,17 @@ impl Mul for CyclotomicRingElement {
 impl Zero for CyclotomicRingElement {
     fn zero() -> Self {
         CyclotomicRingElement {
-            coefficients: [BFieldElement::zero(); 64],
+            coefficients: [BFieldElement::ZERO; 64],
         }
     }
 
     fn is_zero(&self) -> bool {
-        self.coefficients == [BFieldElement::zero(); 64]
+        self.coefficients == [BFieldElement::ZERO; 64]
     }
 }
 
 pub fn embed_msg(msg: [u8; 32]) -> CyclotomicRingElement {
-    let mut embedding: [BFieldElement; 64] = [BFieldElement::zero(); 64];
+    let mut embedding: [BFieldElement; 64] = [BFieldElement::ZERO; 64];
     for i in 0..msg.len() {
         let mut integer = 0u64;
         for j in 0..4 {
@@ -815,7 +816,7 @@ pub mod kem {
 #[cfg(test)]
 mod lattice_test {
     use itertools::Itertools;
-    use num_traits::One;
+    use num_traits::ConstOne;
     use num_traits::Zero;
     use rand::random;
     use rand::thread_rng;
@@ -852,7 +853,7 @@ mod lattice_test {
         let a: [BFieldElement; 64] = random();
         let b: [BFieldElement; 64] = random();
 
-        let mut c_schoolbook = [BFieldElement::zero(); 64];
+        let mut c_schoolbook = [BFieldElement::ZERO; 64];
         for i in 0..64 {
             for j in 0..64 {
                 if i + j >= 64 {
@@ -965,7 +966,7 @@ mod lattice_test {
         assert!(zero_me.is_zero(), "zero must be zero");
         let not_zero = ModuleElement {
             elements: [CyclotomicRingElement {
-                coefficients: [BFieldElement::one(); 64],
+                coefficients: [BFieldElement::ONE; 64],
             }; 4],
         };
         assert!(!not_zero.is_zero(), "not-zero must be not be zero");

--- a/twenty-first/src/math/ntt.rs
+++ b/twenty-first/src/math/ntt.rs
@@ -1,6 +1,7 @@
 use std::ops::MulAssign;
 
-use num_traits::Zero;
+use num_traits::ConstOne;
+use num_traits::ConstZero;
 use rand_distr::num_traits::One;
 
 use super::b_field_element::BFieldElement;
@@ -77,7 +78,7 @@ pub fn ntt<FF: FiniteField + MulAssign<BFieldElement>>(
         let w_m = omega.mod_pow_u32(n / (2 * m));
         let mut k = 0;
         while k < n {
-            let mut w = BFieldElement::one();
+            let mut w = BFieldElement::ONE;
             for j in 0..m {
                 let u = x[(k + j) as usize];
                 let mut v = x[(k + j + m) as usize];
@@ -171,8 +172,8 @@ pub fn ntt_noswap<FF: FiniteField + MulAssign<BFieldElement>>(x: &mut [FF], omeg
         logn += 1;
     }
 
-    let mut powers_of_omega_bitreversed = vec![BFieldElement::zero(); n];
-    let mut omegai = BFieldElement::one();
+    let mut powers_of_omega_bitreversed = vec![BFieldElement::ZERO; n];
+    let mut omegai = BFieldElement::ONE;
     for i in 0..n / 2 {
         powers_of_omega_bitreversed[bitreverse_usize(i, logn - 1)] = omegai;
         omegai *= omega;
@@ -226,7 +227,7 @@ pub fn intt_noswap<FF: FiniteField + MulAssign<BFieldElement>>(x: &mut [FF], ome
         let w_m = omega_inverse.mod_pow_u32((n / (2 * m)).try_into().unwrap());
         let mut k = 0;
         while k < n {
-            let mut w = BFieldElement::one();
+            let mut w = BFieldElement::ONE;
             for j in 0..m {
                 let u = x[k + j];
                 let mut v = x[k + j + m];
@@ -265,7 +266,6 @@ fn bitreverse(mut n: u32, l: u32) -> u32 {
 #[cfg(test)]
 mod fast_ntt_attempt_tests {
     use itertools::Itertools;
-    use num_traits::One;
     use num_traits::Zero;
     use proptest::collection::vec;
     use proptest::prelude::*;
@@ -337,17 +337,17 @@ mod fast_ntt_attempt_tests {
     #[test]
     fn xfield_basic_test_of_chu_ntt() {
         let mut input_output = vec![
-            XFieldElement::new_const(BFieldElement::one()),
-            XFieldElement::new_const(BFieldElement::zero()),
-            XFieldElement::new_const(BFieldElement::zero()),
-            XFieldElement::new_const(BFieldElement::zero()),
+            XFieldElement::new_const(BFieldElement::ONE),
+            XFieldElement::new_const(BFieldElement::ZERO),
+            XFieldElement::new_const(BFieldElement::ZERO),
+            XFieldElement::new_const(BFieldElement::ZERO),
         ];
         let original_input = input_output.clone();
         let expected = vec![
-            XFieldElement::new_const(BFieldElement::one()),
-            XFieldElement::new_const(BFieldElement::one()),
-            XFieldElement::new_const(BFieldElement::one()),
-            XFieldElement::new_const(BFieldElement::one()),
+            XFieldElement::new_const(BFieldElement::ONE),
+            XFieldElement::new_const(BFieldElement::ONE),
+            XFieldElement::new_const(BFieldElement::ONE),
+            XFieldElement::new_const(BFieldElement::ONE),
         ];
         let omega = XFieldElement::primitive_root_of_unity(4).unwrap();
 
@@ -428,7 +428,7 @@ mod fast_ntt_attempt_tests {
     #[proptest]
     fn ntt_on_input_of_length_one(bfe: BFieldElement) {
         let mut test_vector = vec![bfe];
-        let root_of_unity = BFieldElement::one();
+        let root_of_unity = BFieldElement::ONE;
 
         ntt(&mut test_vector, root_of_unity, 0);
         assert_eq!(vec![bfe], test_vector);

--- a/twenty-first/src/math/polynomial.rs
+++ b/twenty-first/src/math/polynomial.rs
@@ -17,6 +17,7 @@ use arbitrary::Arbitrary;
 use itertools::EitherOrBoth;
 use itertools::Itertools;
 use num_bigint::BigInt;
+use num_traits::ConstOne;
 use num_traits::One;
 use num_traits::Zero;
 use rayon::prelude::*;
@@ -706,7 +707,7 @@ where
     ) -> Vec<Self> {
         debug_assert_eq!(
             primitive_root.mod_pow_u32(root_order as u32),
-            BFieldElement::one(),
+            BFieldElement::ONE,
             "Supplied element “primitive_root” must have supplied order.\
             Supplied element was: {primitive_root:?}\
             Supplied order was: {root_order:?}"
@@ -2393,6 +2394,7 @@ impl<FF: FiniteField> Neg for Polynomial<FF> {
 
 #[cfg(test)]
 mod test_polynomials {
+    use num_traits::ConstZero;
     use proptest::collection::size_range;
     use proptest::collection::vec;
     use proptest::prelude::*;
@@ -2475,7 +2477,7 @@ mod test_polynomials {
 
     #[proptest]
     fn leading_coefficient_of_zero_polynomial_is_none(#[strategy(0usize..30)] num_zeros: usize) {
-        let coefficients = vec![BFieldElement::zero(); num_zeros];
+        let coefficients = vec![BFieldElement::ZERO; num_zeros];
         let polynomial = Polynomial { coefficients };
         prop_assert!(polynomial.leading_coefficient().is_none());
     }
@@ -2488,7 +2490,7 @@ mod test_polynomials {
     ) {
         let mut coefficients = polynomial.coefficients;
         coefficients.push(leading_coefficient);
-        coefficients.extend(vec![BFieldElement::zero(); num_leading_zeros]);
+        coefficients.extend(vec![BFieldElement::ZERO; num_leading_zeros]);
         let polynomial_with_leading_zeros = Polynomial { coefficients };
         prop_assert_eq!(
             leading_coefficient,
@@ -2509,7 +2511,7 @@ mod test_polynomials {
         #[strategy(0usize..30)] num_leading_zeros: usize,
     ) {
         let mut coefficients = polynomial.coefficients.clone();
-        coefficients.extend(vec![BFieldElement::zero(); num_leading_zeros]);
+        coefficients.extend(vec![BFieldElement::ZERO; num_leading_zeros]);
         let polynomial_with_leading_zeros = Polynomial { coefficients };
 
         prop_assert_eq!(polynomial, polynomial_with_leading_zeros);
@@ -2523,7 +2525,7 @@ mod test_polynomials {
     ) {
         let mut coefficients = polynomial.coefficients.clone();
         coefficients.push(leading_coefficient);
-        coefficients.extend(vec![BFieldElement::zero(); num_leading_zeros]);
+        coefficients.extend(vec![BFieldElement::ZERO; num_leading_zeros]);
         let mut polynomial_with_leading_zeros = Polynomial { coefficients };
         polynomial_with_leading_zeros.normalize();
 
@@ -2677,7 +2679,7 @@ mod test_polynomials {
     #[test]
     #[should_panic(expected = "Line must not be parallel to y-axis")]
     fn getting_point_on_invalid_line_fails() {
-        let one = BFieldElement::one();
+        let one = BFieldElement::ONE;
         let two = one + one;
         let three = two + one;
         Polynomial::<BFieldElement>::get_colinear_y((one, one), (one, three), two);
@@ -2757,7 +2759,7 @@ mod test_polynomials {
         #[strategy(0usize..30)] shift: usize,
     ) {
         let shifted_polynomial = polynomial.shift_coefficients(shift);
-        let mut expected_coefficients = vec![BFieldElement::zero(); shift];
+        let mut expected_coefficients = vec![BFieldElement::ZERO; shift];
         expected_coefficients.extend(polynomial.coefficients);
         prop_assert_eq!(expected_coefficients, shifted_polynomial.coefficients);
     }
@@ -3098,20 +3100,17 @@ mod test_polynomials {
     ) {
         let zerofier = Polynomial::zerofier(&domain);
         for point in domain {
-            prop_assert_eq!(BFieldElement::zero(), zerofier.evaluate(point));
+            prop_assert_eq!(BFieldElement::ZERO, zerofier.evaluate(point));
         }
         for point in out_of_domain_points {
-            prop_assert_ne!(BFieldElement::zero(), zerofier.evaluate(point));
+            prop_assert_ne!(BFieldElement::ZERO, zerofier.evaluate(point));
         }
     }
 
     #[proptest]
     fn zerofier_has_leading_coefficient_one(domain: Vec<BFieldElement>) {
         let zerofier = Polynomial::zerofier(&domain);
-        prop_assert_eq!(
-            BFieldElement::one(),
-            zerofier.leading_coefficient().unwrap()
-        );
+        prop_assert_eq!(BFieldElement::ONE, zerofier.leading_coefficient().unwrap());
     }
     #[proptest]
     fn par_zerofier_agrees_with_zerofier(domain: Vec<BFieldElement>) {
@@ -3670,7 +3669,7 @@ mod test_polynomials {
     ) {
         let g = f.formal_power_series_inverse_newton(precision);
         let mut coefficients = bfe_vec![0; precision + 1];
-        coefficients[precision] = BFieldElement::new(1);
+        coefficients[precision] = BFieldElement::ONE;
         let xn = Polynomial::new(coefficients);
         let (_quotient, remainder) = g.multiply(&f).divide(&xn);
         prop_assert!(remainder.is_one());
@@ -3690,8 +3689,8 @@ mod test_polynomials {
         let precision = 8;
 
         let g = f.formal_power_series_inverse_newton(precision);
-        let mut coefficients = vec![BFieldElement::new(0); precision + 1];
-        coefficients[precision] = BFieldElement::new(1);
+        let mut coefficients = vec![BFieldElement::ZERO; precision + 1];
+        coefficients[precision] = BFieldElement::ONE;
         let xn = Polynomial::new(coefficients);
         let (_quotient, remainder) = g.multiply(&f).divide(&xn);
         assert!(remainder.is_one());
@@ -3706,8 +3705,8 @@ mod test_polynomials {
         f: Polynomial<BFieldElement>,
     ) {
         let g = f.formal_power_series_inverse_minimal(precision);
-        let mut coefficients = vec![BFieldElement::new(0); precision + 1];
-        coefficients[precision] = BFieldElement::new(1);
+        let mut coefficients = vec![BFieldElement::ZERO; precision + 1];
+        coefficients[precision] = BFieldElement::ONE;
         let xn = Polynomial::new(coefficients);
         let (_quotient, remainder) = g.multiply(&f).divide(&xn);
 
@@ -3753,8 +3752,8 @@ mod test_polynomials {
 
         let x3np1 = Polynomial::new(
             [
-                vec![BFieldElement::new(0); (3 * n + 1) as usize],
-                vec![BFieldElement::new(1); 1],
+                vec![BFieldElement::ZERO; (3 * n + 1) as usize],
+                vec![BFieldElement::ONE; 1],
             ]
             .concat(),
         );
@@ -3767,7 +3766,7 @@ mod test_polynomials {
                 .degree(),
         );
         assert_eq!(
-            BFieldElement::new(1),
+            BFieldElement::ONE,
             *(structured_multiple.clone() - remainder)
                 .coefficients
                 .last()
@@ -3789,8 +3788,8 @@ mod test_polynomials {
 
         let x3np1 = Polynomial::new(
             [
-                vec![BFieldElement::new(0); (3 * n + 1) as usize],
-                vec![BFieldElement::new(1); 1],
+                vec![BFieldElement::ZERO; (3 * n + 1) as usize],
+                vec![BFieldElement::ONE; 1],
             ]
             .concat(),
         );
@@ -3803,7 +3802,7 @@ mod test_polynomials {
                 .degree(),
         );
         assert_eq!(
-            BFieldElement::new(1),
+            BFieldElement::ONE,
             *(structured_multiple.clone() - remainder)
                 .coefficients
                 .last()
@@ -3829,17 +3828,12 @@ mod test_polynomials {
         #[strategy(4usize..100)] n: usize,
         #[strategy(vec(arb(), 3..usize::min(30, #n)))] mut coefficients: Vec<BFieldElement>,
     ) {
-        *coefficients.last_mut().unwrap() = BFieldElement::new(1);
+        *coefficients.last_mut().unwrap() = BFieldElement::ONE;
         let polynomial = Polynomial::new(coefficients);
         let structured_multiple = polynomial.structured_multiple_of_degree(n);
 
-        let xn = Polynomial::new(
-            [
-                vec![BFieldElement::new(0); n],
-                vec![BFieldElement::new(1); 1],
-            ]
-            .concat(),
-        );
+        let xn =
+            Polynomial::new([vec![BFieldElement::ZERO; n], vec![BFieldElement::ONE; 1]].concat());
         let remainder = structured_multiple.reduce_long_division(&xn);
         assert_eq!(
             (structured_multiple.clone() - remainder.clone())
@@ -3848,11 +3842,11 @@ mod test_polynomials {
             0
         );
         assert_eq!(
+            BFieldElement::ONE,
             *(structured_multiple.clone() - remainder)
                 .coefficients
                 .last()
-                .unwrap(),
-            BFieldElement::new(1)
+                .unwrap()
         );
     }
 

--- a/twenty-first/src/math/polynomial.rs
+++ b/twenty-first/src/math/polynomial.rs
@@ -49,7 +49,7 @@ impl<FF: FiniteField> Zero for Polynomial<FF> {
 impl<FF: FiniteField> One for Polynomial<FF> {
     fn one() -> Self {
         Self {
-            coefficients: vec![FF::one()],
+            coefficients: vec![FF::ONE],
         }
     }
 
@@ -239,7 +239,7 @@ where
             root_res.unwrap_or_else(|| panic!("primitive root for order {order} should exist"));
 
         let mut coefficients = self.coefficients.to_vec();
-        coefficients.resize(order as usize, FF::zero());
+        coefficients.resize(order as usize, FF::ZERO);
         let log_2_of_n = coefficients.len().ilog2();
         ntt::<FF>(&mut coefficients, root, log_2_of_n);
 
@@ -267,8 +267,8 @@ where
             return self.fast_square();
         }
 
-        let zero = FF::zero();
-        let one = FF::one();
+        let zero = FF::ZERO;
+        let one = FF::ONE;
         let two = one + one;
         let mut squared_coefficients = vec![zero; squared_coefficient_len];
 
@@ -290,7 +290,7 @@ where
 
     #[must_use]
     pub fn fast_mod_pow(&self, pow: BigInt) -> Self {
-        let one = FF::one();
+        let one = FF::ONE;
 
         // Special case to handle 0^0 = 1
         if pow.is_zero() {
@@ -352,8 +352,8 @@ where
         let mut lhs_coefficients = self.coefficients.to_vec();
         let mut rhs_coefficients = other.coefficients.to_vec();
 
-        lhs_coefficients.resize(order, FF::zero());
-        rhs_coefficients.resize(order, FF::zero());
+        lhs_coefficients.resize(order, FF::ZERO);
+        rhs_coefficients.resize(order, FF::ZERO);
 
         ntt::<FF>(&mut lhs_coefficients, root, order.ilog2());
         ntt::<FF>(&mut rhs_coefficients, root, order.ilog2());
@@ -461,8 +461,8 @@ where
     /// Only `pub` to allow benchmarking; not considered part of the public API.
     #[doc(hidden)]
     pub fn smart_zerofier(roots: &[FF]) -> Self {
-        let mut zerofier = vec![FF::zero(); roots.len() + 1];
-        zerofier[0] = FF::one();
+        let mut zerofier = vec![FF::ZERO; roots.len() + 1];
+        zerofier[0] = FF::ONE;
         let mut num_coeffs = 1;
         for &root in roots {
             for k in (1..=num_coeffs).rev() {
@@ -570,7 +570,7 @@ where
         );
         debug_assert_eq!(domain.len(), values.len());
 
-        let zero = FF::zero();
+        let zero = FF::ZERO;
         let zerofier = Self::zerofier(domain).coefficients;
 
         // In each iteration of this loop, accumulate into the sum one polynomial that evaluates
@@ -841,7 +841,7 @@ where
     /// Evaluate the polynomial on a batch of points.
     pub fn batch_evaluate(&self, domain: &[FF]) -> Vec<FF> {
         if self.is_zero() {
-            vec![FF::zero(); domain.len()]
+            vec![FF::ZERO; domain.len()]
         } else if self.degree()
             >= Self::REDUCE_BEFORE_EVALUATE_THRESHOLD_RATIO * (domain.len() as isize)
         {
@@ -862,7 +862,7 @@ where
     /// Parallel version of [`batch_evaluate`](Self::batch_evaluate).
     pub fn par_batch_evaluate(&self, domain: &[FF]) -> Vec<FF> {
         if domain.is_empty() || self.is_zero() {
-            return vec![FF::zero(); domain.len()];
+            return vec![FF::ZERO; domain.len()];
         }
         let num_threads = available_parallelism()
             .map(|non_zero_usize| non_zero_usize.get())
@@ -929,7 +929,7 @@ where
         );
 
         let mut coefficients = self.scale(offset).coefficients;
-        coefficients.resize(order, FF::zero());
+        coefficients.resize(order, FF::ZERO);
 
         let log_2_of_n = coefficients.len().ilog2();
         ntt::<FF>(&mut coefficients, generator, log_2_of_n);
@@ -1039,7 +1039,7 @@ where
         let log_full_domain_length = full_domain_length.ilog2();
 
         let mut self_ntt = self.coefficients.clone();
-        self_ntt.resize(full_domain_length, FF::zero());
+        self_ntt.resize(full_domain_length, FF::ZERO);
         ntt(&mut self_ntt, full_omega, log_full_domain_length);
 
         // while possible we calculate over a smaller domain
@@ -1966,7 +1966,7 @@ impl<FF: FiniteField> Polynomial<FF> {
     }
 
     pub fn evaluate(&self, x: FF) -> FF {
-        let mut acc = FF::zero();
+        let mut acc = FF::ZERO;
         for &c in self.coefficients.iter().rev() {
             acc = c + x * acc;
         }
@@ -1977,7 +1977,7 @@ impl<FF: FiniteField> Polynomial<FF> {
     /// The coefficient of the polynomial's term of highest power. `None` if (and only if) `self`
     /// [is zero](Self::is_zero).
     ///
-    /// Furthermore, is never `Some(FF::zero())`.
+    /// Furthermore, is never `Some(FF::ZERO)`.
     ///
     /// # Examples
     ///
@@ -2021,7 +2021,7 @@ impl<FF: FiniteField> Polynomial<FF> {
     pub fn naive_zerofier(domain: &[FF]) -> Self {
         domain
             .iter()
-            .map(|&r| Self::new(vec![-r, FF::one()]))
+            .map(|&r| Self::new(vec![-r, FF::ONE]))
             .reduce(|accumulator, linear_poly| accumulator * linear_poly)
             .unwrap_or_else(Self::one)
     }
@@ -2035,8 +2035,8 @@ impl<FF: FiniteField> Polynomial<FF> {
         }
 
         let squared_coefficient_len = self.degree() as usize * 2 + 1;
-        let zero = FF::zero();
-        let one = FF::one();
+        let zero = FF::ZERO;
+        let one = FF::ONE;
         let two = one + one;
         let mut squared_coefficients = vec![zero; squared_coefficient_len];
 
@@ -2088,7 +2088,7 @@ impl<FF: FiniteField> Polynomial<FF> {
             return Self::zero();
         };
 
-        let mut product = vec![FF::zero(); degree_lhs + degree_rhs + 1];
+        let mut product = vec![FF::ZERO; degree_lhs + degree_rhs + 1];
         for i in 0..=degree_lhs {
             for j in 0..=degree_rhs {
                 product[i + j] += self.coefficients[i] * other.coefficients[j];
@@ -2101,7 +2101,7 @@ impl<FF: FiniteField> Polynomial<FF> {
     /// Multiply a polynomial with itself `pow` times
     #[must_use]
     pub fn mod_pow(&self, pow: BigInt) -> Self {
-        let one = FF::one();
+        let one = FF::ONE;
 
         // Special case to handle 0^0 = 1
         if pow.is_zero() {
@@ -2127,13 +2127,13 @@ impl<FF: FiniteField> Polynomial<FF> {
     }
 
     pub fn shift_coefficients_mut(&mut self, power: usize) {
-        self.coefficients.splice(0..0, vec![FF::zero(); power]);
+        self.coefficients.splice(0..0, vec![FF::ZERO; power]);
     }
 
     /// Multiply a polynomial with x^power
     #[must_use]
     pub fn shift_coefficients(&self, power: usize) -> Self {
-        let zero = FF::zero();
+        let zero = FF::ZERO;
 
         let mut coefficients: Vec<FF> = self.coefficients.clone();
         coefficients.splice(0..0, vec![zero; power]);
@@ -2302,7 +2302,7 @@ impl<FF: FiniteField> Sub for Polynomial<FF> {
             .map(|a| match a {
                 EitherOrBoth::Both(l, r) => l - r,
                 EitherOrBoth::Left(l) => l,
-                EitherOrBoth::Right(r) => FF::zero() - r,
+                EitherOrBoth::Right(r) => FF::ZERO - r,
             })
             .collect();
 
@@ -2343,7 +2343,7 @@ impl<FF: FiniteField> Polynomial<FF> {
         }
 
         // normalize result to ensure the gcd, _i.e._, `x` has leading coefficient 1
-        let lc = x.leading_coefficient().unwrap_or_else(FF::one);
+        let lc = x.leading_coefficient().unwrap_or(FF::ONE);
         let normalize = |mut poly: Self| {
             poly.scalar_mul_mut(lc.inverse());
             poly
@@ -2388,7 +2388,7 @@ impl<FF: FiniteField> Neg for Polynomial<FF> {
     type Output = Self;
 
     fn neg(mut self) -> Self::Output {
-        self.scalar_mul_mut(-FF::one());
+        self.scalar_mul_mut(-FF::ONE);
         self
     }
 }

--- a/twenty-first/src/math/polynomial.rs
+++ b/twenty-first/src/math/polynomial.rs
@@ -18,6 +18,7 @@ use itertools::EitherOrBoth;
 use itertools::Itertools;
 use num_bigint::BigInt;
 use num_traits::ConstOne;
+use num_traits::ConstZero;
 use num_traits::One;
 use num_traits::Zero;
 use rayon::prelude::*;
@@ -1880,8 +1881,8 @@ impl Polynomial<BFieldElement> {
         let order_u64 = u64::try_from(order).unwrap();
         let root = BFieldElement::primitive_root_of_unity(order_u64).unwrap();
 
-        dividend_coefficients.resize(order, XFieldElement::zero());
-        divisor_coefficients.resize(order, XFieldElement::zero());
+        dividend_coefficients.resize(order, XFieldElement::ZERO);
+        divisor_coefficients.resize(order, XFieldElement::ZERO);
 
         ntt(&mut dividend_coefficients, root, order.ilog2());
         ntt(&mut divisor_coefficients, root, order.ilog2());

--- a/twenty-first/src/math/tip5.rs
+++ b/twenty-first/src/math/tip5.rs
@@ -616,8 +616,6 @@ impl Sponge for Tip5 {
 pub(crate) mod tip5_tests {
     use std::ops::Mul;
 
-    use num_traits::One;
-    use num_traits::Zero;
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use rand::thread_rng;
@@ -990,15 +988,15 @@ pub(crate) mod tip5_tests {
     #[test]
     fn sample_scalars_test() {
         let mut sponge = Tip5::randomly_seeded();
-        let mut product = XFieldElement::one();
+        let mut product = XFieldElement::ONE;
         for amount in 0..=4 {
             let scalars = sponge.sample_scalars(amount);
             assert_eq!(amount, scalars.len());
             product *= scalars
                 .into_iter()
-                .fold(XFieldElement::one(), XFieldElement::mul);
+                .fold(XFieldElement::ONE, XFieldElement::mul);
         }
-        assert_ne!(product, XFieldElement::zero()); // false failure with prob ~2^{-192}
+        assert_ne!(product, XFieldElement::ZERO); // false failure with prob ~2^{-192}
     }
 
     #[test]

--- a/twenty-first/src/math/traits.rs
+++ b/twenty-first/src/math/traits.rs
@@ -1,10 +1,20 @@
-use num_traits::One;
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::ops::Add;
+use std::ops::AddAssign;
+use std::ops::Div;
+use std::ops::Mul;
+use std::ops::MulAssign;
+use std::ops::Neg;
+use std::ops::Sub;
+use std::ops::SubAssign;
+
+use num_traits::ConstOne;
+use num_traits::ConstZero;
 use num_traits::Zero;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::fmt::{Debug, Display};
-use std::hash::Hash;
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 pub trait CyclicGroupGenerator
 where
@@ -54,8 +64,8 @@ pub trait FiniteField:
     + Serialize
     + DeserializeOwned
     + Hash
-    + Zero
-    + One
+    + ConstZero
+    + ConstOne
     + Add<Output = Self>
     + Mul<Output = Self>
     + Sub<Output = Self>

--- a/twenty-first/src/math/traits.rs
+++ b/twenty-first/src/math/traits.rs
@@ -1,4 +1,5 @@
-use num_traits::{One, Zero};
+use num_traits::One;
+use num_traits::Zero;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fmt::{Debug, Display};

--- a/twenty-first/src/math/zerofier_tree.rs
+++ b/twenty-first/src/math/zerofier_tree.rs
@@ -96,6 +96,7 @@ impl<FF: FiniteField + MulAssign<BFieldElement>> ZerofierTree<FF> {
 
 #[cfg(test)]
 mod test {
+    use num_traits::ConstZero;
     use num_traits::Zero;
     use proptest::collection::vec;
     use proptest::prop_assert_eq;
@@ -144,7 +145,7 @@ mod test {
     ) {
         let zerofier_tree = ZerofierTree::new_from_domain(&points);
         prop_assert_eq!(
-            BFieldElement::zero(),
+            BFieldElement::ZERO,
             zerofier_tree.zerofier().evaluate(points[index])
         );
     }

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -2,10 +2,10 @@ use std::fmt::Debug;
 use std::iter;
 
 use itertools::Itertools;
+use num_traits::ConstOne;
+use num_traits::ConstZero;
 
 use crate::math::b_field_element::BFieldElement;
-use crate::math::b_field_element::BFIELD_ONE;
-use crate::math::b_field_element::BFIELD_ZERO;
 use crate::math::bfield_codec::BFieldCodec;
 use crate::math::digest::Digest;
 use crate::math::digest::DIGEST_LENGTH;
@@ -47,7 +47,8 @@ pub trait Sponge: Clone + Debug + Default + Send + Sync {
     fn pad_and_absorb_all(&mut self, input: &[BFieldElement]) {
         // pad input with [1, 0, 0, …] – padding is at least one element
         let padded_length = (input.len() + 1).next_multiple_of(RATE);
-        let padding_iter = [BFIELD_ONE].iter().chain(iter::repeat(&BFIELD_ZERO));
+        let padding_iter =
+            iter::once(&BFieldElement::ONE).chain(iter::repeat(&BFieldElement::ZERO));
         let padded_input = input.iter().chain(padding_iter).take(padded_length);
 
         for chunk in padded_input.chunks(RATE).into_iter() {
@@ -177,14 +178,14 @@ mod algebraic_hasher_tests {
 
         // BFieldElement
         let bfe_max = BFieldElement::new(BFieldElement::MAX);
-        encode_prop(BFIELD_ZERO, bfe_max);
+        encode_prop(BFieldElement::ZERO, bfe_max);
 
         // XFieldElement
         let xfe_max = XFieldElement::new([bfe_max; EXTENSION_DEGREE]);
         encode_prop(XFieldElement::zero(), xfe_max);
 
         // Digest
-        let digest_zero = Digest::new([BFIELD_ZERO; DIGEST_LENGTH]);
+        let digest_zero = Digest::new([BFieldElement::ZERO; DIGEST_LENGTH]);
         let digest_max = Digest::new([bfe_max; DIGEST_LENGTH]);
         encode_prop(digest_zero, digest_max);
 

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -132,8 +132,6 @@ pub trait AlgebraicHasher: Sponge {
 mod algebraic_hasher_tests {
     use std::ops::Mul;
 
-    use num_traits::One;
-    use num_traits::Zero;
     use rand::Rng;
     use rand_distr::Distribution;
     use rand_distr::Standard;
@@ -182,7 +180,7 @@ mod algebraic_hasher_tests {
 
         // XFieldElement
         let xfe_max = XFieldElement::new([bfe_max; EXTENSION_DEGREE]);
-        encode_prop(XFieldElement::zero(), xfe_max);
+        encode_prop(XFieldElement::ZERO, xfe_max);
 
         // Digest
         let digest_zero = Digest::new([BFieldElement::ZERO; DIGEST_LENGTH]);
@@ -223,14 +221,14 @@ mod algebraic_hasher_tests {
     fn sample_scalars_test() {
         let amounts = [0, 1, 2, 3, 4];
         let mut sponge = Tip5::randomly_seeded();
-        let mut product = XFieldElement::one();
+        let mut product = XFieldElement::ONE;
         for amount in amounts {
             let scalars = sponge.sample_scalars(amount);
             assert_eq!(amount, scalars.len());
             product *= scalars
                 .into_iter()
-                .fold(XFieldElement::one(), XFieldElement::mul);
+                .fold(XFieldElement::ONE, XFieldElement::mul);
         }
-        assert_ne!(product, XFieldElement::zero()); // false failure with prob ~2^{-192}
+        assert_ne!(product, XFieldElement::ZERO); // false failure with prob ~2^{-192}
     }
 }

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -427,7 +427,7 @@ mod accumulator_mmr_tests {
 
     use itertools::izip;
     use itertools::Itertools;
-    use num_traits::Zero;
+    use num_traits::ConstZero;
     use rand::distributions::Uniform;
     use rand::random;
     use rand::thread_rng;
@@ -809,7 +809,7 @@ mod accumulator_mmr_tests {
         type H = Tip5;
         type Mmr = MmrAccumulator<H>;
         let mut mmra: Mmr = MmrAccumulator::new(vec![]);
-        mmra.append(H::hash(&BFieldElement::zero()));
+        mmra.append(H::hash(&BFieldElement::ZERO));
 
         let json = serde_json::to_string(&mmra).unwrap();
         let s_back = serde_json::from_str::<Mmr>(&json).unwrap();


### PR DESCRIPTION
## Idea

Allow writing the following code:

```rust
fn old_and_bland<FF: FiniteField>() {            fn new_and_shiny<FF: FiniteField>() {
    let many_ones = [FF::one(); 42];                 let many_ones = [FF::ONE; 42];
    /* important stuff */                            /* important stuff */
}                                                }
```

## Motivation

Hopefully, this allows the compiler to optimize more. For example, there might be a performance difference between the following two snippets.

```rust
// current                                       // new – maybe faster?
let mut my_vec = vec![0; 0];                     let mut my_vec = vec![0; 0];
my_vec.resize(1024, FF::zero());                 my_vec.resize(1024, FF::ZERO);
```

Whether this is actually true remains to be seen.

## Changes

- Replace `BFIELD_ZERO` and `BFIELD_ONE` with implementations of `ConstZero` and `ConstOne`.
- Implement `ConstZero` and `ConstOne` for `XFieldElement`.
- Replace trait bounds `Zero` and `One` with `ConstZero` and `ConstOne`[^1] on the trait `FiniteField`.
- Use the new associated constants liberally.

[^1]: Note that trait `ConstZero` has a trait bound on `Zero`, and trait `ConstOne` has a trait bound on `One`.

## Benchmarks

```
mul/(XFE,BFE)->XFE/10
              time: [26.711 ns 26.737 ns 26.758 ns] 
              change:  
              time: [-6.5058% -6.2592% -6.0519%] (p = 0.00 < 0.05)   
              Performance has improved.  
mul/(XFE,BFE)->XFE/100
              time: [287.04 ns 287.22 ns 287.38 ns]  
              change:  
              time: [-7.2815% -7.0627% -6.8609%] (p = 0.00 < 0.05)  
              Performance has improved.  
mul/(XFE,BFE)->XFE/1000
              time: [2.8957 µs 2.8975 µs 2.8998 µs]  
              change:  
              time: [-7.0637% -6.9463% -6.8119%] (p = 0.00 < 0.05)  
              Performance has improved.  
mul/(XFE,BFE)->XFE/1000000
              time: [2.9453 ms 2.9574 ms 2.9797 ms]  
              change:  
              time: [-6.0233% -5.4037% -4.6590%] (p = 0.00 < 0.05)  
              Performance has improved. 
```

All other benchmarks are within the noise threshold.