### PR TITLE
refactor: Make `Digest::LEN` an associated const

### DIFF
--- a/twenty-first/benches/tip5.rs
+++ b/twenty-first/benches/tip5.rs
@@ -1,11 +1,12 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use rand::{thread_rng, Rng};
-use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
-use twenty_first::math::b_field_element::BFieldElement;
-use twenty_first::math::digest::DIGEST_LENGTH;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use rand::random;
+use rayon::prelude::*;
+
 use twenty_first::math::other::random_elements;
-use twenty_first::math::tip5::Tip5;
-use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
+use twenty_first::prelude::*;
 
 fn bench_10(c: &mut Criterion) {
     let mut group = c.benchmark_group("tip5/hash_10");
@@ -13,7 +14,7 @@ fn bench_10(c: &mut Criterion) {
     let size = 10;
     group.sample_size(100);
 
-    let single_element: [BFieldElement; 10] = thread_rng().gen();
+    let single_element: [BFieldElement; 10] = random();
     group.bench_function(BenchmarkId::new("Tip5 / Hash 10", size), |bencher| {
         bencher.iter(|| Tip5::hash_10(&single_element));
     });
@@ -22,8 +23,8 @@ fn bench_10(c: &mut Criterion) {
 fn bench_pair(c: &mut Criterion) {
     let mut group = c.benchmark_group("tip5/hash_pair");
 
-    let left = thread_rng().gen();
-    let right = thread_rng().gen();
+    let left = random();
+    let right = random();
 
     group.bench_function(BenchmarkId::new("Tip5 / Hash Pair", "pair"), |bencher| {
         bencher.iter(|| Tip5::hash_pair(left, right));
@@ -59,7 +60,7 @@ fn bench_parallel(c: &mut Criterion) {
             elements
                 .par_iter()
                 .map(Tip5::hash_10)
-                .collect::<Vec<[BFieldElement; DIGEST_LENGTH]>>()
+                .collect::<Vec<[BFieldElement; Digest::LEN]>>()
         });
     });
 }

--- a/twenty-first/src/error.rs
+++ b/twenty-first/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 pub use crate::math::bfield_codec::BFieldCodecError;
 pub use crate::math::bfield_codec::PolynomialBFieldCodecError;
-use crate::prelude::tip5::DIGEST_LENGTH;
+use crate::prelude::tip5::Digest;
 use crate::prelude::x_field_element::EXTENSION_DEGREE;
 use crate::prelude::BFieldElement;
 pub use crate::util_types::merkle_tree::MerkleTreeError;
@@ -36,7 +36,7 @@ pub enum TryFromXFieldElementError {
 #[derive(Debug, Clone, Eq, PartialEq, Error)]
 #[non_exhaustive]
 pub enum TryFromDigestError {
-    #[error("expected {DIGEST_LENGTH} elements for digest, but got {0}")]
+    #[error("expected {} elements for digest, but got {0}", Digest::LEN)]
     InvalidLength(usize),
 
     #[error("invalid `BFieldElement`")]

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -8,7 +8,6 @@ use num_traits::ConstZero;
 use crate::math::b_field_element::BFieldElement;
 use crate::math::bfield_codec::BFieldCodec;
 use crate::math::digest::Digest;
-use crate::math::digest::DIGEST_LENGTH;
 use crate::math::x_field_element::XFieldElement;
 use crate::math::x_field_element::EXTENSION_DEGREE;
 
@@ -78,7 +77,7 @@ pub trait AlgebraicHasher: Sponge {
         sponge.pad_and_absorb_all(input);
         let produce: [BFieldElement; RATE] = sponge.squeeze();
 
-        Digest::new((&produce[..DIGEST_LENGTH]).try_into().unwrap())
+        Digest::new((&produce[..Digest::LEN]).try_into().unwrap())
     }
 
     /// Produce `num_indices` random integer values in the range `[0, upper_bound)`. The
@@ -136,7 +135,7 @@ mod algebraic_hasher_tests {
     use rand_distr::Distribution;
     use rand_distr::Standard;
 
-    use crate::math::digest::DIGEST_LENGTH;
+    use crate::math::digest::Digest;
     use crate::math::tip5::Tip5;
     use crate::math::x_field_element::EXTENSION_DEGREE;
 
@@ -183,8 +182,8 @@ mod algebraic_hasher_tests {
         encode_prop(XFieldElement::ZERO, xfe_max);
 
         // Digest
-        let digest_zero = Digest::new([BFieldElement::ZERO; DIGEST_LENGTH]);
-        let digest_max = Digest::new([bfe_max; DIGEST_LENGTH]);
+        let digest_zero = Digest::new([BFieldElement::ZERO; Digest::LEN]);
+        let digest_max = Digest::new([bfe_max; Digest::LEN]);
         encode_prop(digest_zero, digest_max);
 
         // u128


### PR DESCRIPTION
Also, deprecate `digest::DIGEST_LENGTH`.

I think this design is cleaner. It's a bit of a bikeshed. :shrug: Open to suggestions.