### PR TITLE
Remove generic from MerkleTree

### DIFF
--- a/twenty-first/benches/coset_extrapolation.rs
+++ b/twenty-first/benches/coset_extrapolation.rs
@@ -2,7 +2,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 

--- a/twenty-first/benches/evaluation.rs
+++ b/twenty-first/benches/evaluation.rs
@@ -2,7 +2,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::math::zerofier_tree::ZerofierTree;
 use twenty_first::prelude::*;

--- a/twenty-first/benches/extrapolation.rs
+++ b/twenty-first/benches/extrapolation.rs
@@ -2,7 +2,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-
 use twenty_first::math::ntt::intt;
 use twenty_first::math::other::random_elements;
 use twenty_first::math::traits::PrimitiveRootOfUnity;

--- a/twenty-first/benches/formal_power_series_inverse.rs
+++ b/twenty-first/benches/formal_power_series_inverse.rs
@@ -2,7 +2,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 

--- a/twenty-first/benches/interpolation.rs
+++ b/twenty-first/benches/interpolation.rs
@@ -3,7 +3,6 @@ use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 

--- a/twenty-first/benches/inverses.rs
+++ b/twenty-first/benches/inverses.rs
@@ -1,4 +1,7 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
 use itertools::Itertools;
 use twenty_first::math::b_field_element::BFieldElement;
 use twenty_first::math::other::random_elements;

--- a/twenty-first/benches/merkle_tree.rs
+++ b/twenty-first/benches/merkle_tree.rs
@@ -7,12 +7,10 @@ use criterion::Criterion;
 
 use twenty_first::math::digest::Digest;
 use twenty_first::math::other::random_elements;
