### PR TITLE
perf(tip5): Avoid one permutation in `hash_varlen`

### DIFF
--- a/twenty-first/benches/tip5.rs
+++ b/twenty-first/benches/tip5.rs
@@ -33,14 +33,23 @@ fn bench_pair(c: &mut Criterion) {
 fn bench_varlen(c: &mut Criterion) {
     let mut group = c.benchmark_group("tip5/hash_varlen");
 
-    let size = 16_384;
-    group.sample_size(50);
-    let elements: Vec<BFieldElement> = random_elements(size);
+    let many = 16_384;
+    let many_elements: Vec<BFieldElement> = random_elements(many);
 
+    group.sample_size(50);
     group.bench_function(
-        BenchmarkId::new("Tip5 / Hash Variable Length", size),
+        BenchmarkId::new("Tip5 / Hash Variable Length", many),
         |bencher| {
-            bencher.iter(|| Tip5::hash_varlen(&elements));
+            bencher.iter(|| Tip5::hash_varlen(&many_elements));
+        },
+    );
+
+    let few = 10;
+    let few_elements: Vec<BFieldElement> = random_elements(few);
+    group.bench_function(
+        BenchmarkId::new("Tip5 / Hash Variable Length", few),
+        |bencher| {
+            bencher.iter(|| Tip5::hash_varlen(&few_elements));
         },
     );
 }

--- a/twenty-first/src/math/tip5.rs
+++ b/twenty-first/src/math/tip5.rs
@@ -627,13 +627,14 @@ impl Tip5 {
     //
     // - Apply the correct padding
     // - [Sponge::pad_and_absorb_all()]
-    // - [Sponge::squeeze()] once.
+    // - Read the digest from the resulting state.
     pub fn hash_varlen(input: &[BFieldElement]) -> Digest {
         let mut sponge = Self::init();
         sponge.pad_and_absorb_all(input);
-        let produce: [BFieldElement; crate::util_types::sponge::RATE] = sponge.squeeze();
+        let produce: [BFieldElement; Digest::LEN] =
+            (&sponge.state[..Digest::LEN]).try_into().unwrap();
 
-        Digest::new((&produce[..Digest::LEN]).try_into().unwrap())
+        Digest::new(produce)
     }
 
     /// Produce `num_indices` random integer values in the range `[0, upper_bound)`. The


### PR DESCRIPTION
The last step of `hash_varlen` is to read out the hash from the state. Previous this reading-out was followed by a permutation. But since the of the sponge is dropped after the termination of this function, the last permutation is not needed.

For short inputs to `hash_varlen` this gives a significant speedup. Short instances of `hash_varlen` is used downstream by `neptune-core` in the pow-guessing process, where this change reduces the number of permutations from nine to seven.

Added benchmark shows a 28 % speedup when running `hash_varlen` on an input of length 10. For longer input lengths, this speedup will approach zero.

Shoutout to @macro-ss for identifying this speedup.

Benchmark results, with this change:
```bash
$ cargo criterion --bench tip5
   Compiling twenty-first v0.48.0 (/home/thv/repos/twenty-first/twenty-first)
    Finished `bench` profile [optimized] target(s) in 4.40s
Gnuplot not found, using plotters backend
tip5/hash_10/Tip5 / Hash 10/10
                        time:   [532.41 ns 532.71 ns 533.02 ns]
                        change: [-0.2022% +0.0630% +0.2673%] (p = 0.66 > 0.05)
                        No change in performance detected.

tip5/hash_pair/Tip5 / Hash Pair/pair
                        time:   [531.36 ns 533.53 ns 536.38 ns]
                        change: [-1.4081% -1.0392% -0.6529%] (p = 0.00 < 0.05)
                        Change within noise threshold.

tip5/hash_varlen/Tip5 / Hash Variable Length/16384
                        time:   [1.0669 ms 1.0682 ms 1.0699 ms]
                        change: [+2.3852% +2.6962% +2.9802%] (p = 0.00 < 0.05)
                        Performance has regressed.
tip5/hash_varlen/Tip5 / Hash Variable Length/10
                        time:   [1.3163 µs 1.3181 µs 1.3198 µs]
                        change: [-28.468% -28.273% -28.108%] (p = 0.00 < 0.05)
                        Performance has improved.

tip5/parallel/Tip5 / Parallel Hash/65536
                        time:   [1.0509 ms 1.0606 ms 1.0724 ms]
                        change: [-7.4722% -1.6295% +4.5693%] (p = 0.62 > 0.05)
                        No change in performance detected.
```