### PR TITLE
perf(MmrSuccessorProof): Use shorter auth paths

### DIFF
--- a/twenty-first/src/error.rs
+++ b/twenty-first/src/error.rs
@@ -9,6 +9,11 @@ use crate::prelude::x_field_element::EXTENSION_DEGREE;
 use crate::prelude::BFieldElement;
 pub use crate::util_types::merkle_tree::MerkleTreeError;
 
+pub(crate) const USIZE_TO_U64_ERR: &str =
+    "internal error: type `usize` should have at most 64 bits";
+pub(crate) const U32_TO_USIZE_ERR: &str =
+    "internal error: type `usize` should have at least 32 bits";
+
 #[derive(Debug, Clone, Eq, PartialEq, Error)]
 #[non_exhaustive]
 pub enum ParseBFieldElementError {

--- a/twenty-first/src/util_types/mmr.rs
+++ b/twenty-first/src/util_types/mmr.rs
@@ -4,3 +4,6 @@ pub mod mmr_successor_proof;
 pub mod mmr_trait;
 pub mod shared_advanced;
 pub mod shared_basic;
+
+const TOO_MANY_LEAFS_ERR: &str =
+    "internal error: Merkle Mountain Ranges should have at most 2^63 leafs";

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -7,13 +7,10 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
 
-use super::mmr_membership_proof::MmrMembershipProof;
 use super::mmr_trait::LeafMutation;
-use super::mmr_trait::Mmr;
 use super::shared_basic;
-use crate::math::bfield_codec::BFieldCodec;
-use crate::math::digest::Digest;
-use crate::prelude::Tip5;
+use super::TOO_MANY_LEAFS_ERR;
+use crate::prelude::*;
 use crate::util_types::mmr::shared_advanced;
 use crate::util_types::shared::bag_peaks;
 
@@ -38,6 +35,13 @@ impl MmrAccumulator {
         }
 
         mmra
+    }
+
+    /// Is `self` self-consistent? That is, is it possible to have the claimed
+    /// number of leafs given the number of peaks?
+    pub(crate) fn is_consistent(&self) -> bool {
+        let num_peaks = u32::try_from(self.peaks.len()).expect(TOO_MANY_LEAFS_ERR);
+        num_peaks == self.num_leafs().count_ones()
     }
 }
 

--- a/twenty-first/src/util_types/mmr/mmr_successor_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_successor_proof.rs
@@ -1,338 +1,488 @@
 use arbitrary::Arbitrary;
-use itertools::Itertools;
 
 use super::mmr_accumulator::MmrAccumulator;
-use super::shared_advanced::get_peak_heights_and_peak_node_indices;
-use super::shared_advanced::parent;
-use super::shared_advanced::right_sibling;
-use super::shared_basic::calculate_new_peaks_from_append;
 use super::shared_basic::leaf_index_to_mt_index_and_peak_index;
+use crate::error::USIZE_TO_U64_ERR;
 use crate::prelude::*;
-use crate::util_types::mmr::shared_advanced::left_sibling;
-use crate::util_types::mmr::shared_advanced::node_indices_added_by_append;
 