-use twenty_first::math::tip5::Tip5;
 use twenty_first::util_types::merkle_tree::CpuParallel;
 use twenty_first::util_types::merkle_tree::MerkleTree;
 
 fn merkle_tree(c: &mut Criterion) {
-    type H = Tip5;
     let mut group = c.benchmark_group("merkle_tree");
 
     let exponent = 16;
@@ -23,7 +21,7 @@ fn merkle_tree(c: &mut Criterion) {
     let elements: Vec<Digest> = random_elements(size);
 
     group.bench_function(BenchmarkId::new("merkle_tree", size), |bencher| {
-        bencher.iter(|| MerkleTree::<H>::new::<CpuParallel>(&elements).unwrap());
+        bencher.iter(|| MerkleTree::new::<CpuParallel>(&elements).unwrap());
     });
 }
 

--- a/twenty-first/benches/merkle_tree.rs
+++ b/twenty-first/benches/merkle_tree.rs
@@ -4,7 +4,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-
 use twenty_first::math::digest::Digest;
 use twenty_first::math::other::random_elements;
 use twenty_first::util_types::merkle_tree::CpuParallel;

--- a/twenty-first/benches/merkle_tree_auth_structure_size.rs
+++ b/twenty-first/benches/merkle_tree_auth_structure_size.rs
@@ -11,7 +11,6 @@ use rand::Rng;
 use rand::RngCore;
 use rand::SeedableRng;
 use twenty_first::math::bfield_codec::BFieldCodec;
-
 use twenty_first::math::tip5::Tip5;
 use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;
 use twenty_first::util_types::merkle_tree::CpuParallel;

--- a/twenty-first/benches/merkle_tree_auth_structure_size.rs
+++ b/twenty-first/benches/merkle_tree_auth_structure_size.rs
@@ -76,7 +76,7 @@ fn auth_structure_len(c: &mut Criterion<AuthStructureEncodingLength>) {
     let num_leafs = 1 << tree_height;
     let leafs = (0..num_leafs).map(|_| rng.next_u64()).collect_vec();
     let leaf_digests = leafs.iter().map(Tip5::hash).collect_vec();
-    let mt = MerkleTree::<Tip5>::new::<CpuParallel>(&leaf_digests).unwrap();
+    let mt = MerkleTree::new::<CpuParallel>(&leaf_digests).unwrap();
 
     let num_opened_indices = 40;
     let mut group = c.benchmark_group("merkle_tree_auth_structure_size");

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -1,7 +1,6 @@
 use criterion::*;
 use rand::rngs::StdRng;
 use rand::*;
-
 use twenty_first::math::digest::Digest;
 use twenty_first::math::tip5::Tip5;
 use twenty_first::util_types::algebraic_hasher::AlgebraicHasher;

--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -69,9 +69,9 @@ impl MerkleTreeSampler {
             .collect()
     }
 
-    fn tree(&mut self) -> MerkleTree<Tip5> {
+    fn tree(&mut self) -> MerkleTree {
         let leaf_digests = self.leaf_digests();
-        MerkleTree::<Tip5>::new::<CpuParallel>(&leaf_digests).unwrap()
+        MerkleTree::new::<CpuParallel>(&leaf_digests).unwrap()
     }
 
     fn indices_to_open(&mut self) -> Vec<usize> {
@@ -80,7 +80,7 @@ impl MerkleTreeSampler {
             .collect()
     }
 
-    fn proof(&mut self, tree: &MerkleTree<Tip5>) -> MerkleTreeInclusionProof<Tip5> {
+    fn proof(&mut self, tree: &MerkleTree) -> MerkleTreeInclusionProof {
         let leaf_indices = self.indices_to_open();
         tree.inclusion_proof_for_leaf_indices(&leaf_indices)
             .unwrap()

--- a/twenty-first/benches/ntt_forward.rs
+++ b/twenty-first/benches/ntt_forward.rs
@@ -1,7 +1,10 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
 use criterion::measurement::WallTime;
-use criterion::{
-    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
-};
+use criterion::BenchmarkGroup;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
 use twenty_first::math::b_field_element::BFieldElement;
 use twenty_first::math::ntt::ntt;
 use twenty_first::math::other::random_elements;

--- a/twenty-first/benches/poly_clean_div.rs
+++ b/twenty-first/benches/poly_clean_div.rs
@@ -2,7 +2,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 

--- a/twenty-first/benches/poly_mod_reduce.rs
+++ b/twenty-first/benches/poly_mod_reduce.rs
@@ -2,7 +2,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 

--- a/twenty-first/benches/poly_mul.rs
+++ b/twenty-first/benches/poly_mul.rs
@@ -2,7 +2,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 

--- a/twenty-first/benches/poly_scalar_mul.rs
+++ b/twenty-first/benches/poly_scalar_mul.rs
@@ -3,7 +3,6 @@ use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use rand::random;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 

--- a/twenty-first/benches/poly_scale.rs
+++ b/twenty-first/benches/poly_scale.rs
@@ -3,7 +3,6 @@ use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use rand::random;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 

--- a/twenty-first/benches/polynomial_coset.rs
+++ b/twenty-first/benches/polynomial_coset.rs
@@ -3,7 +3,6 @@ use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
-
 use twenty_first::math::b_field_element::BFieldElement;
 use twenty_first::math::other::random_elements;
 use twenty_first::math::polynomial::Polynomial;

--- a/twenty-first/benches/tip5.rs
+++ b/twenty-first/benches/tip5.rs
@@ -4,7 +4,6 @@ use criterion::BenchmarkId;
 use criterion::Criterion;
 use rand::random;
 use rayon::prelude::*;
-
 use twenty_first::math::other::random_elements;
 use twenty_first::prelude::*;
 

--- a/twenty-first/benches/various_muls.rs
+++ b/twenty-first/benches/various_muls.rs
@@ -7,7 +7,6 @@ use criterion::BenchmarkGroup;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
-
 use twenty_first::math::b_field_element::BFieldElement;
 use twenty_first::math::other::random_elements;
 use twenty_first::math::x_field_element::XFieldElement;

--- a/twenty-first/benches/zerofier.rs
+++ b/twenty-first/benches/zerofier.rs
@@ -2,7 +2,6 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::BenchmarkId;
 use criterion::Criterion;
-
 use twenty_first::math::b_field_element::BFieldElement;
 use twenty_first::math::other::random_elements;
 use twenty_first::math::polynomial::Polynomial;

--- a/twenty-first/src/amount/u32s.rs
+++ b/twenty-first/src/amount/u32s.rs
@@ -390,9 +390,8 @@ mod u32s_tests {
     use rand::Rng;
     use rand::RngCore;
 
-    use crate::math::other::random_elements;
-
     use super::*;
+    use crate::math::other::random_elements;
 
     #[test]
     fn get_size_test() {

--- a/twenty-first/src/lib.rs
+++ b/twenty-first/src/lib.rs
@@ -52,8 +52,8 @@ pub(crate) mod tests {
         implements_usual_auto_traits::<Tip5>();
         implements_usual_auto_traits::<XFieldElement>();
         implements_usual_auto_traits::<CpuParallel>();
-        implements_usual_auto_traits::<MerkleTree<Tip5>>();
-        implements_usual_auto_traits::<MerkleTreeInclusionProof<Tip5>>();
+        implements_usual_auto_traits::<MerkleTree>();
+        implements_usual_auto_traits::<MerkleTreeInclusionProof>();
         implements_usual_auto_traits::<MmrMembershipProof>();
     }
 

--- a/twenty-first/src/math/b_field_element.rs
+++ b/twenty-first/src/math/b_field_element.rs
@@ -29,15 +29,14 @@ use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
 
+use super::traits::Inverse;
+use super::traits::PrimitiveRootOfUnity;
+use super::x_field_element::XFieldElement;
 use crate::error::ParseBFieldElementError;
 use crate::math::traits::CyclicGroupGenerator;
 use crate::math::traits::FiniteField;
 use crate::math::traits::ModPowU32;
 use crate::math::traits::ModPowU64;
-
-use super::traits::Inverse;
-use super::traits::PrimitiveRootOfUnity;
-use super::x_field_element::XFieldElement;
 
 const PRIMITIVE_ROOTS: phf::Map<u64, u64> = phf_map! {
     0u64 => 1,

--- a/twenty-first/src/math/bfield_codec.rs
+++ b/twenty-first/src/math/bfield_codec.rs
@@ -13,11 +13,10 @@ use num_traits::ConstOne;
 use num_traits::ConstZero;
 use thiserror::Error;
 
-use crate::bfe_vec;
-
 use super::b_field_element::BFieldElement;
 use super::polynomial::Polynomial;
 use super::traits::FiniteField;
+use crate::bfe_vec;
 
 /// This trait provides functions for encoding to and decoding from a Vec of [BFieldElement]s.
 /// This encoding does not record the size of objects nor their type information; this is
@@ -547,9 +546,8 @@ mod tests {
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
 
-    use crate::prelude::*;
-
     use super::*;
+    use crate::prelude::*;
 
     #[derive(Debug, PartialEq, Eq, test_strategy::Arbitrary)]
     struct BFieldCodecPropertyTestData<T>
@@ -834,14 +832,13 @@ mod tests {
         use arbitrary::Arbitrary;
         use num_traits::Zero;
 
+        use super::*;
         use crate::math::digest::Digest;
         use crate::math::tip5::Tip5;
         use crate::math::x_field_element::XFieldElement;
         use crate::util_types::algebraic_hasher::AlgebraicHasher;
         use crate::util_types::mmr::mmr_accumulator::MmrAccumulator;
         use crate::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
-
-        use super::*;
 
         #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec, Arbitrary)]
         struct UnitStruct;

--- a/twenty-first/src/math/digest.rs
+++ b/twenty-first/src/math/digest.rs
@@ -325,9 +325,8 @@ pub(crate) mod digest_tests {
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
 
-    use crate::prelude::*;
-
     use super::*;
+    use crate::prelude::*;
 
     impl ProptestArbitrary for Digest {
         type Parameters = ();

--- a/twenty-first/src/math/lattice.rs
+++ b/twenty-first/src/math/lattice.rs
@@ -639,13 +639,12 @@ pub mod kem {
     use sha3::Sha3_256;
     use sha3::Shake256;
 
-    use crate::math::b_field_element::BFieldElement;
-
     use super::embed_msg;
     use super::extract_msg;
     use super::CyclotomicRingElement;
     use super::ModuleElement;
     use super::CYCLOTOMIC_RING_ELEMENT_SIZE_IN_BFES;
+    use crate::math::b_field_element::BFieldElement;
 
     #[derive(PartialEq, Eq, Copy, Clone, Debug, Serialize, Deserialize)]
     pub struct SecretKey {
@@ -824,14 +823,13 @@ mod lattice_test {
     use sha3::Digest as Sha3Digest;
     use sha3::Sha3_256;
 
+    use super::kem::shake256;
+    use super::kem::SecretKey;
+    use super::kem::CIPHERTEXT_SIZE_IN_BFES;
     use crate::math::b_field_element::BFieldElement;
     use crate::math::lattice::kem::Ciphertext;
     use crate::math::lattice::kem::PublicKey;
     use crate::math::lattice::*;
-
-    use super::kem::shake256;
-    use super::kem::SecretKey;
-    use super::kem::CIPHERTEXT_SIZE_IN_BFES;
 
     #[test]
     fn test_kats() {

--- a/twenty-first/src/math/mds.rs
+++ b/twenty-first/src/math/mds.rs
@@ -498,7 +498,8 @@ pub fn generated_function(input: &[u64]) -> [u64; 16] {
 #[cfg(test)]
 mod tests {
     use itertools::Itertools;
-    use rand::{thread_rng, RngCore};
+    use rand::thread_rng;
+    use rand::RngCore;
 
     use super::*;
 

--- a/twenty-first/src/math/ntt.rs
+++ b/twenty-first/src/math/ntt.rs
@@ -273,13 +273,12 @@ mod fast_ntt_attempt_tests {
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
 
+    use super::*;
     use crate::math::other::random_elements;
     use crate::math::traits::PrimitiveRootOfUnity;
     use crate::math::x_field_element::EXTENSION_DEGREE;
     use crate::prelude::*;
     use crate::xfe;
-
-    use super::*;
 
     #[test]
     fn chu_ntt_b_field_prop_test() {

--- a/twenty-first/src/math/polynomial.rs
+++ b/twenty-first/src/math/polynomial.rs
@@ -23,6 +23,8 @@ use num_traits::One;
 use num_traits::Zero;
 use rayon::prelude::*;
 
+use super::traits::PrimitiveRootOfUnity;
+use super::zerofier_tree::ZerofierTree;
 use crate::math::ntt::intt;
 use crate::math::ntt::ntt;
 use crate::math::traits::FiniteField;
@@ -30,9 +32,6 @@ use crate::math::traits::ModPowU32;
 use crate::prelude::BFieldElement;
 use crate::prelude::Inverse;
 use crate::prelude::XFieldElement;
-
-use super::traits::PrimitiveRootOfUnity;
-use super::zerofier_tree::ZerofierTree;
 
 impl<FF: FiniteField> Zero for Polynomial<FF> {
     fn zero() -> Self {
@@ -2408,9 +2407,8 @@ mod test_polynomials {
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
 
-    use crate::prelude::*;
-
     use super::*;
+    use crate::prelude::*;
 
     impl proptest::arbitrary::Arbitrary for Polynomial<BFieldElement> {
         type Parameters = ();

--- a/twenty-first/src/math/tip5.rs
+++ b/twenty-first/src/math/tip5.rs
@@ -624,10 +624,9 @@ pub(crate) mod tip5_tests {
     use rayon::prelude::ParallelIterator;
     use test_strategy::proptest;
 
+    use super::*;
     use crate::math::other::random_elements;
     use crate::math::x_field_element::XFieldElement;
-
-    use super::*;
 
     impl Tip5 {
         pub(crate) fn randomly_seeded() -> Self {

--- a/twenty-first/src/math/x_field_element.rs
+++ b/twenty-first/src/math/x_field_element.rs
@@ -21,6 +21,7 @@ use rand_distr::Standard;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::digest::Digest;
 use crate::bfe_vec;
 use crate::error::TryFromXFieldElementError;
 use crate::math::b_field_element::BFieldElement;
@@ -31,8 +32,6 @@ use crate::math::traits::Inverse;
 use crate::math::traits::ModPowU32;
 use crate::math::traits::ModPowU64;
 use crate::math::traits::PrimitiveRootOfUnity;
-
-use super::digest::Digest;
 
 pub const EXTENSION_DEGREE: usize = 3;
 

--- a/twenty-first/src/mock/mmr/mock_mmr.rs
+++ b/twenty-first/src/mock/mmr/mock_mmr.rs
@@ -399,7 +399,7 @@ mod mmr_test {
             let num_leafs_in_tree = 1 << tree_height;
             let leaf_digests =
                 &digests[num_processed_digests..num_processed_digests + num_leafs_in_tree];
-            let tree = MerkleTree::<Tip5>::new::<CpuParallel>(leaf_digests).unwrap();
+            let tree = MerkleTree::new::<CpuParallel>(leaf_digests).unwrap();
             num_processed_digests += num_leafs_in_tree;
             trees.push(tree);
         }

--- a/twenty-first/src/mock/mmr/mock_mmr.rs
+++ b/twenty-first/src/mock/mmr/mock_mmr.rs
@@ -3,14 +3,13 @@ use itertools::Itertools;
 use crate::math::digest::Digest;
 use crate::prelude::Tip5;
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
-use crate::util_types::mmr::mmr_trait::LeafMutation;
-use crate::util_types::shared::bag_peaks;
-
 use crate::util_types::mmr::mmr_accumulator::MmrAccumulator;
 use crate::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
+use crate::util_types::mmr::mmr_trait::LeafMutation;
 use crate::util_types::mmr::mmr_trait::Mmr;
 use crate::util_types::mmr::shared_advanced;
 use crate::util_types::mmr::shared_basic;
+use crate::util_types::shared::bag_peaks;
 
 /// MockMmr is available for feature `mock` and for unit tests.
 ///
@@ -367,22 +366,19 @@ impl<T: Clone> MyVec<T> {
 #[cfg(test)]
 mod mmr_test {
     use itertools::*;
-
     use rand::random;
     use test_strategy::proptest;
 
+    use super::*;
     use crate::math::b_field_element::BFieldElement;
     use crate::math::other::*;
     use crate::math::tip5::Tip5;
-
     use crate::mock::mmr::*;
     use crate::util_types::merkle_tree::merkle_tree_test::MerkleTreeToTest;
     use crate::util_types::merkle_tree::*;
     use crate::util_types::mmr::mmr_accumulator::MmrAccumulator;
     use crate::util_types::mmr::shared_advanced::get_peak_heights;
     use crate::util_types::mmr::shared_advanced::get_peak_heights_and_peak_node_indices;
-
-    use super::*;
 
     impl MockMmr {
         /// Return the number of nodes in all the trees in the MMR

--- a/twenty-first/src/mock/mmr/mod.rs
+++ b/twenty-first/src/mock/mmr/mod.rs
@@ -24,14 +24,14 @@ pub fn get_mock_ammr_from_digests(digests: Vec<Digest>) -> MockMmr {
 #[cfg(test)]
 mod shared_tests_tests {
     use hashbrown::HashSet;
-    use rand::{random, Rng};
+    use itertools::Itertools;
+    use rand::random;
+    use rand::Rng;
 
+    use super::*;
     use crate::math::other::random_elements;
     use crate::util_types::mmr::mmr_accumulator::util::mmra_with_mps;
     use crate::util_types::mmr::mmr_trait::Mmr;
-    use itertools::Itertools;
-
-    use super::*;
 
     #[should_panic]
     #[test]

--- a/twenty-first/src/prelude.rs
+++ b/twenty-first/src/prelude.rs
@@ -18,7 +18,7 @@ pub use crate::util_types::algebraic_hasher::Sponge;
 pub use crate::util_types::merkle_tree::CpuParallel;
 pub use crate::util_types::merkle_tree::MerkleTree;
 pub use crate::util_types::merkle_tree::MerkleTreeInclusionProof;
-pub use crate::util_types::merkle_tree_maker::MerkleTreeMaker;
+pub use crate::util_types::merkle_tree::MerkleTreeMaker;
 pub use crate::util_types::mmr::mmr_membership_proof::MmrMembershipProof;
 pub use crate::util_types::mmr::mmr_trait::Mmr;
 pub use crate::xfe;

--- a/twenty-first/src/util_types.rs
+++ b/twenty-first/src/util_types.rs
@@ -1,5 +1,4 @@
 pub mod algebraic_hasher;
 pub mod merkle_tree;
-pub mod merkle_tree_maker;
 pub mod mmr;
 pub mod shared;

--- a/twenty-first/src/util_types/algebraic_hasher.rs
+++ b/twenty-first/src/util_types/algebraic_hasher.rs
@@ -135,11 +135,10 @@ mod algebraic_hasher_tests {
     use rand_distr::Distribution;
     use rand_distr::Standard;
 
+    use super::*;
     use crate::math::digest::Digest;
     use crate::math::tip5::Tip5;
     use crate::math::x_field_element::EXTENSION_DEGREE;
-
-    use super::*;
 
     fn encode_prop<T>(smallest: T, largest: T)
     where

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -606,11 +606,10 @@ pub mod merkle_tree_test {
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
 
+    use super::*;
     use crate::math::b_field_element::BFieldElement;
     use crate::math::digest::digest_tests::DigestCorruptor;
     use crate::math::tip5::Tip5;
-
-    use super::*;
 
     impl MerkleTree {
         fn test_tree_of_height(tree_height: usize) -> Self {

--- a/twenty-first/src/util_types/merkle_tree_maker.rs
+++ b/twenty-first/src/util_types/merkle_tree_maker.rs
@@ -1,7 +1,0 @@
-use crate::math::digest::Digest;
-use crate::util_types::algebraic_hasher::AlgebraicHasher;
-use crate::util_types::merkle_tree::*;
-
-pub trait MerkleTreeMaker<H: AlgebraicHasher> {
-    fn from_digests(digests: &[Digest]) -> Result<MerkleTree<H>, MerkleTreeError>;
-}

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -7,17 +7,16 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::mmr_membership_proof::MmrMembershipProof;
+use super::mmr_trait::LeafMutation;
+use super::mmr_trait::Mmr;
+use super::shared_basic;
 use crate::math::bfield_codec::BFieldCodec;
 use crate::math::digest::Digest;
 use crate::prelude::Tip5;
 use crate::util_types::algebraic_hasher::AlgebraicHasher;
 use crate::util_types::mmr::shared_advanced;
 use crate::util_types::shared::bag_peaks;
-
-use super::mmr_membership_proof::MmrMembershipProof;
-use super::mmr_trait::LeafMutation;
-use super::mmr_trait::Mmr;
-use super::shared_basic;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, GetSize, BFieldCodec)]
 pub struct MmrAccumulator {
@@ -318,11 +317,10 @@ impl Mmr for MmrAccumulator {
 pub mod util {
     use itertools::Itertools;
 
+    use super::*;
     use crate::math::other::random_elements;
     use crate::util_types::mmr::shared_advanced::right_lineage_length_from_node_index;
     use crate::util_types::mmr::shared_basic::leaf_index_to_mt_index_and_peak_index;
-
-    use super::*;
 
     /// Get an MMR accumulator with a requested number of leafs, and requested leaf digests at specified indices
     /// Also returns the MMR membership proofs for the specified leafs.
@@ -492,13 +490,12 @@ mod accumulator_mmr_tests {
     use rand::RngCore;
     use test_strategy::proptest;
 
+    use super::*;
     use crate::math::b_field_element::BFieldElement;
     use crate::math::other::random_elements;
     use crate::math::tip5::Tip5;
     use crate::mock::mmr::get_mock_ammr_from_digests;
     use crate::mock::mmr::MockMmr;
-
-    use super::*;
 
     impl From<MockMmr> for MmrAccumulator {
         fn from(ammr: MockMmr) -> Self {

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -1,17 +1,23 @@
+use std::collections::hash_map::RandomState;
+use std::collections::hash_set::Intersection;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::iter::FromIterator;
+
 use arbitrary::Arbitrary;
 use get_size::GetSize;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
-use std::collections::hash_map::RandomState;
-use std::collections::hash_set::Intersection;
-use std::collections::{HashMap, HashSet};
-use std::{fmt::Debug, iter::FromIterator};
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::mmr_trait::LeafMutation;
-use super::{shared_advanced, shared_basic};
+use super::shared_advanced;
+use super::shared_basic;
 use crate::math::bfield_codec::BFieldCodec;
 use crate::math::digest::Digest;
-use crate::prelude::{AlgebraicHasher, Tip5};
+use crate::prelude::AlgebraicHasher;
+use crate::prelude::Tip5;
 
 #[derive(Debug, Clone, Serialize, Deserialize, GetSize, BFieldCodec, Arbitrary)]
 pub struct MmrMembershipProof {
@@ -634,19 +640,22 @@ impl MmrMembershipProof {
 mod mmr_membership_proof_test {
     use itertools::Itertools;
     use proptest_arbitrary_interop::arb;
-    use rand::{random, thread_rng, Rng, RngCore};
+    use rand::random;
+    use rand::thread_rng;
+    use rand::Rng;
+    use rand::RngCore;
     use test_strategy::proptest;
 
+    use super::*;
     use crate::math::b_field_element::BFieldElement;
     use crate::math::digest::Digest;
     use crate::math::other::random_elements;
     use crate::math::tip5::Tip5;
-    use crate::mock::mmr::{get_mock_ammr_from_digests, MockMmr};
+    use crate::mock::mmr::get_mock_ammr_from_digests;
+    use crate::mock::mmr::MockMmr;
     use crate::util_types::mmr::mmr_accumulator::util::mmra_with_mps;
     use crate::util_types::mmr::mmr_accumulator::MmrAccumulator;
     use crate::util_types::mmr::mmr_trait::Mmr;
-
-    use super::*;
 
     #[test]
     fn equality_and_hash_test() {

--- a/twenty-first/src/util_types/mmr/mmr_successor_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_successor_proof.rs
@@ -1,16 +1,18 @@
 use bfieldcodec_derive::BFieldCodec;
 use itertools::Itertools;
 
-use crate::{
-    prelude::{AlgebraicHasher, Digest, Mmr, Tip5},
-    util_types::mmr::shared_advanced::{left_sibling, node_indices_added_by_append},
-};
-
-use super::{
-    mmr_accumulator::MmrAccumulator,
-    shared_advanced::{get_peak_heights_and_peak_node_indices, parent, right_sibling},
-    shared_basic::{calculate_new_peaks_from_append, leaf_index_to_mt_index_and_peak_index},
-};
+use super::mmr_accumulator::MmrAccumulator;
+use super::shared_advanced::get_peak_heights_and_peak_node_indices;
+use super::shared_advanced::parent;
+use super::shared_advanced::right_sibling;
+use super::shared_basic::calculate_new_peaks_from_append;
+use super::shared_basic::leaf_index_to_mt_index_and_peak_index;
+use crate::prelude::AlgebraicHasher;
+use crate::prelude::Digest;
+use crate::prelude::Mmr;
+use crate::prelude::Tip5;
+use crate::util_types::mmr::shared_advanced::left_sibling;
+use crate::util_types::mmr::shared_advanced::node_indices_added_by_append;
 
 /// An MmrSuccessorProof asserts that one MMR Accumulator is the descendant of
 /// another, *i.e.*, that the second can be obtained by appending a set of leafs

--- a/twenty-first/tests/bfield_codec_derive.rs
+++ b/twenty-first/tests/bfield_codec_derive.rs
@@ -2,7 +2,6 @@ use arbitrary::Arbitrary;
 use proptest::prelude::*;
 use proptest_arbitrary_interop::arb;
 use test_strategy::proptest;
-
 // Required by the `BFieldCodec` derive macro. This is generally only needed once per crate, at the top-level `lib.rs`.
 #[allow(clippy::single_component_path_imports)]
 use twenty_first;


### PR DESCRIPTION
Previously, a Merkle tree could be built with any hash function implementing the `AlgebraicHasher` trait. Only one such hash function exists in the codebase: Tip5. The primary downstream consumers heavily rely on Tip5 being used when building a Merkle tree. It is not expected that any other hash function will replace Tip5. As a consequence, the generality of `MerkleTree` is considered an unnecessary overhead.