### PR TITLE
MerkleTree-specific Type Aliases

### DIFF
--- a/twenty-first/benches/merkle_tree_authenticate.rs
+++ b/twenty-first/benches/merkle_tree_authenticate.rs
@@ -56,8 +56,8 @@ impl Default for MerkleTreeSampler {
 }
 
 impl MerkleTreeSampler {
-    fn num_leafs(&self) -> usize {
-        1 << self.tree_height
+    fn num_leafs(&self) -> MerkleTreeLeafIndex {
+        (1 << self.tree_height) as MerkleTreeLeafIndex
     }
 
     fn leaf_digests(&mut self) -> Vec<Digest> {
@@ -72,7 +72,7 @@ impl MerkleTreeSampler {
         MerkleTree::par_new(&leaf_digests).unwrap()
     }
 
-    fn indices_to_open(&mut self) -> Vec<usize> {
+    fn indices_to_open(&mut self) -> Vec<MerkleTreeLeafIndex> {
         (0..self.num_opened_indices)
             .map(|_| self.rng.random_range(0..self.num_leafs()))
             .collect()

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -203,12 +203,15 @@ impl MerkleTree {
         Ok(nodes)
     }
 
-    /// Given a list of leaf indices, return the indices of exactly those nodes that
-    /// are needed to prove (or verify) that the indicated leafs are in the Merkle
-    /// tree.
-    // This function is not defined as a method (taking self as argument) since it's
-    // needed by the verifier, who does not have access to the Merkle tree.
-    fn authentication_structure_node_indices(
+    /// Compute the node indices for an authentication structure.
+    ///
+    /// Given a list of leaf indices, return the indices of exactly those nodes
+    /// that are needed to prove (or verify) that the indicated leafs are in the
+    /// Merkle tree.
+    ///
+    /// Returns an error if any of the leaf indices is bigger than the number of
+    /// leafs.
+    pub fn authentication_structure_node_indices(
         num_leafs: MerkleTreeLeafIndex,
         leaf_indices: &[MerkleTreeLeafIndex],
     ) -> Result<impl ExactSizeIterator<Item = MerkleTreeLeafIndex> + use<>> {

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -18,6 +18,7 @@ use super::shared_basic;
 use crate::error::U32_TO_USIZE_ERR;
 use crate::error::USIZE_TO_U64_ERR;
 use crate::prelude::*;
+use crate::util_types::merkle_tree;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, GetSize, BFieldCodec, Arbitrary)]
 pub struct MmrMembershipProof {
@@ -68,7 +69,7 @@ impl MmrMembershipProof {
             };
             mt_index /= 2;
         }
-        debug_assert_eq!(MerkleTree::ROOT_INDEX as u64, mt_index);
+        debug_assert_eq!(merkle_tree::ROOT_INDEX, mt_index);
 
         let peak_index = usize::try_from(peak_index).expect(U32_TO_USIZE_ERR);
 

--- a/twenty-first/src/util_types/mmr/mmr_successor_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_successor_proof.rs
@@ -4,6 +4,7 @@ use super::mmr_accumulator::MmrAccumulator;
 use super::shared_basic::leaf_index_to_mt_index_and_peak_index;
 use crate::error::USIZE_TO_U64_ERR;
 use crate::prelude::*;
+use crate::util_types::merkle_tree;
 
 /// Asserts that one [MMR Accumulator] is the descendant of another, *i.e.*,
 /// that the second can be obtained by appending a set of leafs to the first. It
@@ -60,7 +61,7 @@ impl MmrSuccessorProof {
         let mut old_peaks = mmra.peaks().into_iter();
         let mut first_unused_new_leaf_idx = num_leafs_in_lowest_peak;
 
-        let merkle_tree_root_index = u64::try_from(MerkleTree::ROOT_INDEX).expect(USIZE_TO_U64_ERR);
+        let merkle_tree_root_index = merkle_tree::ROOT_INDEX;
         while merkle_tree_index > merkle_tree_root_index {
             let current_node_is_left_sibling = merkle_tree_index % 2 == 0;
             current_node = if current_node_is_left_sibling {
@@ -194,7 +195,7 @@ impl MmrSuccessorProof {
         let mut current_node = *auth_path.next().ok_or(Error::AuthenticationPathTooShort)?;
         let mut merkle_tree_index = merkle_tree_index >> height_of_lowest_old_peak;
 
-        let merkle_tree_root_index = u64::try_from(MerkleTree::ROOT_INDEX).expect(USIZE_TO_U64_ERR);
+        let merkle_tree_root_index = merkle_tree::ROOT_INDEX;
         while merkle_tree_index > merkle_tree_root_index {
             let current_node_is_left_sibling = merkle_tree_index % 2 == 0;
             current_node = if current_node_is_left_sibling {

--- a/twenty-first/src/util_types/mmr/shared_basic.rs
+++ b/twenty-first/src/util_types/mmr/shared_basic.rs
@@ -1,6 +1,6 @@
 use crate::error::U32_TO_USIZE_ERR;
-use crate::error::USIZE_TO_U64_ERR;
 use crate::prelude::*;
+use crate::util_types::merkle_tree;
 
 #[inline]
 pub fn left_child(node_index: u64, height: u32) -> u64 {
@@ -111,7 +111,7 @@ pub fn calculate_new_peaks_from_leaf_mutation(
     leaf_index: u64,
     membership_proof: &MmrMembershipProof,
 ) -> Vec<Digest> {
-    let merkle_tree_root_index = u64::try_from(MerkleTree::ROOT_INDEX).expect(USIZE_TO_U64_ERR);
+    let merkle_tree_root_index = merkle_tree::ROOT_INDEX;
 
     let (mut acc_mt_index, peak_index) =
         leaf_index_to_mt_index_and_peak_index(leaf_index, num_leafs);


### PR DESCRIPTION
This PR introduces type aliases:
 - `MerkleTreeNodeIndex` for `u64`
 - `MerkleTreeLeafIndex` for `u64`
 - `MerkleTreeHeight` for `u32`.

It also refactors `MerkleTree` to avoid using `usize` where-ever
possible, particularly in public functions. Instead, these types
aliases are used.

`MerkleTree` internally stores a `Vec<Digest>`, which induces two
limitations:
 1. The index type is `usize`, which complicates matters when
    targeting compilation on 32-bit machines (including 32-bit WASM).
 2. This vector can store at most 2^25 nodes, whereas we would like
    functions associated with Merkle trees to work for Merkle trees
    that are far larger (without needing to store all the internal
    nodes explicitly).

The second limitation persists. However, the first limitation is fixed
by this PR.

Also:

 - Public functions `nodes()` and `leafs()` now return iterators
instead of slices. As these functions were public, this change is
breaking.
 - Private function `authentication_structure_node_indices` is
   marked `pub` as it is needed downstream.

Displaces #250.