### PR TITLE
Move canon check from `Digest` to `BFieldElement`

### DIFF
--- a/twenty-first/src/error.rs
+++ b/twenty-first/src/error.rs
@@ -14,6 +14,15 @@ pub use crate::util_types::merkle_tree::MerkleTreeError;
 pub enum ParseBFieldElementError {
     #[error("invalid `u64`")]
     ParseU64Error(#[source] <u64 as FromStr>::Err),
+
+    #[error("non-canonical {0} >= {} == `BFieldElement::P`", BFieldElement::P)]
+    NotCanonical(u64),
+
+    #[error(
+        "incorrect number of bytes: {0} != {} == `BFieldElement::BYTES`",
+        BFieldElement::BYTES
+    )]
+    InvalidNumBytes(usize),
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Error)]
@@ -41,9 +50,6 @@ pub enum TryFromDigestError {
 
     #[error("invalid `BFieldElement`")]
     InvalidBFieldElement(#[from] ParseBFieldElementError),
-
-    #[error("non-canonical {0} >= {} == `BFieldElement::P`", BFieldElement::P)]
-    NotCanonical(u64),
 
     #[error("overflow converting to Digest")]
     Overflow,

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -459,15 +459,10 @@ pub mod util {
 
 impl<'a> Arbitrary<'a> for MmrAccumulator {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let mut buffer = [0u8; 8];
-        u.fill_buffer(&mut buffer)?;
-        let num_leafs = u64::from_be_bytes(buffer) >> 1; // num_leafs can be at most 63 bits
-
-        let mut peaks = vec![];
-        for _ in 0..(num_leafs.count_ones()) {
-            let peak = Digest::arbitrary(u)?;
-            peaks.push(peak);
-        }
+        let num_leafs = u.arbitrary::<u64>()? >> 1; // num_leafs can be at most 63 bits
+        let peaks = (0..num_leafs.count_ones())
+            .map(|_| Digest::arbitrary(u))
+            .try_collect()?;
 
         Ok(MmrAccumulator::init(peaks, num_leafs))
     }


### PR DESCRIPTION
- Reject non-canonical `BFieldElement`s when parsing string slices or interpreting byte sequences
- Move canon check of `BFieldElement`s from `Digest` to `BFieldElement`
- Deprecate functionality for platform-dependent endianness when decoding

BREAKING CHANGE: The error variant `NotCanonical` from enum `TryFromDigestError` has moved into enum `ParseBFieldElementError`.

This was described as the cleaner solution in #199, a sentiment I concur with.

Supersedes #206.