-/// An MmrSuccessorProof asserts that one MMR Accumulator is the descendant of
-/// another, *i.e.*, that the second can be obtained by appending a set of leafs
-/// to the first. It consists of a set of authentication paths connecting the
-/// old peaks to the new peaks.
+/// Asserts that one [MMR Accumulator] is the descendant of another, *i.e.*,
+/// that the second can be obtained by appending a set of leafs to the first. It
+/// consists of an authentication path connecting the relevant old peaks to the
+/// new peaks.
+///
+/// [MMR Accumulator]: MmrAccumulator
 #[derive(Debug, Clone, BFieldCodec, Arbitrary)]
 pub struct MmrSuccessorProof {
     pub paths: Vec<Digest>,
 }
 
 impl MmrSuccessorProof {
-    /// Compute a new `MmrSuccessorProof` given the starting MMR accumulator and
-    /// a list of digests to be appended.
+    /// Compute a new `MmrSuccessorProof` given the starting MMR accumulator (MMRA)
+    /// and a list of digests to be appended.
     ///
     /// # Panics
     ///
-    ///  - if the number of leafs in the MMRA is greater than or equal to 2^63
+    /// This function will panic if the number of leafs in the MMRA is greater than
+    /// or equal to 2^63.
+    ///
+    /// This function may panic if the passed-in MMRA is inconsistent, that is, has
+    /// fewer peaks than is possible for its claimed number of leafs.
+    //
+    // For an introduction to the inner workings of this function, see
+    // [`Self::verify_internal`].
     pub fn new_from_batch_append(mmra: &MmrAccumulator, new_leafs: &[Digest]) -> Self {
-        let (heights_of_old_peaks, indices_of_old_peaks) =
-            get_peak_heights_and_peak_node_indices(mmra.num_leafs());
-        let (_heights_of_new_peaks, indices_of_new_peaks) =
-            get_peak_heights_and_peak_node_indices(mmra.num_leafs() + new_leafs.len() as u64);
-        let num_old_peaks = heights_of_old_peaks.len();
-
-        let mut needed_indices = vec![vec![]; num_old_peaks];
-        for (i, (index, height)) in indices_of_old_peaks
-            .iter()
-            .copied()
-            .zip(heights_of_old_peaks)
-            .enumerate()
-        {
-            let mut current_index = index;
-            let mut current_height = height;
-            while !indices_of_new_peaks.contains(&current_index) {
-                let mut sibling = right_sibling(current_index, current_height);
-                let parent_index = parent(current_index);
-                if parent(sibling) != parent_index {
-                    sibling = left_sibling(current_index, current_height);
-                };
-                let list_index = needed_indices[i].len();
-                needed_indices[i].push(Some((list_index, sibling)));
-                current_height += 1;
-                current_index = parent_index;
-            }
+        if mmra.num_leafs() == 0 {
+            // any MMR is a successor to the empty MMR – nothing to check, nothing to prove
+            return Self { paths: vec![] };
         }
 
-        let mut current_peaks = mmra.peaks();
-        let mut current_peak_indices = indices_of_old_peaks.clone();
-        let mut current_leaf_count = mmra.num_leafs();
-        let mut paths = needed_indices
-            .iter()
-            .map(|ni| vec![Digest::default(); ni.len()])
-            .collect_vec();
-
-        for &new_leaf in new_leafs {
-            let new_node_indices = node_indices_added_by_append(current_leaf_count);
-
-            let (new_peaks, membership_proof) = calculate_new_peaks_from_append(
-                current_leaf_count,
-                current_peaks.clone(),
-                new_leaf,
-            );
-
-            let (_new_heights, new_peak_indices) =
-                get_peak_heights_and_peak_node_indices(current_leaf_count + 1);
-            let new_nodes = membership_proof
-                .authentication_path
-                .into_iter()
-                .scan(new_leaf, |runner, path_node| {
-                    let yld = *runner;
-                    *runner = Tip5::hash_pair(path_node, *runner);
-                    Some(yld)
-                })
-                .collect_vec();
-
-            for (index, node) in new_node_indices.into_iter().zip(new_nodes).chain(
-                current_peak_indices
-                    .into_iter()
-                    .zip(current_peaks.iter().copied()),
-            ) {
-                for (path, path_indices) in paths.iter_mut().zip(needed_indices.iter_mut()) {
-                    if let Some(wrapped_pair) = path_indices
-                        .iter_mut()
-                        .filter(|maybe| maybe.is_some())
-                        .find(|definitely| definitely.unwrap().1 == index)
-                    {
-                        path[wrapped_pair.unwrap().0] = node;
-                        *wrapped_pair = None;
-                    }
-                }
-            }
-
-            current_peaks = new_peaks;
-            current_peak_indices = new_peak_indices;
-            current_leaf_count += 1;
+        let height_of_lowest_peak = mmra.num_leafs().trailing_zeros();
+        let num_leafs_in_lowest_peak = 1 << height_of_lowest_peak;
+        if new_leafs.len() < num_leafs_in_lowest_peak {
+            // the new leafs do not affect the old peaks
+            return Self { paths: vec![] };
         }
 
-        Self {
-            paths: paths.concat(),
+        let leafs_in_initial_right_tree = &new_leafs[..num_leafs_in_lowest_peak];
+        let initial_right_tree = MerkleTree::new::<CpuParallel>(leafs_in_initial_right_tree)
+            .expect("internal error: should be able to build Merkle tree");
+
+        let num_total_leafs =
+            mmra.num_leafs() + u64::try_from(new_leafs.len()).expect(USIZE_TO_U64_ERR);
+        let first_new_leaf_index = mmra.num_leafs();
+        let (mut merkle_tree_index, _) =
+            leaf_index_to_mt_index_and_peak_index(first_new_leaf_index, num_total_leafs);
+        let height_of_new_peak = merkle_tree_index.ilog2();
+        merkle_tree_index >>= height_of_lowest_peak;
+
+        let mut current_node = initial_right_tree.root();
+        let mut paths = vec![current_node];
+        let mut old_peaks = mmra.peaks().into_iter();
+        let mut first_unused_new_leaf_idx = num_leafs_in_lowest_peak;
+
+        let merkle_tree_root_index = u64::try_from(MerkleTree::ROOT_INDEX).expect(USIZE_TO_U64_ERR);
+        while merkle_tree_index > merkle_tree_root_index {
+            let current_node_is_left_sibling = merkle_tree_index % 2 == 0;
+            current_node = if current_node_is_left_sibling {
+                let current_height = height_of_new_peak - merkle_tree_index.ilog2();
+                let num_leafs_in_right_tree = 1 << current_height;
+                let indices_of_leafs_in_right_tree =
+                    first_unused_new_leaf_idx..first_unused_new_leaf_idx + num_leafs_in_right_tree;
+                let leafs_in_right_tree = &new_leafs[indices_of_leafs_in_right_tree];
+                let right_tree = MerkleTree::new::<CpuParallel>(leafs_in_right_tree)
+                    .expect("internal error: should be able to build Merkle tree");
+                first_unused_new_leaf_idx += num_leafs_in_right_tree;
+
+                paths.push(right_tree.root());
+                Tip5::hash_pair(current_node, right_tree.root())
+            } else {
+                let left_sibling = old_peaks
+                    .next_back()
+                    .expect("Merkle Mountain Range Accumulator should be consistent");
+                Tip5::hash_pair(left_sibling, current_node)
+            };
+            merkle_tree_index /= 2;
         }
+        debug_assert_eq!(merkle_tree_root_index, merkle_tree_index);
+
+        Self { paths }
     }
 
     /// Verify that the `old` [`MmrAccumulator`] is a predecessor of the `new` one.
     pub fn verify(&self, old: &MmrAccumulator, new: &MmrAccumulator) -> bool {
-        let merkle_tree_root_index = u64::try_from(MerkleTree::ROOT_INDEX)
-            .expect("internal error: type `usize` should have at most 64 bits");
-
-        if old.num_leafs() > new.num_leafs() {
-            return false;
-        }
-
-        let num_new_peaks = u32::try_from(new.peaks().len())
-            .expect("internal error: Merkle Mountain Ranges should have at most 2^63 leafs");
-        if num_new_peaks != new.num_leafs().count_ones() {
-            return false;
-        }
-
-        let mut verified_old_leafs_count = 0;
-        let mut authentication_paths = self.paths.iter();
-        for old_peak in old.peaks() {
-            let (merkle_tree_index_of_first_leaf_under_new_peak, new_peak_index) =
-                leaf_index_to_mt_index_and_peak_index(verified_old_leafs_count, new.num_leafs());
-
-            let num_remaining_leafs = old.num_leafs() - verified_old_leafs_count;
-            let old_peak_height = num_remaining_leafs.ilog2();
-            let mut current_merkle_tree_index =
-                merkle_tree_index_of_first_leaf_under_new_peak >> old_peak_height;
-            let mut current_node = old_peak;
-            while current_merkle_tree_index > merkle_tree_root_index {
-                let Some(&sibling) = authentication_paths.next() else {
-                    return false;
-                };
-                let is_left_sibling = current_merkle_tree_index % 2 == 0;
-                current_node = if is_left_sibling {
-                    Tip5::hash_pair(current_node, sibling)
-                } else {
-                    Tip5::hash_pair(sibling, current_node)
-                };
-                current_merkle_tree_index >>= 1;
-            }
-            debug_assert_eq!(merkle_tree_root_index, current_merkle_tree_index);
-
-            let new_peak_index = usize::try_from(new_peak_index)
-                .expect("internal error: type `usize` should have at least 32 bits");
-            let Some(&new_peak) = new.peaks().get(new_peak_index) else {
-                return false;
-            };
-            if current_node != new_peak {
-                return false;
-            }
-
-            verified_old_leafs_count += 1 << old_peak_height;
-        }
-
-        // ensure all digests were read
-        authentication_paths.count() == 0
+        self.verify_internal(old, new).is_ok()
     }
+
+    /// Like [`Self::verify`], but with failure reasons instead of a `bool` to
+    /// increase testability.
+    //
+    // An explanation of the algorithm follows. As an example, take the following
+    // Merkle Mountain Range with 42 = 101010₂ leafs. Peaks are marked with `·`s.
+    //
+    //                                ·
+    //                ╭───────────────┴───────────────╮
+    //        ╭───────┴───────╮               ╭───────┴───────╮               ·
+    //    ╭───┴───╮       ╭───┴───╮       ╭───┴───╮       ╭───┴───╮       ╭───┴───╮
+    //  ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ·
+    // ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮
+    //
+    // Adding 8 leafs to it results in the following new Merkle Mountain Range with
+    // 50 = 110010₂ leafs. The addition is drawn boxy and bold. The elements of the
+    // required authentication path are marked with `x`es. The new peaks are marked
+    // with `○`. The one peak that's both old and new is marked `⊙`.
+    //
+    //             ⊙
+    //   ╭─────────┴─────────╮                               ○
+    // ┄┄┴┄┄         ╭───────┴───────╮               ·━━━━━━━┻━━━━━━━┓
+    //           ╭───┴───╮       ╭───┴───╮       ╭───┴───╮       ┏━━━┻━━━x
+    //         ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ·━┻━x   ┏━┻━┓   ○
+    //        ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ┏┻┓ ┏┻┓ ┏┻┓ ┏┻┓
+    //
+    // The new MMR Accumulator (the one with 50 leafs) is a successor to the old
+    // MMR Accumulator (the one with 42 leafs) if all of the following are true:
+    // - Both MMR Accumulators are self-consistent.
+    // - The new MMR Accumulator has more or equal the number of leafs as the old
+    //   one.
+    // - All “shared peaks” are identical. In the example, only the highest peak is
+    //   shared.
+    // - The first unshared peak in the new MMR Accumulator is a Merkle tree that
+    //   contains all remaining old peaks. In the example, the second new peak
+    //   contains the second and third old peaks.
+    //
+    // All subsequent new peaks are irrelevant for verification. In the example,
+    // this is only the smallest peak of the new MMR Accumulator.
+    //
+    // To re-compute the first unshared peak in the new MMR Accumulator,
+    // - start the Merkle tree authentication from the correct height, that is, from
+    //   the height of the smallest old peak;
+    // - for any left sibling, use an old peak; and
+    // - for any right sibling, use an element of the authentication path.
+    fn verify_internal(&self, old: &MmrAccumulator, new: &MmrAccumulator) -> Result<(), Error> {
+        if !old.is_consistent() {
+            return Err(Error::InconsistentOldMmr);
+        }
+
+        if !new.is_consistent() {
+            return Err(Error::InconsistentNewMmr);
+        }
+
+        let verify_auth_path_is_empty = || {
+            if self.paths.is_empty() {
+                Ok(())
+            } else {
+                Err(Error::AuthenticationPathTooLong)
+            }
+        };
+
+        match old.num_leafs() {
+            0 => return verify_auth_path_is_empty(), // any MMR is a successor to the empty MMR
+            n if n < new.num_leafs() => (),          // nominal case, continued below
+            n if n == new.num_leafs() => {
+                // treated separately to simplify logic in nominal case
+                return if old.peaks() == new.peaks() {
+                    verify_auth_path_is_empty()
+                } else {
+                    Err(Error::DifferentSharedPeak)
+                };
+            }
+            _ => return Err(Error::OldHasMoreLeafsThanNew),
+        };
+
+        let first_unshared_peak_idx = (old.num_leafs() ^ new.num_leafs()).ilog2();
+        let keep_high_bits_mask = !((1 << first_unshared_peak_idx) - 1);
+        let num_unchanged_peaks = (old.num_leafs() & keep_high_bits_mask).count_ones();
+
+        let mut old_peaks = old.peaks().into_iter();
+        let mut new_peaks = new.peaks().into_iter();
+        for _ in 0..num_unchanged_peaks {
+            let old_peak = old_peaks.next().ok_or(Error::MissingOldPeak)?;
+            let new_peak = new_peaks.next().ok_or(Error::MissingNewPeak)?;
+            if old_peak != new_peak {
+                return Err(Error::DifferentSharedPeak);
+            }
+        }
+
+        let height_of_lowest_old_peak = old.num_leafs().trailing_zeros();
+        let num_leafs_in_lowest_old_peak = 1 << height_of_lowest_old_peak;
+        let num_new_leafs = new.num_leafs() - old.num_leafs();
+        if num_new_leafs < num_leafs_in_lowest_old_peak {
+            // the new leafs don't affect the old peaks
+            return verify_auth_path_is_empty();
+        }
+
+        let index_of_first_unverified_leaf = old.num_leafs();
+        let (mut merkle_tree_index, _) =
+            leaf_index_to_mt_index_and_peak_index(index_of_first_unverified_leaf, new.num_leafs());
+        merkle_tree_index >>= height_of_lowest_old_peak;
+
+        let mut auth_path = self.paths.iter();
+        let mut current_node = *auth_path.next().ok_or(Error::AuthenticationPathTooShort)?;
+
+        let merkle_tree_root_index = u64::try_from(MerkleTree::ROOT_INDEX).expect(USIZE_TO_U64_ERR);
+        while merkle_tree_index > merkle_tree_root_index {
+            let current_node_is_left_sibling = merkle_tree_index % 2 == 0;
+            current_node = if current_node_is_left_sibling {
+                let &right_sibling = auth_path.next().ok_or(Error::AuthenticationPathTooShort)?;
+                Tip5::hash_pair(current_node, right_sibling)
+            } else {
+                let left_sibling = old_peaks.next_back().ok_or(Error::MissingOldPeak)?;
+                Tip5::hash_pair(left_sibling, current_node)
+            };
+            merkle_tree_index /= 2;
+        }
+
+        debug_assert_eq!(0, old_peaks.len());
+        if auth_path.len() > 0 {
+            return Err(Error::AuthenticationPathTooLong);
+        }
+
+        let first_unshared_peak = new_peaks.next().ok_or(Error::MissingNewPeak)?;
+        if current_node != first_unshared_peak {
+            return Err(Error::DifferentUnsharedPeak);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, thiserror::Error, Arbitrary)]
+enum Error {
+    #[error("the new MMRA must not take away any leafs")]
+    OldHasMoreLeafsThanNew,
+
+    #[error("the old MMRA must be self-consistent")]
+    InconsistentOldMmr,
+
+    #[error("the new MMRA must be self-consistent")]
+    InconsistentNewMmr,
+
+    #[error("the old MMRA has too few peaks – is it consistent?")]
+    MissingOldPeak,
+
+    #[error("the new MMRA has too few peaks – is it consistent?")]
+    MissingNewPeak,
+
+    #[error("the authentication path contains too few elements")]
+    AuthenticationPathTooShort,
+
+    #[error("the authentication path contains spurious elements")]
+    AuthenticationPathTooLong,
+
+    #[error("a peak that should be shared between old and new MMRA is unequal")]
+    DifferentSharedPeak,
+
+    #[error("the first peak that's unshared between old and new MMRA is not as claimed")]
+    DifferentUnsharedPeak,
 }
 
 #[cfg(test)]
 mod test {
-    use proptest::collection::vec;
-    use proptest::prop_assert;
+    use std::ops::Range;
+
+    use itertools::Itertools;
+    use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
-    use rand::prelude::*;
     use test_strategy::proptest;
 
     use super::*;
+    use crate::math::digest::digest_tests::DigestCorruptor;
 
-    fn verification_succeeds_with_n_leafs_append_m(n: usize, m: usize, rng: &mut dyn RngCore) {
-        let original_leafs = (0..n).map(|_| rng.gen::<Digest>()).collect_vec();
-        let old_mmra = MmrAccumulator::new_from_leafs(original_leafs);
+    /// A type exclusive to testing. Simplifies construction and verification of
+    /// [`MmrSuccessorProof`]s.
+    #[derive(Debug, Clone)]
+    struct MmrSuccessorRelation {
+        old: MmrAccumulator,
+        new: MmrAccumulator,
+        proof: MmrSuccessorProof,
+    }
 
-        let new_leafs = (0..m).map(|_| rng.gen::<Digest>()).collect_vec();
-        let successor_proof = MmrSuccessorProof::new_from_batch_append(&old_mmra, &new_leafs);
+    impl MmrSuccessorRelation {
+        fn new(old_leafs: Vec<Digest>, new_leafs: Vec<Digest>) -> Self {
+            let old = MmrAccumulator::new_from_leafs(old_leafs.clone());
+            let proof = MmrSuccessorProof::new_from_batch_append(&old, &new_leafs);
+            let new = MmrAccumulator::new_from_leafs([old_leafs, new_leafs].concat());
 
-        let mut new_mmra = old_mmra.clone();
-        for new_leaf in new_leafs {
-            new_mmra.append(new_leaf);
+            Self { old, new, proof }
         }
 
-        assert!(successor_proof.verify(&old_mmra, &new_mmra));
+        fn new_with_numbered_leafs(num_old_leafs: u64, num_new_leafs: u64) -> Self {
+            let numbered_leafs = |r: Range<_>| r.map(|leaf| Tip5::hash(&leaf)).collect();
+
+            let old_leafs = numbered_leafs(0..num_old_leafs);
+            let new_leafs = numbered_leafs(num_old_leafs..num_old_leafs + num_new_leafs);
+
+            Self::new(old_leafs, new_leafs)
+        }
+
+        fn verify(&self) -> Result<(), Error> {
+            self.proof.verify_internal(&self.old, &self.new)
+        }
+    }
+
+    impl<'a> arbitrary::Arbitrary<'a> for MmrSuccessorRelation {
+        fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+            let mut leafs = |upper_bound| -> Result<Vec<_>, _> {
+                let num_leafs = u.int_in_range(0..=upper_bound)?;
+                (0..num_leafs).map(|_| u.arbitrary()).collect()
+            };
+
+            Ok(Self::new(leafs(1 << 8)?, leafs(1 << 8)?))
+        }
+    }
+
+    impl proptest::arbitrary::Arbitrary for MmrSuccessorRelation {
+        type Parameters = ();
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            arb().boxed()
+        }
+
+        type Strategy = BoxedStrategy<Self>;
     }
 
     #[test]
-    fn small_leaf_counts_unit() {
-        let mut rng = thread_rng();
-        let threshold = 18;
-        for n in 0..threshold {
-            for m in 0..threshold {
-                verification_succeeds_with_n_leafs_append_m(n, m, &mut rng);
-            }
-        }
-    }
-
-    #[proptest(cases = 50)]
-    fn verification_succeeds_positive_property(
-        #[strategy(arb::<MmrAccumulator>())] old_mmr: MmrAccumulator,
-        #[strategy(vec(arb::<Digest>(), 0usize..(1<<6)))] new_leafs: Vec<Digest>,
-    ) {
-        let mut new_mmr = old_mmr.clone();
-        let mmr_successor_proof = MmrSuccessorProof::new_from_batch_append(&old_mmr, &new_leafs);
-        for leaf in new_leafs {
-            new_mmr.append(leaf);
-        }
-
-        prop_assert!(mmr_successor_proof.verify(&old_mmr, &new_mmr));
-    }
-
-    fn rotr(i: u64) -> u64 {
-        (i >> 1) | ((i & 1) << 63)
-    }
-
-    #[proptest(cases = 50)]
-    fn verification_fails_negative_properties(
-        #[filter(#old_mmr.num_leafs() != rotr(#old_mmr.num_leafs()))]
-        #[strategy(arb::<MmrAccumulator>())]
-        old_mmr: MmrAccumulator,
-        #[strategy(vec(arb::<Digest>(), 0usize..(1<<10)))] new_leafs: Vec<Digest>,
-        #[strategy(arb::<usize>())] mut modify_path_element: usize,
-    ) {
-        let mut new_mmr = old_mmr.clone();
-        let mmr_successor_proof = MmrSuccessorProof::new_from_batch_append(&old_mmr, &new_leafs);
-        for leaf in new_leafs.iter() {
-            new_mmr.append(*leaf);
-        }
-
-        // old MMR has wrong num leafs
-        if rotr(old_mmr.num_leafs()) != old_mmr.num_leafs()
-            && rotr(old_mmr.num_leafs()) < (u64::MAX >> 1)
-        {
-            let fake_old_mmr = MmrAccumulator::init(old_mmr.peaks(), rotr(old_mmr.num_leafs()));
-            prop_assert!(!mmr_successor_proof.verify(&fake_old_mmr, &new_mmr));
-        }
-
-        // new MMR has wrong num leafs
-        if rotr(new_mmr.num_leafs()) != new_mmr.num_leafs()
-            && rotr(new_mmr.num_leafs()) < (u64::MAX >> 1)
-        {
-            let fake_new_mmr = MmrAccumulator::init(new_mmr.peaks(), rotr(new_mmr.num_leafs()));
-            prop_assert!(!mmr_successor_proof.verify(&old_mmr, &fake_new_mmr));
-        }
-
-        // swap two peaks in old mmr
-        if old_mmr.peaks().len() >= 2 {
-            let mut old_peaks_swapped = old_mmr.peaks();
-            old_peaks_swapped.swap(0, 1);
-            let old_mmr_swapped = MmrAccumulator::init(old_peaks_swapped, old_mmr.num_leafs());
-            prop_assert!(!mmr_successor_proof.verify(&old_mmr_swapped, &new_mmr));
-        }
-
-        // swap two peaks in new mmr
-        if new_mmr.peaks().len() >= 2 {
-            let mut new_peaks_swapped = new_mmr.peaks();
-            new_peaks_swapped.swap(0, 1);
-            let new_mmr_swapped = MmrAccumulator::init(new_peaks_swapped, new_mmr.num_leafs());
-            prop_assert!(!mmr_successor_proof.verify(&old_mmr, &new_mmr_swapped));
-        }
-
-        // change one path element
-        if !mmr_successor_proof.paths.is_empty() {
-            let mut fake_mmr_successor_proof_3 = mmr_successor_proof.clone();
-            let path_index = modify_path_element % fake_mmr_successor_proof_3.paths.len();
-            modify_path_element =
-                (modify_path_element - path_index) / fake_mmr_successor_proof_3.paths.len();
-            let value_index = modify_path_element % Digest::LEN;
-            fake_mmr_successor_proof_3.paths[path_index].0[value_index].increment();
-            prop_assert!(!fake_mmr_successor_proof_3.verify(&old_mmr, &new_mmr));
-        }
-
-        // Missing path element
-        if !mmr_successor_proof.paths.is_empty() {
-            let mut fake_mmr_successor_proof_4 = mmr_successor_proof.clone();
-            fake_mmr_successor_proof_4.paths.pop();
-            prop_assert!(!fake_mmr_successor_proof_4.verify(&old_mmr, &new_mmr));
-        }
-
-        // One element too many
-        let mut fake_mmr_successor_proof_5 = mmr_successor_proof.clone();
-        fake_mmr_successor_proof_5.paths.push(Digest::default());
-        prop_assert!(!fake_mmr_successor_proof_5.verify(&old_mmr, &new_mmr));
-
-        // Missing peak
-        let fake_new_mmr = MmrAccumulator::init(
-            new_mmr
-                .peaks()
-                .into_iter()
-                .rev()
-                .skip(1)
-                .rev()
-                .collect_vec(),
-            new_mmr.num_leafs(),
-        );
-        prop_assert!(!mmr_successor_proof.verify(&old_mmr, &fake_new_mmr));
+    fn append_nothing_to_empty_mmra() {
+        let relation = MmrSuccessorRelation::new_with_numbered_leafs(0, 0);
+        assert_eq!(0, relation.proof.paths.len());
+        relation.verify().unwrap();
     }
 
     #[test]
-    fn verification_succeeds_unit() {
-        let mut rng: StdRng = SeedableRng::from_seed(
-            hex::decode("deadbeef00000000deadbeef00000000deadbeef00000000deadbeef00000000")
-                .unwrap()
-                .try_into()
-                .unwrap(),
-        );
-        let num_new_leafs = rng.gen_range(0..(1 << 15));
-        let old_num_leafs = rng.gen_range(0u64..(u64::MAX >> 1));
-        let old_peaks = (0..old_num_leafs.count_ones())
-            .map(|_| rng.gen::<Digest>())
-            .collect_vec();
+    fn append_one_thing_to_empty_mmra() {
+        let relation = MmrSuccessorRelation::new_with_numbered_leafs(0, 1);
+        assert_eq!(0, relation.proof.paths.len());
+        relation.verify().unwrap();
+    }
 
-        let old_mmr = MmrAccumulator::init(old_peaks, old_num_leafs);
-        let mut new_mmr = old_mmr.clone();
+    #[test]
+    fn append_leafs_without_influence_on_existing_peaks() {
+        let relation = MmrSuccessorRelation::new_with_numbered_leafs(1 << 3, 3);
+        assert_eq!(0, relation.proof.paths.len());
+        relation.verify().unwrap();
+    }
 
-        let new_leafs = (0..num_new_leafs)
-            .map(|_| rng.gen::<Digest>())
-            .collect_vec();
+    /// 42 = 101010₂ gives nice gaps between peaks, the additional 8 leafs fill some
+    /// of them nicely and adds a non-trivial new peak that's irrelevant for
+    /// verification.
+    ///
+    /// See the figure below, where the old Merkle Mountain Range is drawn rounded
+    /// and thin, the addition boxy and bold. The elements of the authentication
+    /// path are marked with `x`es, the “old peaks” required for authentication are
+    /// marked with `·`s.
+    ///
+    /// ```markdown
+    ///   ╭─────────┴─────────╮
+    /// ┄┄┴┄┄         ╭───────┴───────╮               ·━━━━━━━┻━━━━━━━┓
+    ///           ╭───┴───╮       ╭───┴───╮       ╭───┴───╮       ┏━━━┻━━━x
+    ///         ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ·━┻━x   ┏━┻━┓
+    ///        ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ┏┻┓ ┏┻┓ ┏┻┓ ┏┻┓
+    /// ```
+    #[test]
+    fn append_8_leafs_to_mmra_with_42_leafs() {
+        let relation = MmrSuccessorRelation::new_with_numbered_leafs(42, 8);
+        assert_eq!(2, relation.proof.paths.len());
 
-        for &leaf in new_leafs.iter() {
-            new_mmr.append(leaf);
+        let first_merkle_tree_leafs = [42_u64, 43].map(|i| Tip5::hash(&i));
+        let first_merkle_tree = MerkleTree::new::<CpuParallel>(&first_merkle_tree_leafs).unwrap();
+        assert_eq!(first_merkle_tree.root(), relation.proof.paths[0]);
+
+        let second_merkle_tree_leafs = [44_u64, 45, 46, 47].map(|i| Tip5::hash(&i));
+        let second_merkle_tree = MerkleTree::new::<CpuParallel>(&second_merkle_tree_leafs).unwrap();
+        assert_eq!(second_merkle_tree.root(), relation.proof.paths[1]);
+
+        relation.verify().unwrap();
+    }
+
+    #[test]
+    fn unit_tests() {
+        for (n, m) in (0..18).cartesian_product(0..18) {
+            dbg!((n, m));
+            let relation = MmrSuccessorRelation::new_with_numbered_leafs(n, m);
+            relation.verify().unwrap();
         }
+    }
 
-        let mmr_successor_proof = MmrSuccessorProof::new_from_batch_append(&old_mmr, &new_leafs);
+    #[proptest]
+    fn arbitrary_mmr_successor_relation_holds(relation: MmrSuccessorRelation) {
+        relation.verify()?;
+    }
 
-        assert!(mmr_successor_proof.verify(&old_mmr, &new_mmr));
+    #[proptest]
+    fn verification_fails_if_old_mmr_is_inconsistent(
+        mut relation: MmrSuccessorRelation,
+        wrong_num_leafs: u64,
+    ) {
+        prop_assume!(wrong_num_leafs != relation.old.num_leafs());
+        relation.old = MmrAccumulator::init(relation.old.peaks(), wrong_num_leafs);
+        prop_assert_eq!(Err(Error::InconsistentOldMmr), relation.verify());
+    }
+
+    #[proptest]
+    fn verification_fails_if_new_mmr_is_inconsistent(
+        mut relation: MmrSuccessorRelation,
+        wrong_num_leafs: u64,
+    ) {
+        prop_assume!(wrong_num_leafs != relation.new.num_leafs());
+        relation.new = MmrAccumulator::init(relation.new.peaks(), wrong_num_leafs);
+        prop_assert_eq!(Err(Error::InconsistentNewMmr), relation.verify());
+    }
+
+    #[proptest]
+    fn verification_fails_if_old_mmra_has_more_leafs_than_new_mmra(
+        #[filter(#relation.old != #relation.new)] mut relation: MmrSuccessorRelation,
+    ) {
+        std::mem::swap(&mut relation.old, &mut relation.new);
+        prop_assert_eq!(Err(Error::OldHasMoreLeafsThanNew), relation.verify());
+    }
+
+    #[proptest]
+    fn verification_fails_if_old_mmra_has_swapped_peaks(
+        #[filter(#relation.old.peaks().len() >= 2)] mut relation: MmrSuccessorRelation,
+        #[strategy(0..#relation.old.peaks().len())] first_swap_idx: usize,
+        #[strategy(0..#relation.old.peaks().len())] second_swap_idx: usize,
+    ) {
+        prop_assume!(first_swap_idx != second_swap_idx);
+        let mut wrong_peaks = relation.old.peaks();
+        wrong_peaks.swap(first_swap_idx, second_swap_idx);
+        relation.old = MmrAccumulator::init(wrong_peaks, relation.old.num_leafs());
+
+        prop_assert!(matches!(
+            relation.verify(),
+            Err(Error::DifferentSharedPeak) | Err(Error::DifferentUnsharedPeak)
+        ));
+    }
+
+    /// Because some peaks of the new MMRA might be irrelevant for the successor
+    /// relation, it is impossible to swap arbitrary peaks and guarantee a
+    /// verification failure. However, if the old MMRA is non-empty, the first
+    /// peak of the new MMRA is always relevant.
+    #[proptest]
+    fn verification_fails_if_new_mmra_has_first_peak_swapped_out(
+        #[filter(#relation.old.num_leafs() > 0)]
+        #[filter(#relation.new.peaks().len() >= 2)]
+        mut relation: MmrSuccessorRelation,
+        #[strategy(1..#relation.new.peaks().len())] swap_idx: usize,
+    ) {
+        let mut wrong_peaks = relation.new.peaks();
+        wrong_peaks.swap(0, swap_idx);
+        relation.new = MmrAccumulator::init(wrong_peaks, relation.new.num_leafs());
+
+        prop_assert!(matches!(
+            relation.verify(),
+            Err(Error::DifferentSharedPeak) | Err(Error::DifferentUnsharedPeak)
+        ));
+    }
+
+    #[proptest(cases = 50)]
+    fn verification_fails_if_authentication_path_is_corrupt(
+        #[filter(!#relation.proof.paths.is_empty())] mut relation: MmrSuccessorRelation,
+        #[strategy(0..#relation.proof.paths.len())] corruption_idx: usize,
+        corruptor: DigestCorruptor,
+    ) {
+        let auth_path = &mut relation.proof.paths;
+        auth_path[corruption_idx] = corruptor.corrupt_digest(auth_path[corruption_idx])?;
+
+        prop_assert!(matches!(
+            relation.verify(),
+            Err(Error::DifferentSharedPeak) | Err(Error::DifferentUnsharedPeak)
+        ));
+    }
+
+    #[proptest]
+    fn verification_fails_if_authentication_path_has_too_few_elements(
+        #[filter(!#relation.proof.paths.is_empty())] mut relation: MmrSuccessorRelation,
+        #[strategy(0..#relation.proof.paths.len())] deletion_idx: usize,
+    ) {
+        relation.proof.paths.remove(deletion_idx);
+        prop_assert_eq!(Err(Error::AuthenticationPathTooShort), relation.verify());
+    }
+
+    #[proptest]
+    fn verification_fails_if_authentication_path_has_too_many_elements(
+        mut relation: MmrSuccessorRelation,
+        #[strategy(arb())] spurious_element: Digest,
+    ) {
+        relation.proof.paths.push(spurious_element);
+        prop_assert_eq!(Err(Error::AuthenticationPathTooLong), relation.verify());
     }
 }

--- a/twenty-first/src/util_types/mmr/shared_basic.rs
+++ b/twenty-first/src/util_types/mmr/shared_basic.rs
@@ -1,3 +1,4 @@
+use crate::error::USIZE_TO_U64_ERR;
 use crate::prelude::*;
 
 #[inline]
@@ -108,8 +109,7 @@ pub fn calculate_new_peaks_from_leaf_mutation(
     leaf_index: u64,
     membership_proof: &MmrMembershipProof,
 ) -> Vec<Digest> {
-    let merkle_tree_root_index = u64::try_from(MerkleTree::ROOT_INDEX)
-        .expect("internal error: type `usize` should have at most 64 bits");
+    let merkle_tree_root_index = u64::try_from(MerkleTree::ROOT_INDEX).expect(USIZE_TO_U64_ERR);
 
     let (mut acc_mt_index, peak_index) =
         leaf_index_to_mt_index_and_peak_index(leaf_index, num_leafs);


### PR DESCRIPTION
Improve the average & worst-case time & memory performance of verifying that one MMR Accumulator is the successor of some other MMR Accumulator, and document the new algorithm.

An explanation of the verification algorithm follows. As an example, take the following Merkle Mountain Range with 42 = 101010₂ leafs. Peaks are marked with `·`s.

```
                               ·
               ╭───────────────┴───────────────╮
       ╭───────┴───────╮               ╭───────┴───────╮               ·
   ╭───┴───╮       ╭───┴───╮       ╭───┴───╮       ╭───┴───╮       ╭───┴───╮
 ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ·
╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮
```

Adding 8 leafs to it results in the following new Merkle Mountain Range with 50 = 110010₂ leafs. The addition is drawn boxy and bold. The elements of the required authentication path is marked with `x`es. The new peaks are marked with `○`. The one peak that's both old and new is marked `⊙`.

```
            ⊙
  ╭─────────┴─────────╮                               ○
┄┄┴┄┄         ╭───────┴───────╮               ·━━━━━━━┻━━━━━━━┓
          ╭───┴───╮       ╭───┴───╮       ╭───┴───╮       ┏━━━┻━━━x
        ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ·━┻━x   ┏━┻━┓   ○
       ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ┏┻┓ ┏┻┓ ┏┻┓ ┏┻┓
```

The new MMR Accumulator (the one with 50 leafs) is a successor to the old MMR Accumulator (the one with 42 leafs) if all of the following are true:
- Both MMR Accumulators are self-consistent.
- The new MMR Accumulator has more or equal the number of leafs as the old one.
- All “shared peaks” are identical. In the example, only the highest peak is shared.
- The first unshared peak in the new MMR Accumulator is a Merkle tree that contains all remaining old peaks. In the example, the second new peak contains the second and third old peaks.

All subsequent new peaks are irrelevant for verification. In the example, this is only the smallest peak of the new MMR Accumulator.

To re-compute the first unshared peak in the new MMR Accumulator,
- start the Merkle tree authentication from the correct height, that is, from the height of the smallest old peak;
- for any left sibling, use an old peak; and
- for any right sibling, use an element of the authentication path.
