### PR TITLE
feat: impl Zeroize for SecretKey

### DIFF
--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -53,6 +53,7 @@ serde_derive = "1"
 serde_json = "1.0"
 sha3 = "^0.10.8"
 thiserror = "2.0"
+zeroize = { version = "1.8.1", features = ["derive"] }
 
 [[bench]]
 name = "tip5"

--- a/twenty-first/src/math/lattice.rs
+++ b/twenty-first/src/math/lattice.rs
@@ -638,6 +638,7 @@ pub mod kem {
     use sha3::Digest as Sha3Digest;
     use sha3::Sha3_256;
     use sha3::Shake256;
+    use zeroize::Zeroize;
 
     use super::embed_msg;
     use super::extract_msg;
@@ -646,7 +647,7 @@ pub mod kem {
     use super::CYCLOTOMIC_RING_ELEMENT_SIZE_IN_BFES;
     use crate::math::b_field_element::BFieldElement;
 
-    #[derive(PartialEq, Eq, Copy, Clone, Debug, Serialize, Deserialize)]
+    #[derive(PartialEq, Eq, Copy, Clone, Debug, Serialize, Deserialize, Zeroize)]
     pub struct SecretKey {
         key: [u8; 32],
         seed: [u8; 32],
@@ -809,6 +810,24 @@ pub mod kem {
 
         let shared_key = Sha3_256::digest(payload).into();
         Some(shared_key)
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::*;
+
+        #[test]
+        fn secret_key_zeroize_test() {
+            let mut secret_key = SecretKey {
+                key: rand::random(),
+                seed: rand::random(),
+            };
+
+            secret_key.zeroize();
+
+            assert_eq!([0; 32], secret_key.key);
+            assert_eq!([0; 32], secret_key.seed);
+        }
     }
 }
 


### PR DESCRIPTION
closes #245.

adds a dep on the zeroize crate in order to impl Zeroize for SecretKey in a secure way that won't be optimized away by the compiler.

This is needed for GenerationSpendingKey in neptune-core.