### PR TITLE
ci: Specify rust version explicitly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.87.0
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Capture installed rustc version
         id: installed_version
         run: |
-          INSTALLED=$(rustc --version | awk '{print $2}' | awk -F. '{print $1"."$2}')
+          INSTALLED=$(rustc --version | awk '{print $2}')
           echo "installed_version=$INSTALLED" >> $GITHUB_OUTPUT
 
       - name: Extract rust-toolchain.toml version

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.87"
+channel = "1.87.0"


### PR DESCRIPTION
Possibly due to https://github.com/rust-lang/rustup/issues/4337, our CI runners did not install all required components anymore and failed. By specifying the version to use explicitly when installing the toolchain, subsequent commands should work again.