### PR TITLE
Thv/remove leaf idx from mmr mp

### DIFF
--- a/twenty-first/benches/merkle_tree_auth_structure_size.rs
+++ b/twenty-first/benches/merkle_tree_auth_structure_size.rs
@@ -73,21 +73,21 @@ fn auth_structure_len(c: &mut Criterion<AuthStructureEncodingLength>) {
     let mut rng = StdRng::seed_from_u64(0);
 
     let tree_height = 22;
-    let num_leaves = 1 << tree_height;
-    let leaves = (0..num_leaves).map(|_| rng.next_u64()).collect_vec();
-    let leaf_digests = leaves.iter().map(Tip5::hash).collect_vec();
+    let num_leafs = 1 << tree_height;
+    let leafs = (0..num_leafs).map(|_| rng.next_u64()).collect_vec();
+    let leaf_digests = leafs.iter().map(Tip5::hash).collect_vec();
     let mt = MerkleTree::<Tip5>::new::<CpuParallel>(&leaf_digests).unwrap();
 
     let num_opened_indices = 40;
     let mut group = c.benchmark_group("merkle_tree_auth_structure_size");
     group.bench_function(
-        BenchmarkId::new("auth_structure_size", num_leaves),
+        BenchmarkId::new("auth_structure_size", num_leafs),
         |bencher| {
             bencher.iter_custom(|iters| {
                 let mut total_len = AuthStructureEncodingLength(0.0);
                 for _ in 0..iters {
                     let opened_indices = (0..num_opened_indices)
-                        .map(|_| rng.gen_range(0..num_leaves))
+                        .map(|_| rng.gen_range(0..num_leafs))
                         .collect_vec();
                     let auth_structure = mt.authentication_structure(&opened_indices).unwrap();
                     let this_len = auth_structure.encode().len();

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -58,12 +58,12 @@ impl Default for MerkleTreeSampler {
 }
 
 impl MerkleTreeSampler {
-    fn num_leaves(&self) -> usize {
+    fn num_leafs(&self) -> usize {
         1 << self.tree_height
     }
 
     fn leaf_digests(&mut self) -> Vec<Digest> {
-        (0..self.num_leaves())
+        (0..self.num_leafs())
             .map(|_| self.rng.next_u64())
             .map(|leaf| Tip5::hash(&leaf))
             .collect()
@@ -76,7 +76,7 @@ impl MerkleTreeSampler {
 
     fn indices_to_open(&mut self) -> Vec<usize> {
         (0..self.num_opened_indices)
-            .map(|_| self.rng.gen_range(0..self.num_leaves()))
+            .map(|_| self.rng.gen_range(0..self.num_leafs()))
             .collect()
     }
 

--- a/twenty-first/src/mock/mmr/mock_mmr.rs
+++ b/twenty-first/src/mock/mmr/mock_mmr.rs
@@ -416,7 +416,6 @@ mod mmr_test {
         bag_peaks::<H>(&roots)
     }
 
-    /// A block can contain an empty list of addition or removal records.
     #[test]
     fn computing_mmr_root_for_no_leaves_produces_some_digest() {
         root_from_arbitrary_number_of_digests::<Tip5>(&[]);

--- a/twenty-first/src/mock/mmr/mod.rs
+++ b/twenty-first/src/mock/mmr/mod.rs
@@ -95,8 +95,8 @@ mod shared_tests_tests {
 
         let (mmra, mps) =
             mmra_with_mps::<H>(32, vec![(12, digest_leaf_idx12), (14, digest_leaf_idx14)]);
-        assert!(mps[0].verify(12, digest_leaf_idx12, &mmra.peaks(), mmra.num_leaves()));
-        assert!(mps[1].verify(14, digest_leaf_idx14, &mmra.peaks(), mmra.num_leaves()));
+        assert!(mps[0].verify(12, digest_leaf_idx12, &mmra.peaks(), mmra.num_leafs()));
+        assert!(mps[1].verify(14, digest_leaf_idx14, &mmra.peaks(), mmra.num_leafs()));
     }
 
     #[test]

--- a/twenty-first/src/mock/mmr/mod.rs
+++ b/twenty-first/src/mock/mmr/mod.rs
@@ -55,7 +55,7 @@ mod shared_tests_tests {
         for leaf_count in 1..10 {
             for leaf_index in 0..leaf_count {
                 let (mmra, mps) = mmra_with_mps::<H>(leaf_count, vec![(leaf_index, some)]);
-                assert!(mps[0].verify(leaf_index, some, &mmra.get_peaks(), leaf_count));
+                assert!(mps[0].verify(leaf_index, some, &mmra.peaks(), leaf_count));
             }
         }
 
@@ -70,8 +70,8 @@ mod shared_tests_tests {
                         leaf_count,
                         vec![(some_index, some), (other_index, other)],
                     );
-                    assert!(mps[0].verify(some_index, some, &mmra.get_peaks(), leaf_count));
-                    assert!(mps[1].verify(other_index, other, &mmra.get_peaks(), leaf_count));
+                    assert!(mps[0].verify(some_index, some, &mmra.peaks(), leaf_count));
+                    assert!(mps[1].verify(other_index, other, &mmra.peaks(), leaf_count));
                 }
             }
         }
@@ -81,7 +81,7 @@ mod shared_tests_tests {
             let specifications = (0..leaf_count).map(|i| (i, random())).collect_vec();
             let (mmra, mps) = mmra_with_mps::<H>(leaf_count, specifications.clone());
             for (mp, (leaf_index, leaf)) in mps.iter().zip(specifications) {
-                assert!(mp.verify(leaf_index, leaf, &mmra.get_peaks(), leaf_count));
+                assert!(mp.verify(leaf_index, leaf, &mmra.peaks(), leaf_count));
             }
         }
     }
@@ -95,18 +95,8 @@ mod shared_tests_tests {
 
         let (mmra, mps) =
             mmra_with_mps::<H>(32, vec![(12, digest_leaf_idx12), (14, digest_leaf_idx14)]);
-        assert!(mps[0].verify(
-            12,
-            digest_leaf_idx12,
-            &mmra.get_peaks(),
-            mmra.count_leaves()
-        ));
-        assert!(mps[1].verify(
-            14,
-            digest_leaf_idx14,
-            &mmra.get_peaks(),
-            mmra.count_leaves()
-        ));
+        assert!(mps[0].verify(12, digest_leaf_idx12, &mmra.peaks(), mmra.num_leaves()));
+        assert!(mps[1].verify(14, digest_leaf_idx14, &mmra.peaks(), mmra.num_leaves()));
     }
 
     #[test]
@@ -129,7 +119,7 @@ mod shared_tests_tests {
                 let (mmra, mps) = mmra_with_mps::<H>(leaf_count, specified_leafs.clone());
 
                 for (mp, (leaf_idx, leaf)) in mps.iter().zip_eq(specified_leafs) {
-                    assert!(mp.verify(leaf_idx, leaf, &mmra.get_peaks(), leaf_count));
+                    assert!(mp.verify(leaf_idx, leaf, &mmra.peaks(), leaf_count));
                 }
             }
         }
@@ -154,7 +144,7 @@ mod shared_tests_tests {
         let (mmra, mps) = mmra_with_mps::<H>(leaf_count, specified_leafs.clone());
 
         for (mp, (leaf_idx, leaf)) in mps.iter().zip_eq(specified_leafs) {
-            assert!(mp.verify(leaf_idx, leaf, &mmra.get_peaks(), leaf_count));
+            assert!(mp.verify(leaf_idx, leaf, &mmra.peaks(), leaf_count));
         }
     }
 }

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -574,7 +574,7 @@ mod accumulator_mmr_tests {
             MmrAccumulator::new(leaf_hashes_start.clone());
         let archive_mmr_start: MockMmr<H> = get_mock_ammr_from_digests(leaf_hashes_start);
         let leaf_index_3 = 3;
-        let membership_proof = archive_mmr_start.prove_membership(leaf_index_3).0;
+        let membership_proof = archive_mmr_start.prove_membership(leaf_index_3);
         let accumulator_mmr_end: MmrAccumulator<H> = MmrAccumulator::new(leaf_hashes_end);
 
         {
@@ -639,8 +639,8 @@ mod accumulator_mmr_tests {
         let archive_mmr_start: MockMmr<H> = get_mock_ammr_from_digests(leaf_hashes_start);
         let leaf_index_1 = 1;
         let leaf_index_3 = 3;
-        let membership_proof1 = archive_mmr_start.prove_membership(leaf_index_1).0;
-        let membership_proof3 = archive_mmr_start.prove_membership(leaf_index_3).0;
+        let membership_proof1 = archive_mmr_start.prove_membership(leaf_index_1);
+        let membership_proof3 = archive_mmr_start.prove_membership(leaf_index_3);
         let accumulator_mmr_end: MmrAccumulator<H> = MmrAccumulator::new(leaf_hashes_end);
         let leaf_mutations = vec![
             LeafMutation::new(leaf_index_1, leaf20, &membership_proof1),
@@ -705,7 +705,7 @@ mod accumulator_mmr_tests {
             // Construct the mutation data
             let all_mps = mutated_leaf_indices
                 .iter()
-                .map(|i| ammr.prove_membership(*i).0)
+                .map(|i| ammr.prove_membership(*i))
                 .collect_vec();
             let mutation_data: Vec<LeafMutation<H>> = new_leafs
                 .into_iter()
@@ -718,7 +718,7 @@ mod accumulator_mmr_tests {
 
             let original_membership_proofs: Vec<MmrMembershipProof<H>> = membership_proof_indices
                 .iter()
-                .map(|i| ammr.prove_membership(*i).0)
+                .map(|i| ammr.prove_membership(*i))
                 .collect();
 
             // Do the update on both MMRs
@@ -788,7 +788,7 @@ mod accumulator_mmr_tests {
                 .collect();
 
             let bad_mmr: MockMmr<H> = get_mock_ammr_from_digests(bad_digests.clone());
-            let bad_membership_proof: MmrMembershipProof<H> = bad_mmr.prove_membership(0).0;
+            let bad_membership_proof: MmrMembershipProof<H> = bad_mmr.prove_membership(0);
             let bad_membership_proof_digest = bad_digests[0];
             let bad_leaf: Digest = local_hash(8765432165123u128);
             let mock_mmr_init: MockMmr<H> = get_mock_ammr_from_digests(leaf_hashes_start.clone());
@@ -836,7 +836,7 @@ mod accumulator_mmr_tests {
                     // Create the inputs to the method call
                     let all_mps = mutated_indices
                         .iter()
-                        .map(|i| mock_mmr_init.prove_membership(*i).0)
+                        .map(|i| mock_mmr_init.prove_membership(*i))
                         .collect_vec();
                     let mut leaf_mutations: Vec<LeafMutation<H>> = new_leaf_values
                         .clone()

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -54,22 +54,29 @@ impl<H: AlgebraicHasher> MmrAccumulator<H> {
 }
 
 impl<H: AlgebraicHasher> Mmr<H> for MmrAccumulator<H> {
+    /// Calculate a commitment to the entire MMR.
     fn bag_peaks(&self) -> Digest {
         bag_peaks::<H>(&self.peaks)
     }
 
+    /// Return the Merkle tree roots of the Merkle trees that this MMR consists
+    /// of.
     fn get_peaks(&self) -> Vec<Digest> {
         self.peaks.clone()
     }
 
+    /// Returns true iff there are no leaves in the MMR.
     fn is_empty(&self) -> bool {
         self.leaf_count == 0
     }
 
+    /// Return the number of leaves in the MMR.
     fn count_leaves(&self) -> u64 {
         self.leaf_count
     }
 
+    /// Add a leaf to the MMR. Returns the membership proof of the newly added
+    /// leaf.
     fn append(&mut self, new_leaf: Digest) -> MmrMembershipProof<H> {
         let (new_peaks, membership_proof) = shared_basic::calculate_new_peaks_from_append::<H>(
             self.leaf_count,
@@ -184,6 +191,10 @@ impl<H: AlgebraicHasher> Mmr<H> for MmrAccumulator<H> {
         running_peaks == new_peaks
     }
 
+    /// Mutate multiple leafs in the MMR. Takes a list of membership proofs
+    /// that will be updated accordingly. Meaning that the provided membership
+    /// proofs will be valid for the new MMR, provided they were valid before
+    /// the update was applied.
     /// Panics if `membership_proofs` and `membership_proof_leaf_indices` do not have
     /// the same length, or if a leaf index is out-of-bounds for the MMR.
     fn batch_mutate_leaf_and_update_mps(

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -339,7 +339,10 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
         modified
     }
 
-    /// Update a membership proof with a `leaf_mutation` proof.
+    /// Update a membership proof with a `leaf_mutation` data structure. In
+    /// other words: Given a valid MMR membership proof for an MMR, calculate
+    /// the updated MMR membership proof after one of the MMR's leafs have been
+    /// changed.
     pub fn update_from_leaf_mutation(
         &mut self,
         own_mp_leaf_index: u64,

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -693,8 +693,7 @@ mod mmr_membership_proof_test {
         const LEAF_INDEX: u64 = 4;
         let leaf_hashes: Vec<Digest> = random_elements(8);
         let archival_mmr: MockMmr<H> = get_mock_ammr_from_digests(leaf_hashes);
-        let (membership_proof, _peaks): (MmrMembershipProof<H>, Vec<Digest>) =
-            archival_mmr.prove_membership(LEAF_INDEX);
+        let membership_proof = archival_mmr.prove_membership(LEAF_INDEX);
         assert_eq!(
             vec![9, 13, 7],
             membership_proof.get_node_indices(LEAF_INDEX)
@@ -717,8 +716,7 @@ mod mmr_membership_proof_test {
         for (leaf_index, expected_peak_index) in
             (0..mmr_size as u64).zip(expected_peak_indices_and_heights.into_iter())
         {
-            let (membership_proof, _peaks): (MmrMembershipProof<H>, Vec<Digest>) =
-                archival_mmr.prove_membership(leaf_index);
+            let membership_proof = archival_mmr.prove_membership(leaf_index);
             assert_eq!(
                 expected_peak_index,
                 membership_proof.get_peak_index_and_height(leaf_index)
@@ -733,8 +731,7 @@ mod mmr_membership_proof_test {
         for (leaf_index, expected_peak_index) in
             (0..mmr_size as u64).zip(expected_peak_indices_and_heights.into_iter())
         {
-            let (membership_proof, _peaks): (MmrMembershipProof<H>, Vec<Digest>) =
-                archival_mmr.prove_membership(leaf_index);
+            let membership_proof = archival_mmr.prove_membership(leaf_index);
             assert_eq!(
                 expected_peak_index,
                 membership_proof.get_peak_index_and_height(leaf_index)
@@ -759,8 +756,7 @@ mod mmr_membership_proof_test {
         for (leaf_index, expected_peak_index) in
             (0..mmr_size as u64).zip(expected_peak_indices_and_heights.into_iter())
         {
-            let (membership_proof, _peaks): (MmrMembershipProof<H>, Vec<Digest>) =
-                archival_mmr.prove_membership(leaf_index);
+            let membership_proof = archival_mmr.prove_membership(leaf_index);
             assert_eq!(
                 expected_peak_index,
                 membership_proof.get_peak_index_and_height(leaf_index)
@@ -778,7 +774,7 @@ mod mmr_membership_proof_test {
         let peaks = archival_mmr.get_peaks();
         for (i, leaf) in leafs.into_iter().enumerate() {
             let leaf_index = i as u64;
-            let mp = archival_mmr.prove_membership(leaf_index).0;
+            let mp = archival_mmr.prove_membership(leaf_index);
             assert!(mp.verify(leaf_index, leaf, &peaks, leaf_count as u64));
             let bad_leaf_index = leaf_index + leaf_count as u64;
             assert!(!mp.verify(bad_leaf_index, leaf, &peaks, leaf_count as u64));
@@ -795,13 +791,13 @@ mod mmr_membership_proof_test {
         let mut membership_proofs: Vec<MmrMembershipProof<H>> = vec![];
         for i in 0..total_leaf_count {
             let leaf_index = i as u64;
-            membership_proofs.push(archival_mmr.prove_membership(leaf_index).0);
+            membership_proofs.push(archival_mmr.prove_membership(leaf_index));
         }
 
         let new_leaf2: Digest = H::hash(&133337u64);
         let new_leaf3: Digest = H::hash(&12345678u64);
-        let mutation_membership_proof_old2 = archival_mmr.prove_membership(2).0;
-        let mutation_membership_proof_old3 = archival_mmr.prove_membership(3).0;
+        let mutation_membership_proof_old2 = archival_mmr.prove_membership(2);
+        let mutation_membership_proof_old3 = archival_mmr.prove_membership(3);
         archival_mmr.mutate_leaf_raw(2, new_leaf2);
         archival_mmr.mutate_leaf_raw(3, new_leaf3);
         for (mp_leaf_index, mp) in membership_proofs.iter_mut().enumerate() {
@@ -842,7 +838,7 @@ mod mmr_membership_proof_test {
         let mp_leaf_indices = 0..total_leaf_count as u64;
         let mut membership_proofs: Vec<MmrMembershipProof<H>> = mp_leaf_indices
             .clone()
-            .map(|leaf_index| archival_mmr_init.prove_membership(leaf_index).0)
+            .map(|leaf_index| archival_mmr_init.prove_membership(leaf_index))
             .collect();
         let membership_proofs_clone = membership_proofs.clone();
         let leaf_mutations: Vec<LeafMutation<H>> = leaf_hashes_final
@@ -897,7 +893,7 @@ mod mmr_membership_proof_test {
             let mut own_membership_proofs: Vec<MmrMembershipProof<H>> = vec![];
             for _ in 0..own_membership_proof_count {
                 let leaf_index = all_leaf_indices.remove(rng.gen_range(0..all_leaf_indices.len()));
-                own_membership_proofs.push(archival_mmr.prove_membership(leaf_index).0);
+                own_membership_proofs.push(archival_mmr.prove_membership(leaf_index));
                 own_mp_leaf_indices.push(leaf_index);
             }
 
@@ -910,7 +906,7 @@ mod mmr_membership_proof_test {
             for _ in 0..modified_leaf_count {
                 let leaf_index =
                     all_leaf_indices_new.remove(rng.gen_range(0..all_leaf_indices_new.len()));
-                authentication_paths.push(archival_mmr.prove_membership(leaf_index).0);
+                authentication_paths.push(archival_mmr.prove_membership(leaf_index));
                 mutated_leaf_leaf_indices.push(leaf_index);
             }
 
@@ -1025,7 +1021,7 @@ mod mmr_membership_proof_test {
         let mut membership_proofs: Vec<MmrMembershipProof<H>> = vec![];
         for i in 0..total_leaf_count {
             let leaf_index = i as u64;
-            membership_proofs.push(archival_mmr.prove_membership(leaf_index).0);
+            membership_proofs.push(archival_mmr.prove_membership(leaf_index));
         }
         (leaf_hashes, membership_proofs)
     }
@@ -1042,7 +1038,7 @@ mod mmr_membership_proof_test {
         let mut own_mp_leaf_indices = vec![];
         for i in 0..modified_leaf_count {
             let leaf_index = i as u64;
-            membership_proofs.push(archival_mmr.prove_membership(leaf_index).0);
+            membership_proofs.push(archival_mmr.prove_membership(leaf_index));
             own_mp_leaf_indices.push(leaf_index);
         }
 
@@ -1091,14 +1087,13 @@ mod mmr_membership_proof_test {
         let original_archival_mmr: MockMmr<H> = get_mock_ammr_from_digests(leaf_hashes.clone());
 
         let own_leaf_leaf_index = 4;
-        let (mut membership_proof, _peaks): (MmrMembershipProof<H>, Vec<Digest>) =
-            an_archival_mmr.prove_membership(own_leaf_leaf_index);
+        let mut membership_proof = an_archival_mmr.prove_membership(own_leaf_leaf_index);
 
         // 1. Update a leaf in both the accumulator MMR and in the archival MMR
         let old_peaks = an_archival_mmr.get_peaks();
         let mutated_leaf_leaf_index = 2;
         let membership_proof_for_manipulated_leaf =
-            an_archival_mmr.prove_membership(mutated_leaf_leaf_index).0;
+            an_archival_mmr.prove_membership(mutated_leaf_leaf_index);
         an_archival_mmr.mutate_leaf_raw(mutated_leaf_leaf_index, new_leaf);
 
         let leaf_mutation = LeafMutation::new(
@@ -1115,8 +1110,9 @@ mod mmr_membership_proof_test {
             "Peaks must change when leaf is mutated"
         );
 
-        let (real_membership_proof_from_archival, archival_peaks) =
+        let real_membership_proof_from_archival =
             an_archival_mmr.prove_membership(own_leaf_leaf_index);
+        let archival_peaks = an_archival_mmr.get_peaks();
         assert_eq!(
             new_peaks_1, archival_peaks,
             "peaks returned from `get_peaks` must match that returned with membership proof"
@@ -1160,11 +1156,10 @@ mod mmr_membership_proof_test {
             let mut mps: Vec<MmrMembershipProof<H>> = vec![];
 
             for j in all_leaf_indices.iter() {
-                mps.push(original_archival_mmr.prove_membership(*j).0);
+                mps.push(original_archival_mmr.prove_membership(*j));
             }
             let original_mps = mps.clone();
-            let leaf_mutation_membership_proof =
-                archival_mmr.prove_membership(*leaf_index_mutated).0;
+            let leaf_mutation_membership_proof = archival_mmr.prove_membership(*leaf_index_mutated);
             archival_mmr.mutate_leaf_raw(*leaf_index_mutated, new_leaf);
             let new_peaks_2 = archival_mmr.get_peaks();
             let new_leaf_mutation = LeafMutation::new(
@@ -1228,10 +1223,7 @@ mod mmr_membership_proof_test {
             // Loop over all leaf indices that we want to modify in the MMR
             for i in 0..leaf_count {
                 let leaf_index_i = i as u64;
-                let (leaf_mutation_membership_proof, _old_peaks): (
-                    MmrMembershipProof<H>,
-                    Vec<Digest>,
-                ) = archival_mmr.prove_membership(leaf_index_i);
+                let leaf_mutation_membership_proof = archival_mmr.prove_membership(leaf_index_i);
                 let mut modified_archival_mmr: MockMmr<H> =
                     get_mock_ammr_from_digests(leaf_hashes.clone());
                 modified_archival_mmr.mutate_leaf_raw(leaf_index_i, new_leaf);
@@ -1241,7 +1233,7 @@ mod mmr_membership_proof_test {
                 for j in 0..leaf_count {
                     let leaf_index_j = j as u64;
                     let mut membership_proof: MmrMembershipProof<H> =
-                        archival_mmr.prove_membership(leaf_index_j).0;
+                        archival_mmr.prove_membership(leaf_index_j);
                     let original_membership_roof = membership_proof.clone();
                     let leaf_mutation =
                         LeafMutation::new(leaf_index_i, new_leaf, &leaf_mutation_membership_proof);
@@ -1272,7 +1264,7 @@ mod mmr_membership_proof_test {
                     // Verify that modified membership proof matches that which can be
                     // fetched from the modified archival MMR
                     assert_eq!(
-                        modified_archival_mmr.prove_membership(leaf_index_j).0,
+                        modified_archival_mmr.prove_membership(leaf_index_j),
                         membership_proof
                     );
                 }
@@ -1345,8 +1337,8 @@ mod mmr_membership_proof_test {
 
         for i in 0..leaf_count {
             let leaf_index = i as u64;
-            let (mut membership_proof, old_peaks): (MmrMembershipProof<H>, Vec<Digest>) =
-                archival_mmr.prove_membership(leaf_index);
+            let mut membership_proof = archival_mmr.prove_membership(leaf_index);
+            let old_peaks = archival_mmr.get_peaks();
             let mut appended_archival_mmr: MockMmr<H> =
                 get_mock_ammr_from_digests(leaf_hashes.clone());
             // let mut appended_archival_mmr = archival_mmr.clone();
@@ -1375,7 +1367,7 @@ mod mmr_membership_proof_test {
             // as the one we got by updating the old membership proof
             assert_eq!(
                 appended_archival_mmr.prove_membership(leaf_index),
-                (membership_proof, new_peaks)
+                membership_proof
             );
         }
     }
@@ -1399,13 +1391,17 @@ mod mmr_membership_proof_test {
                 let new_peaks = appended_archival_mmr.get_peaks();
 
                 // 3. Create membership proof for MockMmr from before `new_leaf_digest`
-                let (original_membership_proof, original_peaks) =
-                    archival_mmr.prove_membership(leaf_index);
+                let original_membership_proof = archival_mmr.prove_membership(leaf_index);
 
                 // 4. Update (a copy of) membership proof and verify it
                 let mut updated_membership_proof = original_membership_proof.clone();
                 let is_updated_membership_proof_changed = updated_membership_proof
-                    .update_from_append(leaf_index, leaf_count, new_leaf_digest, &original_peaks);
+                    .update_from_append(
+                        leaf_index,
+                        leaf_count,
+                        new_leaf_digest,
+                        &archival_mmr.get_peaks(),
+                    );
 
                 let updated_membership_proof_verifies = updated_membership_proof.verify(
                     leaf_index,
@@ -1429,8 +1425,10 @@ mod mmr_membership_proof_test {
                 }
 
                 // 6. Assert that updating an old membership proof is equivalent to getting a proof for an appended MockMmr
-                let expected = (updated_membership_proof, new_peaks);
-                assert_eq!(expected, appended_archival_mmr.prove_membership(leaf_index));
+                assert_eq!(
+                    updated_membership_proof,
+                    appended_archival_mmr.prove_membership(leaf_index)
+                );
             }
 
             // 7. Test batch update of membership proofs...
@@ -1438,7 +1436,7 @@ mod mmr_membership_proof_test {
             let mp_leaf_indices = (0..leaf_count).collect_vec();
             let original_membership_proofs = mp_leaf_indices
                 .iter()
-                .map(|leaf_index| archival_mmr.prove_membership(*leaf_index).0)
+                .map(|leaf_index| archival_mmr.prove_membership(*leaf_index))
                 .collect_vec();
 
             // ...first by asserting that all leaves are members...
@@ -1520,8 +1518,7 @@ mod mmr_membership_proof_test {
             for i in 0..leaf_count {
                 let leaf_index = i as u64;
                 let leaf_count_index = leaf_count as u64;
-                let (original_membership_proof, old_peaks): (MmrMembershipProof<H>, Vec<Digest>) =
-                    archival_mmr.prove_membership(leaf_index);
+                let original_membership_proof = archival_mmr.prove_membership(leaf_index);
                 let mut appended_archival_mmr: MockMmr<H> =
                     get_mock_ammr_from_digests(leaf_hashes.clone());
                 appended_archival_mmr.append(new_leaf);
@@ -1533,7 +1530,7 @@ mod mmr_membership_proof_test {
                     leaf_index,
                     leaf_count_index,
                     new_leaf,
-                    &old_peaks,
+                    &archival_mmr.get_peaks(),
                 );
                 assert!(membership_proof_mutated.verify(
                     leaf_index,
@@ -1556,7 +1553,7 @@ mod mmr_membership_proof_test {
                 // as the one we got by updating the old membership proof
                 assert_eq!(
                     appended_archival_mmr.prove_membership(leaf_index),
-                    (membership_proof_mutated, new_peaks)
+                    membership_proof_mutated
                 );
             }
         }
@@ -1573,7 +1570,7 @@ mod mmr_membership_proof_test {
         let leaf_count = 3;
         let leaf_hashes: Vec<Digest> = random_elements(leaf_count);
         let archival_mmr: MockMmr<H> = get_mock_ammr_from_digests(leaf_hashes.clone());
-        let mp: MmrMembershipProof<H> = archival_mmr.prove_membership(1).0;
+        let mp: MmrMembershipProof<H> = archival_mmr.prove_membership(1);
         let json = serde_json::to_string(&mp).unwrap();
         let s_back = serde_json::from_str::<MmrMembershipProof<H>>(&json).unwrap();
         assert!(s_back.verify(
@@ -1593,7 +1590,7 @@ mod mmr_membership_proof_test {
             let leaf_hashes = random_elements(num_leafs);
             let archival_mmr = get_mock_ammr_from_digests::<H>(leaf_hashes);
             let leaf_index = (rng.next_u32() as usize % num_leafs) as u64;
-            let mp = archival_mmr.prove_membership(leaf_index).0;
+            let mp = archival_mmr.prove_membership(leaf_index);
             let mp_encoded = mp.encode();
             let mp_decoded = *MmrMembershipProof::decode(&mp_encoded).unwrap();
             assert_eq!(mp, mp_decoded);

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -171,7 +171,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
 
         // 4 Get node indices of missing digests
         let new_peak_index: u64 = *added_node_indices.last().unwrap();
-        let new_node_count: u64 = shared_advanced::leaf_count_to_node_count(old_mmr_leaf_count + 1);
+        let new_node_count: u64 = shared_advanced::num_leafs_to_num_nodes(old_mmr_leaf_count + 1);
         let node_indices_for_missing_digests: Vec<u64> =
             shared_advanced::get_authentication_path_node_indices(
                 own_old_peak_index,
@@ -297,7 +297,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
         // Loop over all membership proofs and insert missing hashes for each
         let mut modified: Vec<usize> = vec![];
         let new_peak_index: u64 = *added_node_indices.last().unwrap();
-        let new_node_count: u64 = shared_advanced::leaf_count_to_node_count(old_leaf_count + 1);
+        let new_node_count: u64 = shared_advanced::num_leafs_to_num_nodes(old_leaf_count + 1);
         for (i, (membership_proof, mp_leaf_index)) in membership_proofs
             .iter_mut()
             .zip(membership_proof_leaf_indices)
@@ -556,7 +556,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
             let former_value = new_ap_digests.insert(node_index, new_leaf);
             assert!(
                 former_value.is_none(),
-                "Duplicated leaves are not allowed in membership proof updater"
+                "Duplicated leafs are not allowed in membership proof updater"
             );
             let mut acc_hash: Digest = new_leaf.to_owned();
 
@@ -615,7 +615,7 @@ impl<H: AlgebraicHasher> MmrMembershipProof<H> {
                 .zip(ap_indices.into_iter())
             {
                 // Any number of hashes can be updated in the authentication path, since
-                // we're modifying multiple leaves in the MMR
+                // we're modifying multiple leafs in the MMR
                 // Since this function returns the indices of the modified membership proofs,
                 // a check if the new digest is actually different from the previous value is
                 // needed.
@@ -824,7 +824,7 @@ mod mmr_membership_proof_test {
                 mp_leaf_index as u64,
                 leaf_hash,
                 &archival_mmr.peaks(),
-                archival_mmr.num_leaves(),
+                archival_mmr.num_leafs(),
             );
         }
     }
@@ -955,7 +955,7 @@ mod mmr_membership_proof_test {
                         own_leaf_index,
                         leaf_hashes[own_leaf_index as usize],
                         &archival_mmr.peaks(),
-                        archival_mmr.num_leaves(),
+                        archival_mmr.num_leafs(),
                     ));
                 });
         }
@@ -1072,7 +1072,7 @@ mod mmr_membership_proof_test {
                 mp_leaf_idx,
                 new_leafs[i],
                 &archival_mmr.peaks(),
-                archival_mmr.num_leaves()
+                archival_mmr.num_leafs()
             ));
         }
     }
@@ -1085,7 +1085,7 @@ mod mmr_membership_proof_test {
         let new_leaf: Digest = H::hash(&133337u64);
         let mut accumulator_mmr = MmrAccumulator::<H>::new(leaf_hashes.clone());
 
-        assert_eq!(8, accumulator_mmr.num_leaves());
+        assert_eq!(8, accumulator_mmr.num_leafs());
         let mut an_archival_mmr: MockMmr<H> = get_mock_ammr_from_digests(leaf_hashes.clone());
         let original_archival_mmr: MockMmr<H> = get_mock_ammr_from_digests(leaf_hashes.clone());
 
@@ -1126,19 +1126,19 @@ mod mmr_membership_proof_test {
             own_leaf_leaf_index,
             new_leaf,
             &new_peaks_1,
-            accumulator_mmr.num_leaves()
+            accumulator_mmr.num_leafs()
         ));
         assert!(membership_proof.verify(
             own_leaf_leaf_index,
             leaf_hashes[own_leaf_leaf_index as usize],
             &old_peaks,
-            accumulator_mmr.num_leaves()
+            accumulator_mmr.num_leafs()
         ));
         assert!(real_membership_proof_from_archival.verify(
             own_leaf_leaf_index,
             leaf_hashes[own_leaf_leaf_index as usize],
             &new_peaks_1,
-            accumulator_mmr.num_leaves()
+            accumulator_mmr.num_leafs()
         ));
 
         // 3. Update the membership proof with the membership method
@@ -1149,7 +1149,7 @@ mod mmr_membership_proof_test {
             own_leaf_leaf_index,
             leaf_hashes[own_leaf_leaf_index as usize],
             &new_peaks_1,
-            accumulator_mmr.num_leaves()
+            accumulator_mmr.num_leafs()
         ));
 
         // 5. test batch update from leaf update
@@ -1308,7 +1308,7 @@ mod mmr_membership_proof_test {
                 *leaf_index,
                 *leaf,
                 &mmra.peaks(),
-                mmra.num_leaves()
+                mmra.num_leafs()
             )));
         MmrMembershipProof::batch_update_from_append(
             &mut mps.iter_mut().collect_vec(),
@@ -1325,7 +1325,7 @@ mod mmr_membership_proof_test {
                 *leaf_index,
                 *leaf,
                 &mmra.peaks(),
-                mmra.num_leaves()
+                mmra.num_leafs()
             )));
     }
 
@@ -1380,7 +1380,7 @@ mod mmr_membership_proof_test {
         type H = Tip5;
 
         for leaf_count in 0..68u64 {
-            // 1. Build a MockMmr with a variable amount of leaves
+            // 1. Build a MockMmr with a variable amount of leafs
             let leaf_digests: Vec<Digest> = random_elements(leaf_count as usize);
             let new_leaf_digest: Digest = rand::thread_rng().gen();
             let archival_mmr: MockMmr<H> = get_mock_ammr_from_digests(leaf_digests.clone());
@@ -1442,7 +1442,7 @@ mod mmr_membership_proof_test {
                 .map(|leaf_index| archival_mmr.prove_membership(*leaf_index))
                 .collect_vec();
 
-            // ...first by asserting that all leaves are members...
+            // ...first by asserting that all leafs are members...
             for (membership_proof, leaf_index) in original_membership_proofs
                 .iter()
                 .zip(mp_leaf_indices.iter())

--- a/twenty-first/src/util_types/mmr/mmr_trait.rs
+++ b/twenty-first/src/util_types/mmr/mmr_trait.rs
@@ -46,7 +46,7 @@ impl<'a, H: AlgebraicHasher> LeafMutation<'a, H> {
 
 pub trait Mmr<H: AlgebraicHasher> {
     /// Create a new MMR instanc from a list of hash digests. The supplied digests
-    /// are the leaves of the MMR.
+    /// are the leafs of the MMR.
 
     // constructors cannot be part of the interface since the archival version requires a
     // database which we want the caller to create, and the accumulator does not need a
@@ -59,11 +59,11 @@ pub trait Mmr<H: AlgebraicHasher> {
     /// the MMR
     fn peaks(&self) -> Vec<Digest>;
 
-    /// Returns `true` iff the MMR has no leaves
+    /// Returns `true` iff the MMR has no leafs
     fn is_empty(&self) -> bool;
 
-    /// Returns the number of leaves in the MMR
-    fn num_leaves(&self) -> u64;
+    /// Returns the number of leafs in the MMR
+    fn num_leafs(&self) -> u64;
 
     /// Append a hash digest to the MMR
     fn append(&mut self, new_leaf: Digest) -> MmrMembershipProof<H>;

--- a/twenty-first/src/util_types/mmr/mmr_trait.rs
+++ b/twenty-first/src/util_types/mmr/mmr_trait.rs
@@ -3,12 +3,14 @@ use super::mmr_membership_proof::MmrMembershipProof;
 use crate::math::digest::Digest;
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
 
-/// A definition of a mutation of a leaf in an MMR
+/// A wrapper for the data needed to change the value of a leaf in an MMR when
+/// only the MMR-accumulator is known, i.e., only the peaks and the leaf-count
+/// are known.
 #[derive(Debug, Clone)]
 pub struct LeafMutation<'a, H: AlgebraicHasher> {
     /// The leaf-index of the leaf being mutated. If the MMR is viewed as a
     /// commitment to a list, then this is simply the (0-indexed) list-index
-    ///  into that list.
+    /// into that list.
     pub leaf_index: u64,
 
     /// The new leaf value, after the mutation has been applied.

--- a/twenty-first/src/util_types/mmr/mmr_trait.rs
+++ b/twenty-first/src/util_types/mmr/mmr_trait.rs
@@ -55,13 +55,13 @@ pub trait Mmr<H: AlgebraicHasher> {
 
     /// Returns the peaks of the MMR, which are roots of the Merkle trees that constitute
     /// the MMR
-    fn get_peaks(&self) -> Vec<Digest>;
+    fn peaks(&self) -> Vec<Digest>;
 
     /// Returns `true` iff the MMR has no leaves
     fn is_empty(&self) -> bool;
 
     /// Returns the number of leaves in the MMR
-    fn count_leaves(&self) -> u64;
+    fn num_leaves(&self) -> u64;
 
     /// Append a hash digest to the MMR
     fn append(&mut self, new_leaf: Digest) -> MmrMembershipProof<H>;

--- a/twenty-first/src/util_types/mmr/shared_advanced.rs
+++ b/twenty-first/src/util_types/mmr/shared_advanced.rs
@@ -84,8 +84,8 @@ pub fn get_height_from_leaf_index(leaf_index: u64) -> u32 {
     (leaf_index + 1).ilog2()
 }
 
-/// The number of nodes in an MMR with `leaf_count` leaves.
-pub fn leaf_count_to_node_count(leaf_count: u64) -> u64 {
+/// The number of nodes in an MMR with `leaf_count` leafs.
+pub fn num_leafs_to_num_nodes(leaf_count: u64) -> u64 {
     let hamming_weight = leaf_count.count_ones() as u64;
     2 * leaf_count - hamming_weight
 }
@@ -181,7 +181,7 @@ pub fn get_peak_heights_and_peak_node_indices(leaf_count: u64) -> (Vec<u32>, Vec
     }
 
     let node_index_of_rightmost_leaf = leaf_index_to_node_index(leaf_count - 1);
-    let node_count = leaf_count_to_node_count(leaf_count);
+    let node_count = num_leafs_to_num_nodes(leaf_count);
     let (mut top_peak, mut top_height) = leftmost_ancestor(node_index_of_rightmost_leaf);
     if top_peak > node_count {
         top_peak = left_child(top_peak, top_height);
@@ -456,7 +456,7 @@ mod mmr_test {
             42, 46, 47, 49, 50, 53, 54, 56, 57, 63, 64,
         ];
         for (i, node_count) in node_counts.iter().enumerate() {
-            assert_eq!(*node_count, leaf_count_to_node_count(i as u64));
+            assert_eq!(*node_count, num_leafs_to_num_nodes(i as u64));
         }
     }
 

--- a/twenty-first/src/util_types/mmr/shared_basic.rs
+++ b/twenty-first/src/util_types/mmr/shared_basic.rs
@@ -81,7 +81,7 @@ pub fn calculate_new_peaks_from_append<H: AlgebraicHasher>(
     let mut peaks = old_peaks;
     peaks.push(new_leaf);
     let mut right_lineage_count = right_lineage_length_from_leaf_index(old_leaf_count);
-    let mut membership_proof = MmrMembershipProof::<H>::new(old_leaf_count, vec![]);
+    let mut membership_proof = MmrMembershipProof::<H>::new(vec![]);
     while right_lineage_count != 0 {
         let new_hash = peaks.pop().unwrap();
         let previous_peak = peaks.pop().unwrap();
@@ -98,12 +98,13 @@ pub fn calculate_new_peaks_from_append<H: AlgebraicHasher>(
 /// than `old_peaks`
 pub fn calculate_new_peaks_from_leaf_mutation<H: AlgebraicHasher>(
     old_peaks: &[Digest],
-    new_leaf: Digest,
     leaf_count: u64,
+    new_leaf: Digest,
+    leaf_index: u64,
     membership_proof: &MmrMembershipProof<H>,
 ) -> Vec<Digest> {
     let (mut acc_mt_index, peak_index) =
-        leaf_index_to_mt_index_and_peak_index(membership_proof.leaf_index, leaf_count);
+        leaf_index_to_mt_index_and_peak_index(leaf_index, leaf_count);
     let mut acc_hash: Digest = new_leaf.to_owned();
     let mut i = 0;
     while acc_mt_index != 1 {


### PR DESCRIPTION
- Remove leaf-index from MMR's `MmrMembershipProof`
- Add struct `LeafMutation` for encapsulating the data required to mutate a leaf in an MMR-accumulator
- Change return type of archival-version of MMR (here called `MockMmr`) to only return an MMR membership proof, not the membership proof, *and* the peaks
- change MMR trait method name from `get_peaks` to `peaks`
- change MMR trait method name from `count_leaves` to `num_leaves`.

Not addressed:
Simplification of tests. The tests are very thorough but there is a lot of repetition in them. The number of tests can probably be halved without affecting test coverage negatively.