### PR TITLE
wasm32 support for twenty-first

### DIFF
--- a/twenty-first/.cargo/config.toml
+++ b/twenty-first/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]

--- a/twenty-first/.cargo/config.toml
+++ b/twenty-first/.cargo/config.toml
@@ -1,2 +1,7 @@
 [target.wasm32-unknown-unknown]
-rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
+rustflags = [
+  "--cfg", "getrandom_backend=\"wasm_js\"",
+  "-C", "debuginfo=0",
+  "-C", "strip=symbols",
+]
+runner = "wasm-bindgen-test-runner"

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -15,15 +15,23 @@ readme.workspace = true
 keywords = ["polynomial", "merkle-tree", "post-quantum", "algebra", "tip5"]
 categories = ["cryptography", "mathematics"]
 
+
 [dev-dependencies]
 blake3 = "1.5.5"
 bincode = "1.3.3"
-criterion = { version = "0.6", features = ["html_reports"] }
 insta = "1.42"
-proptest = "1.6"
-proptest-arbitrary-interop = "0.1"
 test-strategy = "0.4"
 trybuild = "1.0"
+
+# dev deps for wasm32 target arch
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+criterion = { version = "0.6.0", default-features = false, features = ["html_reports"] }
+
+# dev deps for everything except wasm32 target arch
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+proptest = { version = "1.6.0", default-features = false, features = ["std"] }
+proptest-arbitrary-interop = "0.1"
+criterion = { version = "0.6", features = ["html_reports"] }
 
 [dev-dependencies.cargo-husky]
 version = "1"
@@ -48,6 +56,14 @@ serde_json = "1.0"
 sha3 = "^0.10.8"
 thiserror = "2.0"
 zeroize = { version = "1.8.1", features = ["derive"] }
+
+# deps for wasm32 target arch
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+
+# convince getrandom to build for wasm target.
+# note that there is also a flag in .cargo/config.toml
+getrandom = { version = "0.3", features = ["wasm_js"] }
+wasm-bindgen = "=0.2.100"
 
 [lints]
 workspace = true

--- a/twenty-first/Cargo.toml
+++ b/twenty-first/Cargo.toml
@@ -22,16 +22,18 @@ bincode = "1.3.3"
 insta = "1.42"
 test-strategy = "0.4"
 trybuild = "1.0"
+proptest-arbitrary-interop = {git="https://github.com/dan-da/proptest-arbitrary-interop.git", version = "0.1", rev="d9fcf5b"}
 
 # dev deps for wasm32 target arch
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 criterion = { version = "0.6.0", default-features = false, features = ["html_reports"] }
+proptest = { version = "1.7.0", default-features = false, features = ["std"] }
+wasm-bindgen-test = "0.3.42"
 
 # dev deps for everything except wasm32 target arch
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-proptest = { version = "1.6.0", default-features = false, features = ["std"] }
-proptest-arbitrary-interop = "0.1"
 criterion = { version = "0.6", features = ["html_reports"] }
+proptest = "1.7.0"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/twenty-first/README-wasm32-dev.md
+++ b/twenty-first/README-wasm32-dev.md
@@ -1,0 +1,106 @@
+# `twenty-first` wasm32 integration
+
+This document provides a summary of changes that were required to get
+the twenty-first crate to build and run tests for wasm32 target.
+
+
+## 1\. Summary of `Cargo.toml` Changes
+
+To support both native and `wasm32` environments, the `Cargo.toml` file was restructured to use target-specific dependency sections. This allows us to have different configurations and dependencies for each compilation target.
+
+### General Dependencies for Wasm
+
+A new section, `[target.'cfg(target_arch = "wasm32")'.dependencies]`, was added to define dependencies that are only needed when compiling for WebAssembly:
+
+- `getrandom = { ..., features = ["js"] }`: Provides an entropy source required by the `rand` crate by linking to JavaScript's Web Crypto API.
+- `wasm-bindgen`: The core library enabling communication between Rust and JavaScript.
+
+```toml
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
+wasm-bindgen = "=0.2.100"
+```
+
+### Target-Specific Development Dependencies
+
+The `[dev-dependencies]` have been split into two target-specific sections to handle the different needs of testing in native vs. Wasm environments.
+
+- When targeting `wasm32`, we use `[target.'cfg(target_arch = "wasm32")'.dev-dependencies]`:
+
+  - `criterion` and `proptest` are included with `default-features = false` to ensure they are `no_std`-compatible.
+  - `wasm-bindgen-test` is included to provide the test runner for the Wasm environment.
+
+- For all other targets (i.e., native builds), we use `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]`:
+
+  - This section contains the standard versions of `criterion` and `proptest` with all their default features enabled for native benchmarking and testing.
+
+## 2\. Rationale for Forked `proptest-arbitrary-interop`
+
+The `twenty-first` crate uses property-based testing via the `proptest` library. To generate arbitrary instances of external types (like `num_bigint::BigUint`), we rely on the `proptest-arbitrary-interop` crate.
+
+The official version of this crate on `crates.io` lacks `wasm32` support. To enable our property tests to run in a WebAssembly environment, we use a forked version of the crate. This fork specifically adds conditional dependencies for the `wasm32` target.
+
+As shown in the fork's `Cargo.toml`, when compiling for `wasm32` it correctly pulls in `proptest` with its `std` feature enabled and adds `getrandom` with the `js` feature, which is necessary for the tests to compile and run successfully.
+
+```toml
+# In the forked proptest-arbitrary-interop/Cargo.toml
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+proptest = { version = "1.2.0", default-features = false, features = ["std"] }
+# convince getrandom to build for wasm target.
+# note that there is also a flag in .cargo/config.toml
+getrandom = { version = "0.2", features = ["js"] }
+```
+
+The dependency is specified in our `Cargo.toml` to point directly to the git repository containing the fork:
+
+```toml
+# In twenty-first/Cargo.toml
+[dev-dependencies]
+proptest-arbitrary-interop = { git = "https://github.com/dan-da/proptest-arbitrary-interop" }
+```
+
+### PR Raised to `proptest-arbitrary-interop`
+
+[PR #3](https://github.com/graydon/proptest-arbitrary-interop/pull/3) has been raised to the [proptest-arbitrary-interop repo
+](https://github.com/graydon/proptest-arbitrary-interop).  So if/when it is included in a new release on crates.io
+twenty-first can again use the official version.
+
+## 3\. Code Changes for Wasm Testing
+
+The WebAssembly environment uses its own test harness (`wasm-pack test`) which ignores `#[test]` and looks for tests marked with `#[wasm_bindgen_test]` instead.
+Yet our test suite should run in both the regular `cargo test` harness and the `wasm-pack test` harness.
+
+## Dual Test Harness Compatibility
+
+The core change is to conditionally add the `#[wasm_bindgen_test]` attribute to our existing tests, which already have the `#[test]` or `#[proptest]` attributes. This is accomplished using the `#[cfg_attr]` attribute, which applies another attribute only when a certain configuration is met.
+
+This pattern allows a single test function to be recognized by both test harnesses:
+
+1. The native harness sees `#[test]` (or `#[proptest]`) and runs the test.
+2. The Wasm harness sees `#[wasm_bindgen_test]` and runs the test.
+3. Each harness ignores the attribute it doesn't recognize.
+
+Here is the specific pattern used throughout the codebase:
+
+```rust
+// This 'use' statement is only included when compiling Wasm tests.
+#[cfg(all(test, target_arch = "wasm32"))]
+use wasm_bindgen_test::wasm_bindgen_test;
+
+// The #[wasm_bindgen_test] attribute is conditionally added only when building
+// for the wasm32 target. This prevents compilation errors on native builds.
+#[cfg_attr(all(test, target_arch = "wasm32"), wasm_bindgen_test)]
+// The standard #[test] attribute is always present for the native test runner.
+# [test]
+fn my_dual_target_test() {
+    // ... test logic ...
+}
+
+// The same pattern applies to proptests:
+# [cfg_attr(all(test, target_arch = "wasm32"), wasm_bindgen_test)]
+# [proptest]
+fn my_dual_target_proptest() {
+    // ... test logic ...
+}
+
+By using `#[cfg_attr(...)]` and a conditional `use` statement, we make our test suite compatible with the Wasm environment without breaking the existing native test workflow.

--- a/twenty-first/README-wasm32.md
+++ b/twenty-first/README-wasm32.md
@@ -1,0 +1,61 @@
+# Building and Testing `twenty-first` for wasm32
+
+This document provides instructions on how to build and test the `twenty-first` crate for the `wasm32-unknown-unknown` target, which allows the library to run in WebAssembly environments.
+
+## 1\. What is wasm32?
+
+WebAssembly (Wasm) is a binary instruction format for a stack-based virtual machine. The `wasm32-unknown-unknown` target allows Rust code to be compiled into Wasm, enabling high-performance applications to run directly in web browsers and other Wasm-compatible environments. This is ideal for bringing computationally intensive tasks, like the cryptographic operations in `twenty-first`, to the web without sacrificing performance.
+
+For more detailed information, see the official [WebAssembly website](https://webassembly.org/).
+
+## 2\. Required Tools and Setup
+
+To build and test for `wasm32`, you need to set up your Rust environment with the correct target and tooling.
+
+### Add the `wasm32` Target
+
+First, add the `wasm32-unknown-unknown` target to your Rust toolchain using `rustup`:
+
+```shell
+rustup target add wasm32-unknown-unknown
+```
+
+### Install `wasm-pack`
+
+`wasm-pack` is the primary tool for building, testing, and publishing Rust-generated WebAssembly. It coordinates the build process and handles the interaction with other tools like `wasm-bindgen`.
+
+Install `wasm-pack` using `cargo`:
+
+```shell
+cargo install wasm-pack
+```
+
+### Install Node.js (for Testing)
+
+Running the `wasm32` test suite requires a JavaScript runtime. `wasm-pack` uses Node.js for this purpose.
+
+- **Requirement**: You must have Node.js v20 (LTS) or later installed. The getrandom crate, a dependency for our tests, requires the Web Crypto API, which is stable and fully supported in all modern LTS releases of Node.js.
+
+- **Installation**: You can download Node.js from the [official Node.js website](https://nodejs.org/) or install it using a version manager like `nvm`.
+
+## 3\. Build and Test Commands
+
+With the environment configured, you can now build and test the crate.
+
+### Build the Crate
+
+To compile the `twenty-first` crate for WebAssembly, run the following command from the root of the repository:
+
+```shell
+wasm-pack build --target nodejs
+```
+
+This command compiles the crate and generates the necessary JavaScript bindings, placing the output in a `pkg/` directory.
+
+### Run Tests
+
+To run the test suite for the `wasm32` target, use the `test` command from `wasm-pack`. This command will compile the tests and execute them using your installed Node.js runtime.
+
+```shell
+wasm-pack test --node
+```

--- a/twenty-first/src/lib.rs
+++ b/twenty-first/src/lib.rs
@@ -21,6 +21,8 @@ pub use bfieldcodec_derive;
 #[cfg(test)]
 pub(crate) mod tests {
     use prelude::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
 
@@ -39,6 +41,7 @@ pub(crate) mod tests {
     /// Inspired by “Rust for Rustaceans” by Jon Gjengset.
     pub fn implements_usual_auto_traits<T: Sized + Send + Sync + Unpin>() {}
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn types_in_prelude_implement_the_usual_auto_traits() {
         implements_usual_auto_traits::<BFieldElement>();
@@ -52,6 +55,7 @@ pub(crate) mod tests {
         implements_usual_auto_traits::<MmrMembershipProof>();
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn public_types_implement_the_usual_auto_traits() {
         implements_usual_auto_traits::<math::lattice::CyclotomicRingElement>();
@@ -69,6 +73,7 @@ pub(crate) mod tests {
         >();
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn errors_implement_the_usual_auto_traits() {
         implements_usual_auto_traits::<error::BFieldCodecError>();

--- a/twenty-first/src/math/b_field_element.rs
+++ b/twenty-first/src/math/b_field_element.rs
@@ -811,6 +811,8 @@ mod b_prime_field_element_test {
     use proptest_arbitrary_interop::arb;
     use rand::random;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use crate::math::b_field_element::*;
     use crate::math::other::random_elements;
@@ -826,11 +828,13 @@ mod b_prime_field_element_test {
         type Strategy = BoxedStrategy<Self>;
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn get_size(bfe: BFieldElement) {
         prop_assert_eq!(8, bfe.get_size());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn serialization_and_deserialization_to_and_from_json_is_identity(bfe: BFieldElement) {
         let serialized = serde_json::to_string(&bfe).unwrap();
@@ -838,6 +842,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(bfe, deserialized);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn deserializing_u64_is_like_calling_new(#[strategy(0..=BFieldElement::MAX)] value: u64) {
         let bfe = BFieldElement::new(value);
@@ -845,6 +850,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(bfe, deserialized);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn parsing_interval_is_open_minus_p_to_p() {
         let p = i128::from(BFieldElement::P);
@@ -856,6 +862,7 @@ mod b_prime_field_element_test {
         assert!(display_then_parse(p).is_err());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn parsing_string_representing_canonical_negative_integer_gives_correct_bfield_element(
         #[strategy(0..=BFieldElement::MAX)] v: u64,
@@ -864,6 +871,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(BFieldElement::P - v, bfe.value());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn parsing_string_representing_canonical_positive_integer_gives_correct_bfield_element(
         #[strategy(0..=BFieldElement::MAX)] v: u64,
@@ -872,6 +880,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(v, bfe.value());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn parsing_string_representing_too_big_positive_integer_as_bfield_element_gives_error(
         #[strategy(i128::from(BFieldElement::P)..)] v: i128,
@@ -880,6 +889,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(ParseBFieldElementError::NotCanonical(v), err);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn parsing_string_representing_too_small_negative_integer_as_bfield_element_gives_error(
         #[strategy(..=i128::from(BFieldElement::P))] v: i128,
@@ -888,28 +898,33 @@ mod b_prime_field_element_test {
         prop_assert_eq!(ParseBFieldElementError::NotCanonical(v), err);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn zero_is_neutral_element_for_addition(bfe: BFieldElement) {
         let zero = BFieldElement::ZERO;
         prop_assert_eq!(bfe + zero, bfe);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn one_is_neutral_element_for_multiplication(bfe: BFieldElement) {
         let one = BFieldElement::ONE;
         prop_assert_eq!(bfe * one, bfe);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn addition_is_commutative(element_0: BFieldElement, element_1: BFieldElement) {
         prop_assert_eq!(element_0 + element_1, element_1 + element_0);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn multiplication_is_commutative(element_0: BFieldElement, element_1: BFieldElement) {
         prop_assert_eq!(element_0 * element_1, element_1 * element_0);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
 
     fn addition_is_associative(
@@ -923,6 +938,7 @@ mod b_prime_field_element_test {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn multiplication_is_associative(
         element_0: BFieldElement,
@@ -935,6 +951,7 @@ mod b_prime_field_element_test {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn multiplication_distributes_over_addition(
         element_0: BFieldElement,
@@ -947,16 +964,19 @@ mod b_prime_field_element_test {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn multiplication_with_inverse_gives_identity(#[filter(!#bfe.is_zero())] bfe: BFieldElement) {
         prop_assert!((bfe.inverse() * bfe).is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn division_by_self_gives_identity(#[filter(!#bfe.is_zero())] bfe: BFieldElement) {
         prop_assert!((bfe / bfe).is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn values_larger_than_modulus_are_handled_correctly(
         #[strategy(BFieldElement::P..)] large_value: u64,
@@ -966,6 +986,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(expected_value, bfe.value());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn display_test() {
         let seven: BFieldElement = BFieldElement::new(7);
@@ -978,6 +999,7 @@ mod b_prime_field_element_test {
         assert_eq!("-15", format!("{minus_fifteen}"));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn display_and_from_str_are_reciprocal_unit_test() {
         for bfe in bfe_array![
@@ -988,12 +1010,14 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn display_and_from_str_are_reciprocal_prop_test(bfe: BFieldElement) {
         let bfe_again = bfe.to_string().parse()?;
         prop_assert_eq!(bfe, bfe_again);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn zero_is_zero() {
         let zero = BFieldElement::zero();
@@ -1001,6 +1025,7 @@ mod b_prime_field_element_test {
         assert_eq!(zero, BFieldElement::ZERO);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn not_zero_is_nonzero(bfe: BFieldElement) {
         if bfe.value() == 0 {
@@ -1009,6 +1034,7 @@ mod b_prime_field_element_test {
         prop_assert!(!bfe.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn one_is_one() {
         let one = BFieldElement::one();
@@ -1016,6 +1042,7 @@ mod b_prime_field_element_test {
         assert_eq!(one, BFieldElement::ONE);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn not_one_is_not_one(bfe: BFieldElement) {
         if bfe.value() == 1 {
@@ -1024,6 +1051,7 @@ mod b_prime_field_element_test {
         prop_assert!(!bfe.is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn one_unequal_zero() {
         let one = BFieldElement::ONE;
@@ -1031,6 +1059,7 @@ mod b_prime_field_element_test {
         assert_ne!(one, zero);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn byte_array_of_small_field_elements_is_zero_at_high_indices(value: u8) {
         let bfe = BFieldElement::new(value as u64);
@@ -1042,6 +1071,7 @@ mod b_prime_field_element_test {
         });
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn byte_array_conversion(bfe: BFieldElement) {
         let array: [u8; 8] = bfe.into();
@@ -1049,17 +1079,20 @@ mod b_prime_field_element_test {
         prop_assert_eq!(bfe, bfe_recalculated);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn byte_array_outside_range_is_not_accepted(#[strategy(BFieldElement::P..)] value: u64) {
         let byte_array = value.to_le_bytes();
         prop_assert!(BFieldElement::try_from(byte_array).is_err());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn value_is_preserved(#[strategy(0..BFieldElement::P)] value: u64) {
         prop_assert_eq!(value, BFieldElement::new(value).value());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn supposed_generator_is_generator() {
         let generator = BFieldElement::generator();
@@ -1071,11 +1104,13 @@ mod b_prime_field_element_test {
         assert_ne!(BFieldElement::ONE, generator_pow_p_half);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn lift_then_unlift_preserves_element(bfe: BFieldElement) {
         prop_assert_eq!(Some(bfe), bfe.lift().unlift());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn increment(mut bfe: BFieldElement) {
         let old_value = bfe.value();
@@ -1084,6 +1119,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(expected_value, bfe.value());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn incrementing_max_value_wraps_around() {
         let mut bfe = BFieldElement::new(BFieldElement::MAX);
@@ -1091,6 +1127,7 @@ mod b_prime_field_element_test {
         assert_eq!(0, bfe.value());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn decrement(mut bfe: BFieldElement) {
         let old_value = bfe.value();
@@ -1099,6 +1136,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(expected_value, bfe.value());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn decrementing_min_value_wraps_around() {
         let mut bfe = BFieldElement::ZERO;
@@ -1106,12 +1144,14 @@ mod b_prime_field_element_test {
         assert_eq!(BFieldElement::MAX, bfe.value());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn empty_batch_inversion() {
         let empty_inv = BFieldElement::batch_inversion(vec![]);
         assert!(empty_inv.is_empty());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn batch_inversion(bfes: Vec<BFieldElement>) {
         let bfes_inv = BFieldElement::batch_inversion(bfes.clone());
@@ -1121,6 +1161,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn power_accumulator_simple_test() {
         let input_a = [
@@ -1142,6 +1183,7 @@ mod b_prime_field_element_test {
         assert_eq!(BFieldElement::new(8), powers[3]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mul_div_plus_minus_neg_property_based_test() {
         let elements: Vec<BFieldElement> = random_elements(300);
@@ -1202,6 +1244,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mul_div_pbt() {
         // Verify that the mul result is sane
@@ -1219,6 +1262,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn add_sub_wrap_around_test() {
         // Ensure that something that exceeds P but is smaller than $2^64$
@@ -1232,6 +1276,7 @@ mod b_prime_field_element_test {
         assert_eq!(BFieldElement::new(BFieldElement::MAX), diff);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn neg_test() {
         assert_eq!(-BFieldElement::ZERO, BFieldElement::ZERO);
@@ -1246,6 +1291,7 @@ mod b_prime_field_element_test {
         assert_eq!(max, -max_plus_two);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn equality_and_hash_test() {
         assert_eq!(BFieldElement::ZERO, BFieldElement::ZERO);
@@ -1280,6 +1326,7 @@ mod b_prime_field_element_test {
         assert_eq!(hasher_a.finish(), hasher_b.finish());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn create_polynomial_test() {
         let a = Polynomial::from([1, 3, 7]);
@@ -1289,6 +1336,7 @@ mod b_prime_field_element_test {
         assert_eq!(expected, a + b);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mod_pow_test_powers_of_two() {
         let two = BFieldElement::new(2);
@@ -1298,6 +1346,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mod_pow_test_powers_of_three() {
         let three = BFieldElement::new(3);
@@ -1307,6 +1356,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mod_pow_test() {
         // These values were found by finding primitive roots of unity and verifying
@@ -1323,6 +1373,7 @@ mod b_prime_field_element_test {
         assert!(BFieldElement::new(0).mod_pow(0).is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn get_primitive_root_of_unity_test() {
         for i in 1..33 {
@@ -1338,6 +1389,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "Attempted to find the multiplicative inverse of zero.")]
     fn multiplicative_inverse_of_zero() {
@@ -1345,6 +1397,7 @@ mod b_prime_field_element_test {
         let _ = zero.inverse();
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn u32_conversion() {
         let val = BFieldElement::new(u32::MAX as u64);
@@ -1358,6 +1411,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn inverse_or_zero_bfe() {
         let zero = BFieldElement::ZERO;
@@ -1373,6 +1427,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_random_squares() {
         let mut rng = rand::rng();
@@ -1391,6 +1446,7 @@ mod b_prime_field_element_test {
         assert_eq!(one, one * one);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn equals() {
         let a = BFieldElement::ONE;
@@ -1401,6 +1457,7 @@ mod b_prime_field_element_test {
         assert_eq!(a.value(), b.value());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_random_raw() {
         let mut rng = rand::rng();
@@ -1428,6 +1485,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_fixed_inverse() {
         // (8561862112314395584, 17307602810081694772)
@@ -1439,6 +1497,7 @@ mod b_prime_field_element_test {
         assert_eq!(a_inv, expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_fixed_modpow() {
         let exponent = 16608971246357572739u64;
@@ -1447,6 +1506,7 @@ mod b_prime_field_element_test {
         assert_eq!(base.mod_pow_u64(exponent), expected);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_fixed_mul() {
         {
@@ -1466,6 +1526,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn conversion_from_i32_to_bfe_is_correct(v: i32) {
         let bfe = BFieldElement::from(v);
@@ -1475,6 +1536,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn conversion_from_isize_to_bfe_is_correct(v: isize) {
         let bfe = BFieldElement::from(v);
@@ -1484,6 +1546,7 @@ mod b_prime_field_element_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn bfield_element_can_be_converted_to_and_from_many_types() {
         let _ = BFieldElement::from(0_u8);
@@ -1515,6 +1578,7 @@ mod b_prime_field_element_test {
         let _ = i128::from(max);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn bfield_conversion_works_for_types_min_and_max() {
         let _ = BFieldElement::from(u8::MIN);
@@ -1541,6 +1605,7 @@ mod b_prime_field_element_test {
         let _ = BFieldElement::from(isize::MAX);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn naive_and_actual_conversion_from_u128_agree(v: u128) {
         fn naive_conversion(x: u128) -> BFieldElement {
@@ -1552,6 +1617,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(naive_conversion(v), BFieldElement::from(v));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn naive_and_actual_conversion_from_i64_agree(v: i64) {
         fn naive_conversion(x: i64) -> BFieldElement {
@@ -1563,6 +1629,7 @@ mod b_prime_field_element_test {
         prop_assert_eq!(naive_conversion(v), BFieldElement::from(v));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn bfe_macro_can_be_used() {
         let b = bfe!(42);
@@ -1578,11 +1645,13 @@ mod b_prime_field_element_test {
         assert_eq!(c, d);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn bfe_macro_produces_same_result_as_calling_new(value: u64) {
         prop_assert_eq!(BFieldElement::new(value), bfe!(value));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn const_minus_two_inverse_is_really_minus_two_inverse() {
         assert_eq!(bfe!(-2).inverse(), BFieldElement::MINUS_TWO_INVERSE);

--- a/twenty-first/src/math/bfield_codec.rs
+++ b/twenty-first/src/math/bfield_codec.rs
@@ -602,6 +602,8 @@ mod tests {
     use proptest::test_runner::TestCaseResult;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::prelude::*;
@@ -710,6 +712,7 @@ mod tests {
 
     macro_rules! test_case {
         (fn $fn_name:ident for $t:ty: $static_len:expr) => {
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             #[proptest]
             fn $fn_name(test_data: BFieldCodecPropertyTestData<$t>) {
                 prop_assert_eq!($static_len, <$t as BFieldCodec>::static_length());
@@ -720,6 +723,7 @@ mod tests {
 
     macro_rules! neg_test_case {
         (fn $fn_name:ident for $t:ty) => {
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             #[proptest]
             fn $fn_name(random_encoding: Vec<BFieldElement>) {
                 let decoding = <$t as BFieldCodec>::decode(&random_encoding);
@@ -781,6 +785,7 @@ mod tests {
     neg_test_case! { fn poly_of_bfe_neg for Polynomial<BFieldElement> }
     neg_test_case! { fn poly_of_xfe_neg for Polynomial<XFieldElement> }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn encoding_tuple_puts_fields_in_expected_order() {
         let encoding = (1_u8, 2_u16, 3_u32, 4_u64, true).encode();
@@ -788,18 +793,21 @@ mod tests {
         assert_eq!(expected, encoding);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn leading_zero_coefficient_have_no_effect_on_encoding_empty_poly_bfe() {
         let empty_poly = Polynomial::<BFieldElement>::new(vec![]);
         assert_eq!(empty_poly.encode(), Polynomial::new(bfe_vec![0]).encode());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn leading_zero_coefficients_have_no_effect_on_encoding_empty_poly_xfe() {
         let empty_poly = Polynomial::<XFieldElement>::new(vec![]);
         assert_eq!(empty_poly.encode(), Polynomial::new(xfe_vec![0]).encode());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn leading_zero_coefficients_have_no_effect_on_encoding_poly_bfe_pbt(
         polynomial: Polynomial<'static, BFieldElement>,
@@ -814,6 +822,7 @@ mod tests {
         prop_assert_eq!(encoded, poly_w_leading_zeros.encode());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn leading_zero_coefficients_have_no_effect_on_encoding_poly_xfe_pbt(
         polynomial: Polynomial<'static, XFieldElement>,
@@ -860,6 +869,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn disallow_trailing_zeros_in_poly_encoding_bfe(
         polynomial: Polynomial<'static, BFieldElement>,
@@ -873,6 +883,7 @@ mod tests {
         )?
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn disallow_trailing_zeros_in_poly_encoding_xfe(
         polynomial: Polynomial<'static, XFieldElement>,
@@ -898,6 +909,8 @@ mod tests {
     pub mod derive_tests {
         use arbitrary::Arbitrary;
         use num_traits::Zero;
+        #[cfg(target_arch = "wasm32")]
+        use wasm_bindgen_test::*;
 
         use super::*;
         use crate::math::digest::Digest;
@@ -1163,6 +1176,7 @@ mod tests {
             b: usize,
         }
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[proptest]
         fn unsupported_fields_can_be_ignored_test(#[strategy(arb())] my_struct: UnsupportedFields) {
             let encoded = my_struct.encode();
@@ -1316,6 +1330,7 @@ mod tests {
             fn enum_with_generics_and_where_clause for EnumWithGenericsAndWhereClause<u32>: None
         }
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[test]
         fn enums_bfield_codec_discriminant_can_be_accessed() {
             let a = EnumWithGenericsAndWhereClause::<u32>::A;
@@ -1349,6 +1364,7 @@ mod tests {
             coefficients: Vec<T>,
         }
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[proptest]
         fn manual_poly_encoding_implementation_is_consistent_with_derived_bfe(
             #[strategy(arb())] coefficients: Vec<BFieldElement>,
@@ -1356,6 +1372,7 @@ mod tests {
             manual_poly_encoding_implementation_is_consistent_with_derived(coefficients)?;
         }
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[proptest]
         fn manual_poly_encoding_implementation_is_consistent_with_derived_xfe(
             #[strategy(arb())] coefficients: Vec<XFieldElement>,

--- a/twenty-first/src/math/digest.rs
+++ b/twenty-first/src/math/digest.rs
@@ -293,6 +293,8 @@ pub(crate) mod digest_tests {
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::error::ParseBFieldElementError;
@@ -333,6 +335,7 @@ pub(crate) mod digest_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn digest_corruptor_rejects_uncorrupting_corruption() {
         let digest = Digest(bfe_array![1, 2, 3, 4, 5]);
@@ -344,6 +347,7 @@ pub(crate) mod digest_tests {
         assert!(matches!(err, TestCaseError::Reject(_)));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn get_size() {
         let stack = Digest::get_stack_size();
@@ -357,6 +361,7 @@ pub(crate) mod digest_tests {
         assert_eq!(stack + heap, total)
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn digest_from_str() {
         let valid_digest_string = "12063201067205522823,\
@@ -376,11 +381,13 @@ pub(crate) mod digest_tests {
         assert!(second_invalid_digest.is_err());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn test_reversed_involution(digest: Digest) {
         prop_assert_eq!(digest, digest.reversed().reversed())
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn digest_biguint_conversion_simple_test() {
         let fourteen: BigUint = 14u128.into();
@@ -445,6 +452,7 @@ pub(crate) mod digest_tests {
         assert_eq!(two_pow_315, two_pow_315_converted_expected.into());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn digest_biguint_conversion_pbt(components_0: [u64; 4], component_1: u32) {
         let big_uint = components_0
@@ -457,6 +465,7 @@ pub(crate) mod digest_tests {
         prop_assert_eq!(big_uint, big_uint_again);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn digest_ordering() {
         let val0 = Digest::new(bfe_array![0; Digest::LEN]);
@@ -479,6 +488,7 @@ pub(crate) mod digest_tests {
         assert!(val4 > val0);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn digest_biguint_overflow_test() {
         let mut two_pow_384: BigUint = (1u128 << 96).into();
@@ -488,6 +498,7 @@ pub(crate) mod digest_tests {
         assert_eq!(TryFromDigestError::Overflow, err);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn forty_bytes_can_be_converted_to_digest(bytes: [u8; Digest::BYTES]) {
         let digest = Digest::try_from(bytes).unwrap();
@@ -496,6 +507,7 @@ pub(crate) mod digest_tests {
     }
 
     // note: for background on this test, see issue 195
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn try_from_bytes_not_canonical() -> Result<(), TryFromDigestError> {
         let bytes: [u8; Digest::BYTES] = [255; Digest::BYTES];
@@ -509,6 +521,7 @@ pub(crate) mod digest_tests {
     }
 
     // note: for background on this test, see issue 195
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn from_str_not_canonical() -> Result<(), TryFromDigestError> {
         let str = format!("0,0,0,0,{}", u64::MAX);
@@ -521,6 +534,7 @@ pub(crate) mod digest_tests {
         Ok(())
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn bytes_in_matches_bytes_out() -> Result<(), TryFromDigestError> {
         let bytes1: [u8; Digest::BYTES] = [254; Digest::BYTES];
@@ -563,6 +577,7 @@ pub(crate) mod digest_tests {
             ]
         }
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[test]
         fn digest_to_hex() {
             for (digest, hex) in hex_examples() {
@@ -570,6 +585,7 @@ pub(crate) mod digest_tests {
             }
         }
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[proptest]
         fn to_hex_and_from_hex_are_reciprocal_proptest(bytes: [u8; Digest::BYTES]) {
             let digest = Digest::try_from(bytes).unwrap();
@@ -588,6 +604,7 @@ pub(crate) mod digest_tests {
             prop_assert_eq!(digest, digest_from_upper_hex);
         }
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[test]
         fn to_hex_and_from_hex_are_reciprocal() -> Result<(), TryFromHexDigestError> {
             let hex_vals = vec![
@@ -604,6 +621,7 @@ pub(crate) mod digest_tests {
             Ok(())
         }
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[test]
         fn digest_from_hex() -> Result<(), TryFromHexDigestError> {
             for (digest, hex) in hex_examples() {
@@ -613,6 +631,7 @@ pub(crate) mod digest_tests {
             Ok(())
         }
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[test]
         fn digest_from_invalid_hex_errors() {
             use hex::FromHexError;
@@ -652,6 +671,7 @@ pub(crate) mod digest_tests {
         mod json_test {
             use super::*;
 
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             #[test]
             fn serialize() -> Result<(), serde_json::Error> {
                 for (digest, hex) in hex_examples() {
@@ -660,6 +680,7 @@ pub(crate) mod digest_tests {
                 Ok(())
             }
 
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             #[test]
             fn deserialize() -> Result<(), serde_json::Error> {
                 for (digest, hex) in hex_examples() {
@@ -687,6 +708,7 @@ pub(crate) mod digest_tests {
                 ]
             }
 
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             #[test]
             fn serialize() {
                 for (digest, bytes) in bincode_examples() {
@@ -694,6 +716,7 @@ pub(crate) mod digest_tests {
                 }
             }
 
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
             #[test]
             fn deserialize() {
                 for (digest, bytes) in bincode_examples() {

--- a/twenty-first/src/math/lattice.rs
+++ b/twenty-first/src/math/lattice.rs
@@ -814,8 +814,12 @@ pub mod kem {
 
     #[cfg(test)]
     mod test {
+        #[cfg(target_arch = "wasm32")]
+        use wasm_bindgen_test::*;
+
         use super::*;
 
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         #[test]
         fn secret_key_zeroize_test() {
             let mut secret_key = SecretKey {
@@ -840,6 +844,8 @@ mod lattice_test {
     use rand::random;
     use sha3::Digest as Sha3Digest;
     use sha3::Sha3_256;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::kem::CIPHERTEXT_SIZE_IN_BFES;
     use super::kem::SecretKey;
@@ -849,6 +855,7 @@ mod lattice_test {
     use crate::math::lattice::kem::PublicKey;
     use crate::math::lattice::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_kats() {
         // KATs lifted from
@@ -868,6 +875,7 @@ mod lattice_test {
         assert_eq!(expected_output_sha3_256, &*sha3_out);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_fast_mul() {
         let a: [BFieldElement; 64] = random();
@@ -891,6 +899,7 @@ mod lattice_test {
         assert_eq!(c_fast, c_schoolbook);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_embedding() {
         let mut rng = rand::rng();
@@ -905,6 +914,7 @@ mod lattice_test {
         assert_eq!(msg, extracted);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_module_distributivity() {
         let mut rng = rand::rng();
@@ -928,6 +938,7 @@ mod lattice_test {
         assert_eq!(sumprod, prodsum);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_module_multiply() {
         let mut rng = rand::rng();
@@ -947,6 +958,7 @@ mod lattice_test {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_kem() {
         let mut rng = rand::rng();
@@ -969,6 +981,7 @@ mod lattice_test {
         assert!(kem::dec(other_sk, ctxt).is_none());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_ciphertext_conversion() {
         let bfes: [BFieldElement; CIPHERTEXT_SIZE_IN_BFES] = random();
@@ -980,6 +993,7 @@ mod lattice_test {
         assert_eq!(ciphertext, ciphertext_again);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn zero_test() {
         let zero_me = ModuleElement::<4>::zero();
@@ -992,6 +1006,7 @@ mod lattice_test {
         assert!(!not_zero.is_zero(), "not-zero must be not be zero");
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn serialization_deserialization_test() {
         // This is tested here since the serialization for these objects is a bit more complicated

--- a/twenty-first/src/math/mds.rs
+++ b/twenty-first/src/math/mds.rs
@@ -499,9 +499,12 @@ pub fn generated_function(input: &[u64]) -> [u64; 16] {
 mod tests {
     use itertools::Itertools;
     use rand::RngCore;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_karatsuba() {
         let mut rng = rand::rng();
@@ -522,6 +525,7 @@ mod tests {
         println!("{}", c_karatsuba.iter().map(|x| x.to_string()).join(","));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_negacyclic_mul() {
         let mut rng = rand::rng();
@@ -545,6 +549,7 @@ mod tests {
         println!("{}", c_karatsuba.iter().map(|x| x.to_string()).join(","));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_recursive_cyclic_mul() {
         let mut rng = rand::rng();

--- a/twenty-first/src/math/ntt.rs
+++ b/twenty-first/src/math/ntt.rs
@@ -13,9 +13,14 @@ use super::traits::PrimitiveRootOfUnity;
 /// The number of different domains over which this library can compute (i)NTT.
 ///
 /// In particular, the maximum slice length for both [NTT][ntt] and [iNTT][intt]
-/// supported by this library is 2^31. All domains of length some power of 2
-/// smaller than this, plus the empty domain, are supported as well.
-const NUM_DOMAINS: usize = 32;
+/// supported by this library is 2^31 on 64 bit systems and 2^28 on 32 bit systems.
+/// All domains of length some power of 2 smaller than this, plus the empty domain,
+/// are supported as well.
+#[cfg(target_pointer_width = "32")]
+const NUM_DOMAINS: usize = 29; // On 32-bit, up to length 2^28 to avoid isize::MAX overflow.
+
+#[cfg(not(target_pointer_width = "32"))]
+const NUM_DOMAINS: usize = 32; // Default for 64-bit and other architectures.
 
 /// ## Perform NTT on slices of prime-field elements
 ///

--- a/twenty-first/src/math/ntt.rs
+++ b/twenty-first/src/math/ntt.rs
@@ -315,6 +315,8 @@ mod tests {
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::math::other::random_elements;
@@ -323,6 +325,7 @@ mod tests {
     use crate::prelude::*;
     use crate::xfe;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn chu_ntt_b_field_prop_test() {
         for log_2_n in 1..10 {
@@ -345,6 +348,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn chu_ntt_x_field_prop_test() {
         for log_2_n in 1..10 {
@@ -375,6 +379,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn xfield_basic_test_of_chu_ntt() {
         let mut input_output = vec![
@@ -401,6 +406,7 @@ mod tests {
         assert_eq!(original_input, input_output);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn bfield_basic_test_of_chu_ntt() {
         let mut input_output = vec![
@@ -425,6 +431,7 @@ mod tests {
         assert_eq!(original_input, input_output);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn bfield_max_value_test_of_chu_ntt() {
         let mut input_output = vec![
@@ -449,6 +456,7 @@ mod tests {
         assert_eq!(original_input, input_output);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn ntt_on_empty_input() {
         let mut input_output = vec![];
@@ -462,6 +470,7 @@ mod tests {
         assert_eq!(original_input, input_output);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn ntt_on_input_of_length_one(bfe: BFieldElement) {
         let mut test_vector = vec![bfe];
@@ -469,6 +478,7 @@ mod tests {
         assert_eq!(vec![bfe], test_vector);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 10)]
     fn ntt_then_intt_is_identity_operation(
         #[strategy((0_usize..18).prop_map(|l| 1 << l))] _vector_length: usize,
@@ -480,6 +490,7 @@ mod tests {
         assert_eq!(original_input, input);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn b_field_ntt_with_length_32() {
         let mut input_output = bfe_vec![
@@ -531,6 +542,7 @@ mod tests {
         assert_eq!(original_input, input_output);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_compare_ntt_to_eval() {
         for log_size in 1..10 {
@@ -550,6 +562,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn swap_indices_can_be_computed() {
         // exponential growth is powerful; cap the number of domains
@@ -558,6 +571,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn twiddle_factors_can_be_computed() {
         // exponential growth is powerful; cap the number of domains

--- a/twenty-first/src/math/polynomial.rs
+++ b/twenty-first/src/math/polynomial.rs
@@ -2706,6 +2706,8 @@ mod test_polynomials {
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::prelude::*;
@@ -2736,12 +2738,14 @@ mod test_polynomials {
         type Strategy = BoxedStrategy<Self>;
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn polynomial_can_be_debug_printed() {
         let polynomial = Polynomial::new(bfe_vec![1, 2, 3]);
         println!("{polynomial:?}");
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn unequal_hash_implies_unequal_polynomials(poly_0: BfePoly, poly_1: BfePoly) {
         let hash = |poly: &Polynomial<_>| {
@@ -2760,6 +2764,7 @@ mod test_polynomials {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn polynomial_display_test() {
         fn polynomial<const N: usize>(coeffs: [u64; N]) -> BfePoly {
@@ -2785,6 +2790,7 @@ mod test_polynomials {
         assert_eq!("2x^4 + 1", polynomial([1, 0, 0, 0, 2]).to_string());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn leading_coefficient_of_zero_polynomial_is_none(#[strategy(0usize..30)] num_zeros: usize) {
         let coefficients = vec![BFieldElement::ZERO; num_zeros];
@@ -2792,6 +2798,7 @@ mod test_polynomials {
         prop_assert!(polynomial.leading_coefficient().is_none());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn leading_coefficient_of_non_zero_polynomial_is_some(
         polynomial: BfePoly,
@@ -2808,6 +2815,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn normalizing_canonical_zero_polynomial_has_no_effect() {
         let mut zero_polynomial = Polynomial::<BFieldElement>::zero();
@@ -2815,6 +2823,7 @@ mod test_polynomials {
         assert_eq!(Polynomial::zero(), zero_polynomial);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn spurious_leading_zeros_dont_affect_equality(
         polynomial: BfePoly,
@@ -2827,6 +2836,7 @@ mod test_polynomials {
         prop_assert_eq!(polynomial, polynomial_with_leading_zeros);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn normalizing_removes_spurious_leading_zeros(
         polynomial: BfePoly,
@@ -2846,6 +2856,7 @@ mod test_polynomials {
         prop_assert_eq!(expected_num_coefficients, num_coefficients);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn accessing_coefficients_of_empty_polynomial_gives_empty_slice() {
         let poly = BfePoly::new(vec![]);
@@ -2853,6 +2864,7 @@ mod test_polynomials {
         assert!(poly.into_coefficients().is_empty());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn accessing_coefficients_of_polynomial_with_only_zero_coefficients_gives_empty_slice(
         #[strategy(0_usize..30)] num_zeros: usize,
@@ -2862,6 +2874,7 @@ mod test_polynomials {
         prop_assert!(poly.into_coefficients().is_empty());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn accessing_the_coefficients_is_equivalent_to_normalizing_then_raw_access(
         mut coefficients: Vec<BFieldElement>,
@@ -2880,18 +2893,21 @@ mod test_polynomials {
         prop_assert_eq!(&raw_coefficients, &accessed_coefficients_owned);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_to_the_0_is_constant_1() {
         assert!(Polynomial::<BFieldElement>::x_to_the(0).is_one());
         assert!(Polynomial::<XFieldElement>::x_to_the(0).is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_to_the_1_is_x() {
         assert!(Polynomial::<BFieldElement>::x_to_the(1).is_x());
         assert!(Polynomial::<XFieldElement>::x_to_the(1).is_x());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn x_to_the_n_to_the_m_is_homomorphic(
         #[strategy(0_usize..50)] n: usize,
@@ -2902,6 +2918,7 @@ mod test_polynomials {
         prop_assert_eq!(to_the_n_times_m, to_the_n_then_to_the_m);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn scaling_a_polynomial_works_with_different_fields_as_the_offset() {
         let bfe_poly = Polynomial::new(bfe_vec![0, 1, 2]);
@@ -2913,6 +2930,7 @@ mod test_polynomials {
         let _ = xfe_poly.scale(xfe!(42));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_scaling_is_equivalent_in_extension_field(
         bfe_polynomial: BfePoly,
@@ -2927,6 +2945,7 @@ mod test_polynomials {
         prop_assert_eq!(xfe_poly_bfe_scalar, bfe_poly_xfe_scalar);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn evaluating_scaled_polynomial_is_equivalent_to_evaluating_original_in_offset_point(
         polynomial: BfePoly,
@@ -2940,6 +2959,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_multiplication_with_scalar_is_equivalent_for_the_two_methods(
         mut polynomial: BfePoly,
@@ -2950,6 +2970,7 @@ mod test_polynomials {
         prop_assert_eq!(polynomial, new_polynomial);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_multiplication_with_scalar_is_equivalent_for_all_mul_traits(
         polynomial: BfePoly,
@@ -2966,6 +2987,7 @@ mod test_polynomials {
         prop_assert_eq!(bfe_lhs * XFieldElement::ONE, xfe_lhs);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn polynomial_multiplication_with_scalar_works_for_various_types() {
         let bfe_poly = Polynomial::new(bfe_vec![0, 1, 2]);
@@ -2984,6 +3006,7 @@ mod test_polynomials {
         xfe_poly.scalar_mul_mut(xfe!(42));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn slow_lagrange_interpolation(
         polynomial: BfePoly,
@@ -2998,6 +3021,7 @@ mod test_polynomials {
         prop_assert_eq!(polynomial, interpolation_polynomial);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn three_colinear_points_are_colinear(
         p0: (BFieldElement, BFieldElement),
@@ -3009,6 +3033,7 @@ mod test_polynomials {
         prop_assert!(Polynomial::are_colinear(&[p0, p1, p2]));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn three_non_colinear_points_are_not_colinear(
         p0: (BFieldElement, BFieldElement),
@@ -3021,6 +3046,7 @@ mod test_polynomials {
         prop_assert!(!Polynomial::are_colinear(&[p0, p1, p2]));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn colinearity_check_needs_at_least_three_points(
         p0: (BFieldElement, BFieldElement),
@@ -3031,6 +3057,7 @@ mod test_polynomials {
         prop_assert!(!Polynomial::are_colinear(&[p0, p1]));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn colinearity_check_with_repeated_points_fails(
         p0: (BFieldElement, BFieldElement),
@@ -3039,6 +3066,7 @@ mod test_polynomials {
         prop_assert!(!Polynomial::are_colinear(&[p0, p1, p1]));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn colinear_points_are_colinear(
         p0: (BFieldElement, BFieldElement),
@@ -3058,6 +3086,7 @@ mod test_polynomials {
         prop_assert!(Polynomial::are_colinear(&all_points));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "Line must not be parallel to y-axis")]
     fn getting_point_on_invalid_line_fails() {
@@ -3067,6 +3096,7 @@ mod test_polynomials {
         Polynomial::<BFieldElement>::get_colinear_y((one, one), (one, three), two);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn point_on_line_and_colinear_point_are_identical(
         p0: (BFieldElement, BFieldElement),
@@ -3079,6 +3109,7 @@ mod test_polynomials {
         prop_assert_eq!(y, y_from_get_point_on_line);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn point_on_line_and_colinear_point_are_identical_in_extension_field(
         p0: (XFieldElement, XFieldElement),
@@ -3091,11 +3122,13 @@ mod test_polynomials {
         prop_assert_eq!(y, y_from_get_point_on_line);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn shifting_polynomial_coefficients_by_zero_is_the_same_as_not_shifting_it(poly: BfePoly) {
         prop_assert_eq!(poly.clone(), poly.shift_coefficients(0));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn shifting_polynomial_one_is_equivalent_to_raising_polynomial_x_to_the_power_of_the_shift(
         #[strategy(0usize..30)] shift: usize,
@@ -3105,6 +3138,7 @@ mod test_polynomials {
         prop_assert_eq!(shifted_one, x_to_the_shift);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn polynomial_shift_test() {
         fn polynomial<const N: usize>(coeffs: [u64; N]) -> BfePoly {
@@ -3135,6 +3169,7 @@ mod test_polynomials {
         assert_eq!(polynomial([0, 0, 0, 0, 17, 14]), poly_shift_4);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn shifting_a_polynomial_means_prepending_zeros_to_its_coefficients(
         poly: BfePoly,
@@ -3146,24 +3181,28 @@ mod test_polynomials {
         prop_assert_eq!(expected_coefficients, shifted_poly.coefficients.to_vec());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn any_polynomial_to_the_power_of_zero_is_one(poly: BfePoly) {
         let poly_to_the_zero = poly.pow(0);
         prop_assert_eq!(Polynomial::one(), poly_to_the_zero);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn any_polynomial_to_the_power_one_is_itself(poly: BfePoly) {
         let poly_to_the_one = poly.pow(1);
         prop_assert_eq!(poly, poly_to_the_one);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_one_to_any_power_is_one(#[strategy(0u32..30)] exponent: u32) {
         let one_to_the_exponent = Polynomial::<BFieldElement>::one().pow(exponent);
         prop_assert_eq!(Polynomial::one(), one_to_the_exponent);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn pow_test() {
         fn polynomial<const N: usize>(coeffs: [u64; N]) -> BfePoly {
@@ -3185,6 +3224,7 @@ mod test_polynomials {
         assert_eq!(parabola_squared, parabola.pow(2));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn pow_arbitrary_test(poly: BfePoly, #[strategy(0u32..15)] exponent: u32) {
         let actual = poly.pow(exponent);
@@ -3198,18 +3238,21 @@ mod test_polynomials {
         prop_assert_eq!(expected, fast_actual);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_zero_is_neutral_element_for_addition(a: BfePoly) {
         prop_assert_eq!(a.clone() + Polynomial::zero(), a.clone());
         prop_assert_eq!(Polynomial::zero() + a.clone(), a);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_one_is_neutral_element_for_multiplication(a: BfePoly) {
         prop_assert_eq!(a.clone() * Polynomial::<BFieldElement>::one(), a.clone());
         prop_assert_eq!(Polynomial::<BFieldElement>::one() * a.clone(), a);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn multiplication_by_zero_is_zero(a: BfePoly) {
         let zero = Polynomial::<BFieldElement>::zero();
@@ -3218,26 +3261,31 @@ mod test_polynomials {
         prop_assert_eq!(Polynomial::zero(), zero * a);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_addition_is_commutative(a: BfePoly, b: BfePoly) {
         prop_assert_eq!(a.clone() + b.clone(), b + a);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_multiplication_is_commutative(a: BfePoly, b: BfePoly) {
         prop_assert_eq!(a.clone() * b.clone(), b * a);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_addition_is_associative(a: BfePoly, b: BfePoly, c: BfePoly) {
         prop_assert_eq!((a.clone() + b.clone()) + c.clone(), a + (b + c));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_multiplication_is_associative(a: BfePoly, b: BfePoly, c: BfePoly) {
         prop_assert_eq!((a.clone() * b.clone()) * c.clone(), a * (b * c));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_multiplication_is_distributive(a: BfePoly, b: BfePoly, c: BfePoly) {
         prop_assert_eq!(
@@ -3246,21 +3294,25 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_subtraction_of_self_is_zero(a: BfePoly) {
         prop_assert_eq!(Polynomial::zero(), a.clone() - a);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_division_by_self_is_one(#[filter(!#a.is_zero())] a: BfePoly) {
         prop_assert_eq!(Polynomial::one(), a.clone() / a);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_division_removes_common_factors(a: BfePoly, #[filter(!#b.is_zero())] b: BfePoly) {
         prop_assert_eq!(a.clone(), a * b.clone() / b);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_multiplication_raises_degree_at_maximum_to_sum_of_degrees(
         a: BfePoly,
@@ -3270,6 +3322,7 @@ mod test_polynomials {
         prop_assert!((a * b).degree() <= sum_of_degrees);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn leading_zeros_dont_affect_polynomial_division() {
         // This test was used to catch a bug where the polynomial division was
@@ -3307,6 +3360,7 @@ mod test_polynomials {
         assert_eq!(expected, res_numerator_not_normalized_2);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn leading_coefficient_of_truncated_polynomial_is_same_as_original_leading_coefficient(
         poly: BfePoly,
@@ -3324,6 +3378,7 @@ mod test_polynomials {
         prop_assert_eq!(lc, trunc_lc);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn truncated_polynomial_is_of_degree_min_of_truncation_point_and_poly_degree(
         poly: BfePoly,
@@ -3333,6 +3388,7 @@ mod test_polynomials {
         prop_assert_eq!(expected_degree, poly.truncate(truncation_point).degree());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn truncating_zero_polynomial_gives_zero_polynomial(
         #[strategy(..50_usize)] truncation_point: usize,
@@ -3341,6 +3397,7 @@ mod test_polynomials {
         prop_assert!(poly.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn truncation_negates_degree_shifting(
         #[strategy(0_usize..30)] shift: usize,
@@ -3353,12 +3410,14 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn zero_polynomial_mod_any_power_of_x_is_zero_polynomial(power: usize) {
         let must_be_zero = Polynomial::<BFieldElement>::zero().mod_x_to_the_n(power);
         prop_assert!(must_be_zero.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_mod_some_power_of_x_results_in_polynomial_of_degree_one_less_than_power(
         #[filter(!#poly.is_zero())] poly: BfePoly,
@@ -3368,6 +3427,7 @@ mod test_polynomials {
         prop_assert_eq!(isize::try_from(power).unwrap() - 1, remainder.degree());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_mod_some_power_of_x_shares_low_degree_terms_coefficients_with_original_polynomial(
         #[filter(!#poly.is_zero())] poly: BfePoly,
@@ -3381,29 +3441,34 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn fast_multiplication_by_zero_gives_zero(poly: BfePoly) {
         let product = poly.fast_multiply(&Polynomial::<BFieldElement>::zero());
         prop_assert_eq!(Polynomial::zero(), product);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn fast_multiplication_by_one_gives_self(poly: BfePoly) {
         let product = poly.fast_multiply(&Polynomial::<BFieldElement>::one());
         prop_assert_eq!(poly, product);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn fast_multiplication_is_commutative(a: BfePoly, b: BfePoly) {
         prop_assert_eq!(a.fast_multiply(&b), b.fast_multiply(&a));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn fast_multiplication_and_normal_multiplication_are_equivalent(a: BfePoly, b: BfePoly) {
         let product = a.fast_multiply(&b);
         prop_assert_eq!(a * b, product);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn batch_multiply_agrees_with_iterative_multiply(a: Vec<BfePoly>) {
         let mut acc = Polynomial::one();
@@ -3413,6 +3478,7 @@ mod test_polynomials {
         prop_assert_eq!(acc, Polynomial::batch_multiply(&a));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn par_batch_multiply_agrees_with_batch_multiply(a: Vec<BfePoly>) {
         prop_assert_eq!(
@@ -3421,6 +3487,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 50)]
     fn naive_zerofier_and_fast_zerofier_are_identical(
         #[any(size_range(..Polynomial::<BFieldElement>::FAST_ZEROFIER_CUTOFF_THRESHOLD * 2).lift())]
@@ -3431,6 +3498,7 @@ mod test_polynomials {
         prop_assert_eq!(naive_zerofier, fast_zerofier);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 50)]
     fn smart_zerofier_and_fast_zerofier_are_identical(
         #[any(size_range(..Polynomial::<BFieldElement>::FAST_ZEROFIER_CUTOFF_THRESHOLD * 2).lift())]
@@ -3441,6 +3509,7 @@ mod test_polynomials {
         prop_assert_eq!(smart_zerofier, fast_zerofier);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 50)]
     fn zerofier_and_naive_zerofier_are_identical(
         #[any(size_range(..Polynomial::<BFieldElement>::FAST_ZEROFIER_CUTOFF_THRESHOLD * 2).lift())]
@@ -3451,6 +3520,7 @@ mod test_polynomials {
         prop_assert_eq!(zerofier, naive_zerofier);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 50)]
     fn zerofier_is_zero_only_on_domain(
         #[any(size_range(..1024).lift())] domain: Vec<BFieldElement>,
@@ -3466,11 +3536,13 @@ mod test_polynomials {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn zerofier_has_leading_coefficient_one(domain: Vec<BFieldElement>) {
         let zerofier = Polynomial::zerofier(&domain);
         prop_assert_eq!(BFieldElement::ONE, zerofier.leading_coefficient().unwrap());
     }
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn par_zerofier_agrees_with_zerofier(domain: Vec<BFieldElement>) {
         prop_assert_eq!(
@@ -3479,6 +3551,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn fast_evaluate_on_hardcoded_domain_and_polynomial() {
         let domain = bfe_array![6, 12];
@@ -3489,6 +3562,7 @@ mod test_polynomials {
         assert_eq!(manual_evaluations, fast_evaluations);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn slow_and_fast_polynomial_evaluation_are_equivalent(
         poly: BfePoly,
@@ -3502,30 +3576,35 @@ mod test_polynomials {
         prop_assert_eq!(evaluations, fast_evaluations);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "zero points")]
     fn interpolation_through_no_points_is_impossible() {
         let _ = Polynomial::<BFieldElement>::interpolate(&[], &[]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "zero points")]
     fn lagrange_interpolation_through_no_points_is_impossible() {
         let _ = Polynomial::<BFieldElement>::lagrange_interpolate(&[], &[]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "zero points")]
     fn zipped_lagrange_interpolation_through_no_points_is_impossible() {
         let _ = Polynomial::<BFieldElement>::lagrange_interpolate_zipped(&[]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "zero points")]
     fn fast_interpolation_through_no_points_is_impossible() {
         let _ = Polynomial::<BFieldElement>::fast_interpolate(&[], &[]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "equal length")]
     fn interpolation_with_domain_size_different_from_number_of_points_is_impossible() {
@@ -3534,6 +3613,7 @@ mod test_polynomials {
         let _ = Polynomial::interpolate(&domain, &points);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "Repeated")]
     fn zipped_lagrange_interpolate_using_repeated_domain_points_is_impossible() {
@@ -3543,6 +3623,7 @@ mod test_polynomials {
         let _ = Polynomial::lagrange_interpolate_zipped(&zipped);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn interpolating_through_one_point_gives_constant_polynomial(
         x: BFieldElement,
@@ -3553,6 +3634,7 @@ mod test_polynomials {
         prop_assert_eq!(polynomial, interpolant);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 10)]
     fn lagrange_and_fast_interpolation_are_identical(
         #[any(size_range(1..2048).lift())]
@@ -3565,6 +3647,7 @@ mod test_polynomials {
         prop_assert_eq!(lagrange_interpolant, fast_interpolant);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 10)]
     fn par_fast_interpolate_and_fast_interpolation_are_identical(
         #[any(size_range(1..2048).lift())]
@@ -3577,12 +3660,14 @@ mod test_polynomials {
         prop_assert_eq!(par_fast_interpolant, fast_interpolant);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn fast_interpolation_through_a_single_point_succeeds() {
         let zero_arr = bfe_array![0];
         let _ = Polynomial::fast_interpolate(&zero_arr, &zero_arr);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 20)]
     fn interpolation_then_evaluation_is_identity(
         #[any(size_range(1..2048).lift())]
@@ -3595,6 +3680,7 @@ mod test_polynomials {
         prop_assert_eq!(values, evaluations);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 1)]
     fn fast_batch_interpolation_is_equivalent_to_fast_interpolation(
         #[any(size_range(1..2048).lift())]
@@ -3627,6 +3713,7 @@ mod test_polynomials {
         domain
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn fast_coset_evaluation_and_fast_evaluation_on_coset_are_identical(
         polynomial: BfePoly,
@@ -3646,6 +3733,7 @@ mod test_polynomials {
         prop_assert_eq!(fast_values, fast_coset_values);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn fast_coset_interpolation_and_and_fast_interpolation_on_coset_are_identical(
         #[filter(!#offset.is_zero())] offset: BFieldElement,
@@ -3663,6 +3751,7 @@ mod test_polynomials {
         prop_assert_eq!(fast_interpolant, fast_coset_interpolant);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn naive_division_gives_quotient_and_remainder_with_expected_properties(
         a: BfePoly,
@@ -3673,6 +3762,7 @@ mod test_polynomials {
         prop_assert_eq!(a, quot * b + rem);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn clean_naive_division_gives_quotient_and_remainder_with_expected_properties(
         #[filter(!#a_roots.is_empty())] a_roots: Vec<BFieldElement>,
@@ -3688,6 +3778,7 @@ mod test_polynomials {
         prop_assert_eq!(a, quot * b);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn clean_division_agrees_with_divide_on_clean_division(
         #[strategy(arb())] a: BfePoly,
@@ -3703,6 +3794,7 @@ mod test_polynomials {
         prop_assert_eq!(Polynomial::<BFieldElement>::zero(), naive_remainder);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn clean_division_agrees_with_division_if_divisor_has_only_0_as_root(
         #[strategy(arb())] mut dividend_roots: Vec<BFieldElement>,
@@ -3717,6 +3809,7 @@ mod test_polynomials {
         prop_assert_eq!(Polynomial::<BFieldElement>::zero(), remainder);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn clean_division_agrees_with_division_if_divisor_has_only_0_as_multiple_root(
         #[strategy(arb())] mut dividend_roots: Vec<BFieldElement>,
@@ -3733,6 +3826,7 @@ mod test_polynomials {
         prop_assert_eq!(Polynomial::<BFieldElement>::zero(), remainder);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn clean_division_agrees_with_division_if_divisor_has_0_as_root(
         #[strategy(arb())] mut dividend_roots: Vec<BFieldElement>,
@@ -3756,6 +3850,7 @@ mod test_polynomials {
         prop_assert_eq!(dividend / divisor, quotient);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn clean_division_agrees_with_division_if_divisor_has_0_through_9_as_roots(
         #[strategy(arb())] additional_dividend_roots: Vec<BFieldElement>,
@@ -3770,6 +3865,7 @@ mod test_polynomials {
         prop_assert_eq!(dividend / divisor, quotient);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn clean_division_gives_quotient_and_remainder_with_expected_properties(
         #[filter(!#a_roots.is_empty())] a_roots: Vec<BFieldElement>,
@@ -3784,6 +3880,7 @@ mod test_polynomials {
         prop_assert_eq!(a, quotient * b);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn dividing_constant_polynomials_is_equivalent_to_dividing_constants(
         a: BFieldElement,
@@ -3795,6 +3892,7 @@ mod test_polynomials {
         prop_assert_eq!(expected_quotient, a_poly / b_poly);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn dividing_any_polynomial_by_a_constant_polynomial_results_in_remainder_zero(
         a: BfePoly,
@@ -3805,6 +3903,7 @@ mod test_polynomials {
         prop_assert_eq!(Polynomial::zero(), remainder);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn polynomial_division_by_and_with_shah_polynomial() {
         fn polynomial<const N: usize>(coeffs: [u64; N]) -> BfePoly {
@@ -3829,6 +3928,7 @@ mod test_polynomials {
         assert_eq!(expected_rem, x_to_the_6_mod_shah);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn xgcd_does_not_panic_on_input_zero() {
         let zero = Polynomial::<BFieldElement>::zero;
@@ -3838,6 +3938,7 @@ mod test_polynomials {
         println!("b = {b}");
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn xgcd_b_field_pol_test(x: BfePoly, y: BfePoly) {
         let (gcd, a, b) = Polynomial::xgcd(x.clone(), y.clone());
@@ -3845,6 +3946,7 @@ mod test_polynomials {
         prop_assert_eq!(gcd, a * x + b * y);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn xgcd_x_field_pol_test(x: XfePoly, y: XfePoly) {
         let (gcd, a, b) = Polynomial::xgcd(x.clone(), y.clone());
@@ -3852,6 +3954,7 @@ mod test_polynomials {
         prop_assert_eq!(gcd, a * x + b * y);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn add_assign_is_equivalent_to_adding_and_assigning(a: BfePoly, b: BfePoly) {
         let mut c = a.clone();
@@ -3859,6 +3962,7 @@ mod test_polynomials {
         prop_assert_eq!(a + b, c);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn only_monic_polynomial_of_degree_1_is_x() {
         fn polynomial<const N: usize>(coeffs: [u64; N]) -> BfePoly {
@@ -3877,6 +3981,7 @@ mod test_polynomials {
         assert!(!polynomial([0, 0, 1]).is_x());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn hardcoded_polynomial_squaring() {
         fn polynomial<const N: usize>(coeffs: [u64; N]) -> BfePoly {
@@ -3899,21 +4004,25 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn polynomial_squaring_is_equivalent_to_multiplication_with_self(poly: BfePoly) {
         prop_assert_eq!(poly.clone() * poly.clone(), poly.square());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn slow_and_normal_squaring_are_equivalent(poly: BfePoly) {
         prop_assert_eq!(poly.slow_square(), poly.square());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn normal_and_fast_squaring_are_equivalent(poly: BfePoly) {
         prop_assert_eq!(poly.square(), poly.fast_square());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn constant_zero_eq_constant_zero() {
         let zero_polynomial1 = Polynomial::<BFieldElement>::zero();
@@ -3922,12 +4031,14 @@ mod test_polynomials {
         assert_eq!(zero_polynomial1, zero_polynomial2)
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn zero_polynomial_is_zero() {
         assert!(Polynomial::<BFieldElement>::zero().is_zero());
         assert!(Polynomial::<XFieldElement>::zero().is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn zero_polynomial_is_zero_independent_of_spurious_leading_zeros(
         #[strategy(..500usize)] num_zeros: usize,
@@ -3939,6 +4050,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn no_constant_polynomial_with_non_zero_coefficient_is_zero(
         #[filter(!#constant.is_zero())] constant: BFieldElement,
@@ -3947,6 +4059,7 @@ mod test_polynomials {
         prop_assert!(!constant_polynomial.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn constant_one_eq_constant_one() {
         let one_polynomial1 = Polynomial::<BFieldElement>::one();
@@ -3955,12 +4068,14 @@ mod test_polynomials {
         assert_eq!(one_polynomial1, one_polynomial2)
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn one_polynomial_is_one() {
         assert!(Polynomial::<BFieldElement>::one().is_one());
         assert!(Polynomial::<XFieldElement>::one().is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn one_polynomial_is_one_independent_of_spurious_leading_zeros(
         #[strategy(..500usize)] num_leading_zeros: usize,
@@ -3974,6 +4089,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn no_constant_polynomial_with_non_one_coefficient_is_one(
         #[filter(!#constant.is_one())] constant: BFieldElement,
@@ -3982,6 +4098,7 @@ mod test_polynomials {
         prop_assert!(!constant_polynomial.is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn formal_derivative_of_zero_is_zero() {
         let bfe_0_poly = Polynomial::<BFieldElement>::zero();
@@ -3991,12 +4108,14 @@ mod test_polynomials {
         assert!(xfe_0_poly.formal_derivative().is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn formal_derivative_of_constant_polynomial_is_zero(constant: BFieldElement) {
         let formal_derivative = Polynomial::from_constant(constant).formal_derivative();
         prop_assert!(formal_derivative.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn formal_derivative_of_non_zero_polynomial_is_of_degree_one_less_than_the_polynomial(
         #[filter(!#poly.is_zero())] poly: BfePoly,
@@ -4004,6 +4123,7 @@ mod test_polynomials {
         prop_assert_eq!(poly.degree() - 1, poly.formal_derivative().degree());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn formal_derivative_of_product_adheres_to_the_leibniz_product_rule(a: BfePoly, b: BfePoly) {
         let product_formal_derivative = (a.clone() * b.clone()).formal_derivative();
@@ -4011,12 +4131,14 @@ mod test_polynomials {
         prop_assert_eq!(product_rule, product_formal_derivative);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn zero_is_zero() {
         let f = Polynomial::new(vec![BFieldElement::new(0)]);
         assert!(f.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn formal_power_series_inverse_newton(
         #[strategy(2usize..20)] precision: usize,
@@ -4033,6 +4155,7 @@ mod test_polynomials {
         prop_assert!(remainder.is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn formal_power_series_inverse_newton_concrete() {
         let f = Polynomial::new(vec![
@@ -4054,6 +4177,7 @@ mod test_polynomials {
         assert!(remainder.is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn formal_power_series_inverse_minimal(
         #[strategy(2usize..20)] precision: usize,
@@ -4075,6 +4199,7 @@ mod test_polynomials {
         prop_assert!(g.degree() <= precision as isize);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn structured_multiple_is_multiple(
         #[filter(#coefficients.iter().any(|c|!c.is_zero()))]
@@ -4087,6 +4212,7 @@ mod test_polynomials {
         prop_assert!(remainder.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn structured_multiple_of_modulus_with_trailing_zeros_is_multiple(
         #[filter(!#raw_modulus.is_zero())] raw_modulus: BfePoly,
@@ -4097,6 +4223,7 @@ mod test_polynomials {
         prop_assert!(multiple.reduce_long_division(&modulus).is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn structured_multiple_generates_structure(
         #[filter(#coefficients.iter().filter(|c|!c.is_zero()).count() >= 3)]
@@ -4120,6 +4247,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn structured_multiple_generates_structure_concrete() {
         let polynomial = Polynomial::new(
@@ -4143,6 +4271,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn structured_multiple_of_degree_is_multiple(
         #[strategy(2usize..100)] n: usize,
@@ -4156,6 +4285,7 @@ mod test_polynomials {
         prop_assert!(remainder.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn structured_multiple_of_degree_generates_structure(
         #[strategy(4usize..100)] n: usize,
@@ -4183,6 +4313,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn structured_multiple_of_degree_has_given_degree(
         #[strategy(2usize..100)] n: usize,
@@ -4201,12 +4332,14 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn reverse_polynomial_with_nonzero_constant_term_twice_gives_original_back(f: BfePoly) {
         let fx_plus_1 = f.shift_coefficients(1) + Polynomial::from_constant(bfe!(1));
         prop_assert_eq!(fx_plus_1.clone(), fx_plus_1.reverse().reverse());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn reverse_polynomial_with_zero_constant_term_twice_gives_shift_back(
         #[filter(!#f.is_zero())] f: BfePoly,
@@ -4219,6 +4352,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn reduce_by_structured_modulus_and_reduce_long_division_agree(
         #[strategy(1usize..10)] n: usize,
@@ -4239,6 +4373,7 @@ mod test_polynomials {
         prop_assert_eq!(long_remainder, structured_remainder);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn reduce_by_structured_modulus_and_reduce_agree_long_division_concrete() {
         let a = Polynomial::new(
@@ -4264,6 +4399,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn reduce_by_ntt_friendly_modulus_and_reduce_long_division_agree(
         #[strategy(1usize..10)] m: usize,
@@ -4292,6 +4428,7 @@ mod test_polynomials {
         prop_assert_eq!(long_remainder, structured_remainder);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn reduce_by_ntt_friendly_modulus_and_reduce_agree_concrete() {
         let m = 1;
@@ -4317,6 +4454,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn reduce_fast_and_reduce_long_division_agree(
         numerator: BfePoly,
@@ -4328,6 +4466,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn reduce_and_fast_reduce_long_division_agree_on_fixed_input() {
         // The bug exhibited by this minimal failing test case has since been
@@ -4359,6 +4498,7 @@ mod test_polynomials {
         assert_eq!(0, failures.len(), "failures at indices: {failures:?}");
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn reduce_long_division_and_fast_reduce_agree_simple_fixed() {
         let roots = (0..10).map(BFieldElement::new).collect_vec();
@@ -4381,6 +4521,7 @@ mod test_polynomials {
         assert_eq!(long_div_remainder, preprocessed_remainder);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 100)]
     fn batch_evaluate_methods_are_equivalent(
         #[strategy(vec(arb(), (1<<10)..(1<<11)))] coefficients: Vec<BFieldElement>,
@@ -4396,11 +4537,13 @@ mod test_polynomials {
         prop_assert_eq!(evaluations_iterative, evaluations_reduce_then);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn reduce_agrees_with_division(a: BfePoly, #[filter(!#b.is_zero())] b: BfePoly) {
         prop_assert_eq!(a.divide(&b).1, a.reduce(&b));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn structured_multiple_of_monomial_term_is_actually_multiple_and_of_right_degree(
         #[strategy(1usize..1000)] degree: usize,
@@ -4414,6 +4557,7 @@ mod test_polynomials {
         prop_assert_eq!(multiple.degree() as usize, target_degree);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn monomial_term_divided_by_smaller_monomial_term_gives_clean_division(
         #[strategy(100usize..102)] high_degree: usize,
@@ -4435,6 +4579,7 @@ mod test_polynomials {
         prop_assert_eq!(Polynomial::zero(), remainder);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn fast_modular_coset_interpolate_agrees_with_interpolate_then_reduce_property(
         #[filter(!#modulus.is_zero())] modulus: BfePoly,
@@ -4457,6 +4602,7 @@ mod test_polynomials {
         )
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn fast_modular_coset_interpolate_agrees_with_interpolate_then_reduce_concrete() {
         let logn = 8;
@@ -4477,6 +4623,7 @@ mod test_polynomials {
         )
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 100)]
     fn coset_extrapolation_methods_agree_with_interpolate_then_evaluate(
         #[strategy(0usize..10)] _logn: usize,
@@ -4502,6 +4649,7 @@ mod test_polynomials {
         prop_assert_eq!(fast_coset_extrapolation, interpolation_then_evaluation);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn coset_extrapolate_and_batch_coset_extrapolate_agree(
         #[strategy(1usize..10)] _logn: usize,
@@ -4544,6 +4692,7 @@ mod test_polynomials {
         prop_assert_eq!(one_by_one_naive, par_batched_naive);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn fast_modular_coset_interpolate_thresholds_relate_properly() {
         type BfePoly = Polynomial<'static, BFieldElement>;
@@ -4553,6 +4702,7 @@ mod test_polynomials {
         assert!(intt > lagrange);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn interpolate_and_par_interpolate_agree(
         #[filter(!#points.is_empty())] points: Vec<BFieldElement>,
@@ -4563,6 +4713,7 @@ mod test_polynomials {
         prop_assert_eq!(expected_interpolant, observed_interpolant);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn batch_evaluate_agrees_with_par_batch_evalaute(
         polynomial: BfePoly,
@@ -4574,6 +4725,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 20)]
     fn polynomial_evaluation_and_barycentric_evaluation_are_equivalent(
         #[strategy(1_usize..8)] _log_num_coefficients: usize,
@@ -4599,6 +4751,7 @@ mod test_polynomials {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn regular_evaluation_works_with_various_types() {
         let bfe_poly = Polynomial::new(bfe_vec![1]);
@@ -4611,6 +4764,7 @@ mod test_polynomials {
         let _: XFieldElement = xfe_poly.evaluate(xfe!(0));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn barycentric_evaluation_works_with_many_types() {
         let bfe_codeword = bfe_array![1];
@@ -4622,6 +4776,7 @@ mod test_polynomials {
         let _ = barycentric_evaluate(&xfe_codeword, xfe!(0));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn various_multiplications_work_with_various_types() {
         let b = Polynomial::<BFieldElement>::zero;
@@ -4648,6 +4803,7 @@ mod test_polynomials {
         let _ = x().fast_multiply(&x());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn evaluating_polynomial_with_borrowed_coefficients_leaves_coefficients_borrowed() {
         let coefficients = bfe_vec![4, 5, 6];

--- a/twenty-first/src/math/tip5.rs
+++ b/twenty-first/src/math/tip5.rs
@@ -1164,7 +1164,7 @@ pub(crate) mod tip5_tests {
         );
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    // note: test disabled for wasm32 due to use of assert_snapshot()
     #[test]
     fn tip5_hasher_trait_test() {
         let mut hasher = Tip5::init();

--- a/twenty-first/src/math/tip5.rs
+++ b/twenty-first/src/math/tip5.rs
@@ -744,6 +744,8 @@ pub(crate) mod tip5_tests {
     use rayon::prelude::IntoParallelIterator;
     use rayon::prelude::ParallelIterator;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::math::other::random_elements;
@@ -758,6 +760,7 @@ pub(crate) mod tip5_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn get_size_test() {
         assert_eq!(
@@ -766,6 +769,7 @@ pub(crate) mod tip5_tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn lookup_table_is_correct() {
         let table: [u8; 256] = (0..256)
@@ -787,6 +791,7 @@ pub(crate) mod tip5_tests {
         });
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn round_constants_are_correct() {
         let to_int = |bytes: &[u8]| {
@@ -819,6 +824,7 @@ pub(crate) mod tip5_tests {
         });
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_fermat_cube_map_is_permutation() {
         let mut touched = [false; 256];
@@ -830,6 +836,7 @@ pub(crate) mod tip5_tests {
         assert_eq!(Tip5::offset_fermat_cube_map(255), 255);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn calculate_differential_uniformity() {
         // cargo test calculate_differential_uniformity -- --include-ignored --nocapture
@@ -890,6 +897,7 @@ pub(crate) mod tip5_tests {
         println!("bitwise differential uniformity for fermat cube map: {du_fermat_bitwise}");
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn calculate_approximation_quality() {
         let mut fermat_cubed = [0u16; 65536];
@@ -907,6 +915,7 @@ pub(crate) mod tip5_tests {
         println!("agreement with low-degree function: {equal_count}");
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn hash10_test_vectors() {
         let mut preimage = [BFieldElement::ZERO; RATE];
@@ -943,6 +952,7 @@ pub(crate) mod tip5_tests {
         )
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn hash_varlen_test_vectors() {
         let mut digest_sum = [BFieldElement::ZERO; Digest::LEN];
@@ -988,6 +998,7 @@ pub(crate) mod tip5_tests {
         Digest::new((&squeeze_result[..Digest::LEN]).try_into().unwrap())
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn hash_var_len_equivalence_corner_cases() {
         for preimage_length in 0..=11 {
@@ -999,6 +1010,7 @@ pub(crate) mod tip5_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn hash_var_len_equivalence(#[strategy(arb())] preimage: Vec<BFieldElement>) {
         let hash_varlen_digest = Tip5::hash_varlen(&preimage);
@@ -1006,6 +1018,7 @@ pub(crate) mod tip5_tests {
         prop_assert_eq!(digest_through_pad_squeeze_absorb, hash_varlen_digest);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_linearity_of_mds() {
         type SpongeState = [BFieldElement; STATE_SIZE];
@@ -1037,6 +1050,7 @@ pub(crate) mod tip5_tests {
         assert_eq!(w, w_);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_mds_circulancy() {
         let mut sponge = Tip5::init();
@@ -1073,6 +1087,7 @@ pub(crate) mod tip5_tests {
         assert_eq!(sponge_2.state, mv);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_complex_karatsuba() {
         const N: usize = 4;
@@ -1091,6 +1106,7 @@ pub(crate) mod tip5_tests {
         assert_eq!(h0, h1);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_complex_product() {
         let mut rng = rand::rng();
@@ -1104,6 +1120,7 @@ pub(crate) mod tip5_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn sample_scalars_test() {
         let mut sponge = Tip5::randomly_seeded();
@@ -1118,6 +1135,7 @@ pub(crate) mod tip5_tests {
         assert_ne!(product, XFieldElement::ZERO); // false failure with prob ~2^{-192}
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_mds_agree() {
         let mut rng = rand::rng();
@@ -1146,6 +1164,7 @@ pub(crate) mod tip5_tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn tip5_hasher_trait_test() {
         let mut hasher = Tip5::init();
@@ -1154,6 +1173,7 @@ pub(crate) mod tip5_tests {
         assert_snapshot!(hasher.finish(), @"2267905471610932299");
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn tip5_hasher_consumes_small_data(#[filter(!#bytes.is_empty())] bytes: Vec<u8>) {
         let mut hasher = Tip5::init();
@@ -1162,6 +1182,7 @@ pub(crate) mod tip5_tests {
         prop_assert_ne!(Tip5::init().finish(), hasher.finish());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn appending_small_data_to_big_data_changes_tip5_hash(
         #[any(size_range(2_000..8_000).lift())] big_data: Vec<u8>,
@@ -1178,6 +1199,7 @@ pub(crate) mod tip5_tests {
         prop_assert_ne!(big_data_hash, all_data_hash);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn tip5_trace_starts_with_initial_state_and_is_equivalent_to_permutation(
         #[strategy(arb())] mut tip5: Tip5,

--- a/twenty-first/src/math/x_field_element.rs
+++ b/twenty-first/src/math/x_field_element.rs
@@ -591,6 +591,8 @@ mod tests {
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use crate::bfe;
     use crate::math::b_field_element::*;
@@ -609,6 +611,7 @@ mod tests {
         type Strategy = BoxedStrategy<Self>;
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn one_zero_test() {
         let one = XFieldElement::one();
@@ -646,6 +649,7 @@ mod tests {
         assert!(!one_as_constant_term_1.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_field_random_element_generation_test() {
         let rand_xs: Vec<XFieldElement> = random_elements(14);
@@ -655,6 +659,7 @@ mod tests {
         assert!(rand_xs.into_iter().all_unique());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn incr_decr_test() {
         let one_const = XFieldElement::new([1, 0, 0].map(BFieldElement::new));
@@ -716,6 +721,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_field_add_test() {
         let poly1 = XFieldElement::new([2, 0, 0].map(BFieldElement::new));
@@ -749,6 +755,7 @@ mod tests {
         assert_eq!(poly_sum, poly9 + poly10);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_field_sub_test() {
         let poly1 = XFieldElement::new([2, 0, 0].map(BFieldElement::new));
@@ -782,6 +789,7 @@ mod tests {
         assert_eq!(poly_diff, poly10 - poly9);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_field_mul_test() {
         let poly1 = XFieldElement::new([2, 0, 0].map(BFieldElement::new));
@@ -825,6 +833,7 @@ mod tests {
         assert_eq!(poly1112_product, poly11 * poly12);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_field_overloaded_arithmetic_test() {
         let mut rng = rand::rng();
@@ -855,6 +864,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_field_into_test() {
         let zero_poly: XFieldElement = Polynomial::<BFieldElement>::new(vec![]).into();
@@ -868,6 +878,7 @@ mod tests {
         assert!(neg_shah_zero.is_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_field_xgcp_test() {
         // Verify expected properties of XGCP: symmetry and that gcd is always
@@ -933,6 +944,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn x_field_inv_test() {
         let one = XFieldElement::new([1, 0, 0].map(BFieldElement::new));
@@ -987,6 +999,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn field_element_inversion(
         #[filter(!#x.is_zero())] x: XFieldElement,
@@ -1000,6 +1013,7 @@ mod tests {
         prop_assert_ne!(XFieldElement::ONE, x * not_x.inverse());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn field_element_batch_inversion(
         #[filter(!#xs.iter().any(|x| x.is_zero()))] xs: Vec<XFieldElement>,
@@ -1010,6 +1024,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mul_xfe_with_bfe_pbt() {
         let test_iterations = 100;
@@ -1028,6 +1043,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 1_000)]
     fn x_field_division_mul_pbt(a: XFieldElement, b: XFieldElement) {
         let a_b = a * b;
@@ -1092,6 +1108,7 @@ mod tests {
         prop_assert_eq!(a_minus_b_field_b_as_b, a_minus_b_field_b_as_x);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn xfe_mod_pow_zero() {
         assert!(XFieldElement::ZERO.mod_pow_u32(0).is_one());
@@ -1100,6 +1117,7 @@ mod tests {
         assert!(XFieldElement::ONE.mod_pow_u64(0).is_one());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn xfe_mod_pow(base: XFieldElement, #[strategy(0_u32..200)] exponent: u32) {
         let mut acc = XFieldElement::ONE;
@@ -1109,6 +1127,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn xfe_mod_pow_static() {
         let three_to_the_n = |n| xfe!(3).mod_pow_u64(n);
@@ -1117,6 +1136,7 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 100)]
     fn xfe_intt_is_inverse_of_xfe_ntt(
         #[strategy(1..=11)]
@@ -1130,6 +1150,7 @@ mod tests {
         prop_assert_eq!(inputs, rv);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 40)]
     fn xfe_ntt_corresponds_to_polynomial_evaluation(
         #[strategy(1..=11)]
@@ -1147,12 +1168,14 @@ mod tests {
         prop_assert_eq!(evaluations, rv);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn inverse_or_zero_of_zero_is_zero() {
         let zero = XFieldElement::ZERO;
         assert_eq!(zero, zero.inverse_or_zero());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn inverse_or_zero_of_non_zero_is_inverse(#[filter(!#xfe.is_zero())] xfe: XFieldElement) {
         let inv = xfe.inverse_or_zero();
@@ -1160,6 +1183,7 @@ mod tests {
         prop_assert_eq!(XFieldElement::ONE, xfe * inv);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "Cannot invert the zero element in the extension field.")]
     fn multiplicative_inverse_of_zero() {
@@ -1167,6 +1191,7 @@ mod tests {
         let _ = zero.inverse();
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn xfe_to_digest_to_xfe_is_invariant(xfe: XFieldElement) {
         let digest: Digest = xfe.into();
@@ -1174,6 +1199,7 @@ mod tests {
         assert_eq!(xfe, xfe2);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn converting_random_digest_to_xfield_element_fails(digest: Digest) {
         if XFieldElement::try_from(digest).is_ok() {
@@ -1182,6 +1208,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn xfe_macro_can_be_used() {
         let x = xfe!(42);
@@ -1201,12 +1228,14 @@ mod tests {
         assert_eq!(m.to_vec(), n);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn xfe_macro_produces_same_result_as_calling_new(coeffs: [BFieldElement; EXTENSION_DEGREE]) {
         let xfe = XFieldElement::new(coeffs);
         prop_assert_eq!(xfe, xfe!(coeffs));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn xfe_macro_produces_same_result_as_calling_new_const(scalar: BFieldElement) {
         let xfe = XFieldElement::new_const(scalar);

--- a/twenty-first/src/math/zerofier_tree.rs
+++ b/twenty-first/src/math/zerofier_tree.rs
@@ -107,15 +107,19 @@ mod test {
     use proptest::prop_assert_eq;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use crate::math::zerofier_tree::ZerofierTree;
     use crate::prelude::BFieldElement;
     use crate::prelude::Polynomial;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn zerofier_tree_can_be_empty() {
         ZerofierTree::<BFieldElement>::new_from_domain(&[]);
     }
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn zerofier_tree_root_is_multiple_of_children(
         #[strategy(vec(arb(), 2*ZerofierTree::<BFieldElement>::RECURSION_CUTOFF_THRESHOLD))]
@@ -135,6 +139,7 @@ mod test {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn zerofier_tree_root_has_right_degree(
         #[strategy(vec(arb(), 1..(1<<10)))] points: Vec<BFieldElement>,
@@ -143,6 +148,7 @@ mod test {
         prop_assert_eq!(points.len(), zerofier_tree.zerofier().degree() as usize);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn zerofier_tree_root_zerofies(
         #[strategy(vec(arb(), 1..(1<<10)))] points: Vec<BFieldElement>,
@@ -155,6 +161,7 @@ mod test {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn zerofier_tree_and_polynomial_agree_on_zerofiers(
         #[strategy(vec(arb(), 1..(1<<10)))] points: Vec<BFieldElement>,

--- a/twenty-first/src/util_types/merkle_tree.rs
+++ b/twenty-first/src/util_types/merkle_tree.rs
@@ -950,6 +950,8 @@ pub mod merkle_tree_test {
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::math::digest::digest_tests::DigestCorruptor;
@@ -1000,6 +1002,7 @@ pub mod merkle_tree_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn building_merkle_tree_from_empty_list_of_digests_fails_with_expected_error() {
         let maybe_tree = MerkleTree::par_new(&[]);
@@ -1007,6 +1010,7 @@ pub mod merkle_tree_test {
         assert_eq!(MerkleTreeError::TooFewLeafs, err);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn merkle_tree_with_one_leaf_has_expected_height_and_number_of_leafs() {
         let digest = Digest::default();
@@ -1015,12 +1019,14 @@ pub mod merkle_tree_test {
         assert_eq!(0, tree.height());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn building_merkle_tree_from_one_digest_makes_that_digest_the_root(digest: Digest) {
         let tree = MerkleTree::par_new(&[digest]).unwrap();
         assert_eq!(digest, tree.root());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn building_merkle_tree_from_list_of_digests_with_incorrect_number_of_leafs_fails(
         #[filter(!#num_leafs.is_power_of_two())]
@@ -1034,6 +1040,7 @@ pub mod merkle_tree_test {
         assert_eq!(MerkleTreeError::IncorrectNumberOfLeafs, err);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn merkle_tree_construction_strategies_behave_identically_on_random_input(leafs: Vec<Digest>) {
         let sequential = MerkleTree::sequential_new(&leafs);
@@ -1041,6 +1048,7 @@ pub mod merkle_tree_test {
         prop_assert_eq!(sequential, parallel);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn merkle_tree_construction_strategies_produce_identical_trees(
         #[strategy(0_usize..10)] _tree_height: usize,
@@ -1051,6 +1059,7 @@ pub mod merkle_tree_test {
         prop_assert_eq!(sequential, parallel);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn merkle_tree_construction_strategies_are_independent_of_parallelization_cutoff(
         #[strategy(0_usize..10)] _tree_height: usize,
@@ -1064,6 +1073,7 @@ pub mod merkle_tree_test {
         prop_assert_eq!(sequential, parallel);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn ram_frugal_merkle_root_is_identical_to_full_tree_root(
         #[strategy(0_usize..10)] _tree_height: usize,
@@ -1077,6 +1087,7 @@ pub mod merkle_tree_test {
         prop_assert_eq!(par_frugal, hungry);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn ram_frugal_merkle_root_is_independent_of_parallelization_cutoff(
         #[strategy(0_usize..10)] _tree_height: usize,
@@ -1093,6 +1104,7 @@ pub mod merkle_tree_test {
         prop_assert_eq!(par_frugal, hungry);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 100)]
     fn various_small_parallelization_cutoffs_dont_cause_infinite_iterations(
         #[strategy(0_usize..10)] _tree_height: usize,
@@ -1105,6 +1117,7 @@ pub mod merkle_tree_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 100)]
     fn accessing_number_of_leafs_and_height_never_panics(
         #[strategy(arb())] merkle_tree: MerkleTree,
@@ -1113,6 +1126,7 @@ pub mod merkle_tree_test {
         let _ = merkle_tree.height();
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 50)]
     fn trivial_proof_can_be_verified(#[strategy(arb())] merkle_tree: MerkleTree) {
         let proof = merkle_tree.inclusion_proof_for_leaf_indices(&[]).unwrap();
@@ -1121,6 +1135,7 @@ pub mod merkle_tree_test {
         prop_assert!(verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 40)]
     fn honestly_generated_authentication_structure_can_be_verified(test_tree: MerkleTreeToTest) {
         let proof = test_tree.proof();
@@ -1128,6 +1143,7 @@ pub mod merkle_tree_test {
         prop_assert!(verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 30)]
     fn corrupt_root_leads_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
@@ -1139,6 +1155,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 20)]
     fn corrupt_authentication_structure_leads_to_verification_failure(
         #[filter(!#test_tree.proof().authentication_structure.is_empty())]
@@ -1164,6 +1181,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 30)]
     fn corrupt_leaf_digests_lead_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
@@ -1188,6 +1206,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 30)]
     fn removing_leafs_from_proof_leads_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
@@ -1211,6 +1230,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 30)]
     fn checking_set_inclusion_of_items_not_in_set_leads_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
@@ -1229,6 +1249,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 30)]
     fn honestly_generated_proof_with_duplicate_leafs_can_be_verified(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
@@ -1245,6 +1266,7 @@ pub mod merkle_tree_test {
         prop_assert!(verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 40)]
     fn incorrect_tree_height_leads_to_verification_failure(
         #[filter(#test_tree.has_non_trivial_proof())] test_tree: MerkleTreeToTest,
@@ -1258,6 +1280,7 @@ pub mod merkle_tree_test {
         prop_assert!(!verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 20)]
     fn honestly_generated_proof_with_all_leafs_revealed_can_be_verified(
         #[strategy(arb())] tree: MerkleTree,
@@ -1270,6 +1293,7 @@ pub mod merkle_tree_test {
         prop_assert!(verdict);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 30)]
     fn requesting_inclusion_proof_for_nonexistent_leaf_fails_with_expected_error(
         #[strategy(arb())] tree: MerkleTree,
@@ -1283,6 +1307,7 @@ pub mod merkle_tree_test {
         assert_eq!(MerkleTreeError::LeafIndexInvalid, err);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn authentication_paths_of_extremely_small_tree_use_expected_digests() {
         //     _ 1_
@@ -1303,6 +1328,7 @@ pub mod merkle_tree_test {
         assert_eq!(auth_path_with_nodes([6, 2]), auth_path_for_leaf(3));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn authentication_paths_of_very_small_tree_use_expected_digests() {
         //         ──── 1 ────
@@ -1330,6 +1356,7 @@ pub mod merkle_tree_test {
         assert_eq!(auth_path_with_nodes([14, 6, 2]), auth_path_for_leaf(7));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn authentication_paths_of_very_small_tree_are_identical_when_using_tree_or_only_leafs() {
         let tree = MerkleTree::test_tree_of_height(3);
@@ -1348,6 +1375,7 @@ pub mod merkle_tree_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 100)]
     fn auth_structure_is_independent_of_compute_method(test_tree: MerkleTreeToTest) {
         let tree = test_tree.tree;
@@ -1364,6 +1392,7 @@ pub mod merkle_tree_test {
         prop_assert_eq!(&cached_auth_structure, &par_auth_structure);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn subtree_leafs_are_actually_sub_tree_leafs() {
         let tree = MerkleTree::test_tree_of_height(5);
@@ -1383,6 +1412,7 @@ pub mod merkle_tree_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 10)]
     fn each_leaf_can_be_verified_individually(test_tree: MerkleTreeToTest) {
         let tree = test_tree.tree;
@@ -1398,6 +1428,7 @@ pub mod merkle_tree_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn partial_merkle_tree_built_from_authentication_structure_contains_expected_nodes() {
         let merkle_tree = MerkleTree::test_tree_of_height(3);
@@ -1422,6 +1453,7 @@ pub mod merkle_tree_test {
         assert_eq!(expected_node_indices, node_indices);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn manually_constructed_partial_tree_can_be_filled() {
         //         ──── _ ───
@@ -1444,6 +1476,7 @@ pub mod merkle_tree_test {
         partial_tree.fill().unwrap();
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn trying_to_compute_root_of_partial_tree_with_necessary_node_missing_gives_expected_error() {
         //         ──── _ ────
@@ -1468,6 +1501,7 @@ pub mod merkle_tree_test {
         assert_eq!(MerkleTreeError::MissingNodeIndex(3), err);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn trying_to_compute_root_of_partial_tree_with_redundant_node_gives_expected_error() {
         //         ──── _ ────
@@ -1492,6 +1526,7 @@ pub mod merkle_tree_test {
         assert_eq!(MerkleTreeError::SpuriousNodeIndex(2), err);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn converting_authentication_structure_to_authentication_paths_results_in_expected_paths() {
         const TREE_HEIGHT: MerkleTreeHeight = 3;
@@ -1511,6 +1546,7 @@ pub mod merkle_tree_test {
         assert_eq!(expected_paths, auth_paths);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn merkle_subtrees_are_sliced_correctly() {
         const TREE_HEIGHT: usize = 5;
@@ -1569,6 +1605,7 @@ pub mod merkle_tree_test {
         assert_eq!((56..64).collect_vec().as_slice(), right_right_tree[3]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn auth_structure_node_indices_can_be_computed_with_different_types() -> Result<()> {
         let u32_indices: Vec<u32> =

--- a/twenty-first/src/util_types/mmr/archival_mmr.rs
+++ b/twenty-first/src/util_types/mmr/archival_mmr.rs
@@ -312,11 +312,14 @@ impl ArchivalMmr {
 }
 
 mod tests {
+    use std::collections::HashSet;
+
     use itertools::Itertools;
     use itertools::izip;
     use rand::Rng;
     use rand::random;
-    use std::collections::HashSet;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::math::b_field_element::BFieldElement;
@@ -324,6 +327,7 @@ mod tests {
     use crate::util_types::mmr::mmr_accumulator::util::mmra_with_mps;
     use crate::util_types::mmr::shared_advanced::get_peak_heights_and_peak_node_indices;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn empty_mmr_behavior_test() {
         let mut archival_mmr = ArchivalMmr::default();
@@ -393,6 +397,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn verify_against_correct_peak_test() {
         // This test addresses a bug that was discovered late in the development
@@ -430,6 +435,7 @@ mod tests {
         ));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mutate_leaf_archival_test() {
         let leaf_count: u64 = 3;
@@ -498,6 +504,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn bagging_peaks_is_equivalent_for_archival_and_accumulator_mmrs() {
         let leaf_digests: Vec<Digest> = random_elements(3);
@@ -518,6 +525,7 @@ mod tests {
         assert!(no_peak_is_bag);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn accumulator_mmr_mutate_leaf_test() {
         // Verify that updating leafs in archival and in accumulator MMR results
@@ -545,6 +553,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mmr_prove_verify_leaf_mutation_test() {
         for size in 1..150 {
@@ -582,6 +591,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mmr_append_test() {
         // Verify that building an MMR iteratively or in *one* function call
@@ -639,6 +649,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn one_input_mmr_test() {
         let input_hash = Tip5::hash(&BFieldElement::new(14));
@@ -705,6 +716,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn two_input_mmr_test() {
         let num_leafs: u64 = 3;
@@ -751,6 +763,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn variable_size_tip5_mmr_test() {
         let leaf_counts = (1..34).collect_vec();
@@ -816,6 +829,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn variable_size_mmr_test() {
         let node_counts = [
@@ -895,12 +909,14 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic]
     fn disallow_repeated_leaf_indices_in_construction() {
         mmra_with_mps(14, vec![(0, random()), (0, random())]);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mmra_and_mps_construct_test_cornercases() {
         let mut rng = rand::rng();
@@ -940,6 +956,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mmra_and_mps_construct_test_small() {
         let mut rng = rand::rng();
@@ -951,6 +968,7 @@ mod tests {
         assert!(mps[1].verify(14, digest_leaf_idx14, &mmra.peaks(), mmra.num_leafs()));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mmra_and_mps_construct_test_pbt() {
         let mut rng = rand::rng();
@@ -976,6 +994,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mmra_and_mps_construct_test_big() {
         let mut rng = rand::rng();

--- a/twenty-first/src/util_types/mmr/mmr_accumulator.rs
+++ b/twenty-first/src/util_types/mmr/mmr_accumulator.rs
@@ -560,6 +560,8 @@ mod accumulator_mmr_tests {
     use rand::prelude::*;
     use rand::random;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::math::other::random_elements;
@@ -580,6 +582,7 @@ mod accumulator_mmr_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn conversion_test() {
         let leaf_hashes = random_elements(3);
@@ -594,6 +597,7 @@ mod accumulator_mmr_tests {
         assert_eq!(3, mmra.num_leafs());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn verify_batch_update_single_append_test() {
         let leaf_hashes_start: Vec<Digest> = random_elements(3);
@@ -614,6 +618,7 @@ mod accumulator_mmr_tests {
         assert!(leafs_were_appended);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn verify_batch_update_single_mutate_test() {
         let leaf0: Digest = random();
@@ -659,6 +664,7 @@ mod accumulator_mmr_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn verify_batch_update_two_append_test() {
         let leaf_hashes_start: Vec<Digest> = random_elements(3);
@@ -677,6 +683,7 @@ mod accumulator_mmr_tests {
         assert!(leafs_were_appended);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn verify_batch_update_two_mutate_test() {
         let leaf14: Digest = random();
@@ -708,6 +715,7 @@ mod accumulator_mmr_tests {
         ));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn batch_mutate_leaf_and_update_mps_test() {
         let mut rng = rand::rng();
@@ -818,6 +826,7 @@ mod accumulator_mmr_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn verify_batch_update_pbt() {
         for start_size in 1..18 {
@@ -930,6 +939,7 @@ mod accumulator_mmr_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mmra_serialization_test() {
         // You could argue that this test doesn't belong here, as it tests the behavior of
@@ -945,6 +955,7 @@ mod accumulator_mmr_tests {
         assert_eq!(1, mmra.num_leafs());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn get_size_test() {
         // 10 digests produces an MMRA with two peaks
@@ -963,6 +974,7 @@ mod accumulator_mmr_tests {
         assert!(mmra.get_size() < 100 * std::mem::size_of::<Digest>());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_mmr_accumulator_decode() {
         for _ in 0..100 {
@@ -975,6 +987,7 @@ mod accumulator_mmr_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "Lists must have same length. Got: 0 and 3")]
     fn test_diff_len_lists_batch_mutate_leaf_and_update_mps() {
@@ -996,6 +1009,7 @@ mod accumulator_mmr_tests {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn arbitrary_mmra_has_consistent_num_leafs_and_peaks(
         #[strategy(arb::<MmrAccumulator>())] mmra: MmrAccumulator,
@@ -1003,6 +1017,7 @@ mod accumulator_mmr_tests {
         prop_assert_eq!(mmra.peaks().len(), mmra.num_leafs().count_ones() as usize);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 20)]
     fn mmra_with_mps_produces_valid_output(
         #[strategy(0..u64::MAX / 2)] mmr_leaf_count: u64,
@@ -1022,11 +1037,13 @@ mod accumulator_mmr_tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn computing_mmr_root_for_no_leafs_produces_some_digest() {
         MmrAccumulator::new_from_leafs(vec![]).bag_peaks();
     }
 
+    // note: snapshot not supported for wasm32 target.
     #[test]
     fn bag_peaks_snapshot() {
         let mut rng = StdRng::seed_from_u64(0x92ca758afeec6d29);

--- a/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_membership_proof.rs
@@ -636,6 +636,8 @@ mod mmr_membership_proof_test {
     use rand::Rng;
     use rand::random;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::math::b_field_element::BFieldElement;
@@ -647,6 +649,7 @@ mod mmr_membership_proof_test {
     use crate::util_types::mmr::mmr_accumulator::util::mmra_with_mps;
     use crate::util_types::mmr::mmr_trait::Mmr;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn equality_and_hash_test() {
         let mut rng = rand::rng();
@@ -685,6 +688,7 @@ mod mmr_membership_proof_test {
         assert_ne!(Tip5::hash(&mp4), Tip5::hash(&mp5));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn get_node_indices_simple_test() {
         const LEAF_INDEX: u64 = 4;
@@ -701,6 +705,7 @@ mod mmr_membership_proof_test {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn get_peak_index_simple_test() {
         let mut mmr_size = 7;
@@ -759,6 +764,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 10)]
     fn mmr_verification_if_leaf_index_is_out_of_bounds(
         #[strategy(0..=121usize)] leaf_count: usize,
@@ -776,12 +782,14 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn mmr_verify_does_not_crash_on_too_short_peaks_list_unit() {
         let mmr_mp = MmrMembershipProof::new(vec![Default::default()]);
         assert!(!mmr_mp.verify(0, Default::default(), &[], 2));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 10)]
     fn mmr_verification_with_wrong_length_of_peak_list(
         #[strategy(0..=1_000_000u64)] leaf_count: u64,
@@ -805,6 +813,7 @@ mod mmr_membership_proof_test {
         assert!(!mp.verify(leaf_index, leaf, &one_too_many, leaf_count));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn update_batch_membership_proofs_from_leaf_mutations_new_test() {
         let total_leaf_count = 8;
@@ -850,6 +859,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn batch_update_from_batch_leaf_mutation_total_replacement_test() {
         let total_leaf_count = 268;
@@ -899,6 +909,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn batch_update_from_batch_leaf_mutation_test() {
         let total_leaf_count = 34;
@@ -979,6 +990,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn batch_update_from_leaf_mutation_no_change_return_value_test() {
         // This test verifies that the return value indicating changed membership proofs is empty
@@ -1045,6 +1057,7 @@ mod mmr_membership_proof_test {
         (leaf_hashes, membership_proofs)
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn update_batch_membership_proofs_from_batch_leaf_mutations_test() {
         let total_leaf_count = 8;
@@ -1091,6 +1104,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn update_membership_proof_from_leaf_mutation_test() {
         let leaf_hashes: Vec<Digest> = random_elements(8);
@@ -1223,6 +1237,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn update_membership_proof_from_leaf_mutation_big_test() {
         // Build MMR from leaf count 0 to 22, and loop through *each*
@@ -1287,6 +1302,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn update_membership_proof_from_append_simple_with_bit_mmra() {
         let original_leaf_count = (1 << 35) + (1 << 7) - 1;
@@ -1333,6 +1349,7 @@ mod mmr_membership_proof_test {
         assert!(all_proofs_are_valid);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn update_membership_proof_from_append_simple() {
         let leaf_count = 7;
@@ -1376,6 +1393,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn update_membership_proof_from_append_big_tests() {
         for leaf_count in 0..68u64 {
@@ -1509,6 +1527,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn update_membership_proof_from_append_big_tip5() {
         // Build MMR from leaf count 0 to 9, and loop through *each*
@@ -1561,6 +1580,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn serialization_test() {
         // You could argue that this test doesn't belong here, as it tests the behavior of
@@ -1582,6 +1602,7 @@ mod mmr_membership_proof_test {
         ));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn test_decode_mmr_membership_proof() {
         let mut rng = rand::rng();
@@ -1597,6 +1618,7 @@ mod mmr_membership_proof_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "Lists must have same length. Got: 0 and 3")]
     fn test_diff_len_lists_batch_update_from_append() {
@@ -1616,6 +1638,7 @@ mod mmr_membership_proof_test {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "Lists must have same length. Got: 0 and 3")]
     fn test_diff_len_lists_batch_update_from_leaf_mutation() {
@@ -1637,6 +1660,7 @@ mod mmr_membership_proof_test {
         );
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "Lists must have same length. Got: 0 and 3")]
     fn test_diff_len_lists_batch_update_from_batch_leaf_mutation() {

--- a/twenty-first/src/util_types/mmr/mmr_successor_proof.rs
+++ b/twenty-first/src/util_types/mmr/mmr_successor_proof.rs
@@ -261,6 +261,8 @@ mod test {
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::math::digest::digest_tests::DigestCorruptor;
@@ -318,6 +320,7 @@ mod test {
         type Strategy = BoxedStrategy<Self>;
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn append_nothing_to_empty_mmra() {
         let relation = MmrSuccessorRelation::new_with_numbered_leafs(0, 0);
@@ -325,6 +328,7 @@ mod test {
         relation.verify().unwrap();
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn append_one_thing_to_empty_mmra() {
         let relation = MmrSuccessorRelation::new_with_numbered_leafs(0, 1);
@@ -332,6 +336,7 @@ mod test {
         relation.verify().unwrap();
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn append_leafs_without_influence_on_existing_peaks() {
         let relation = MmrSuccessorRelation::new_with_numbered_leafs(1 << 3, 3);
@@ -355,6 +360,7 @@ mod test {
     ///         ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ╭─┴─╮   ·━┻━x   ┏━┻━┓
     ///        ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ╭┴╮ ┏┻┓ ┏┻┓ ┏┻┓ ┏┻┓
     /// ```
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn append_8_leafs_to_mmra_with_42_leafs() {
         let relation = MmrSuccessorRelation::new_with_numbered_leafs(42, 8);
@@ -371,6 +377,7 @@ mod test {
         relation.verify().unwrap();
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn unit_tests() {
         for (n, m) in (0..18).cartesian_product(0..18) {
@@ -380,11 +387,13 @@ mod test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn arbitrary_mmr_successor_relation_holds(relation: MmrSuccessorRelation) {
         relation.verify()?;
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn verification_fails_if_old_mmr_is_inconsistent(
         mut relation: MmrSuccessorRelation,
@@ -395,6 +404,7 @@ mod test {
         prop_assert_eq!(Err(Error::InconsistentOldMmr), relation.verify());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn verification_fails_if_new_mmr_is_inconsistent(
         mut relation: MmrSuccessorRelation,
@@ -405,6 +415,7 @@ mod test {
         prop_assert_eq!(Err(Error::InconsistentNewMmr), relation.verify());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn verification_fails_if_old_mmra_has_more_leafs_than_new_mmra(
         #[filter(#relation.old != #relation.new)] mut relation: MmrSuccessorRelation,
@@ -413,6 +424,7 @@ mod test {
         prop_assert_eq!(Err(Error::OldHasMoreLeafsThanNew), relation.verify());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn verification_fails_if_old_mmra_has_swapped_peaks(
         #[filter(#relation.old.peaks().len() >= 2)] mut relation: MmrSuccessorRelation,
@@ -434,6 +446,7 @@ mod test {
     /// relation, it is impossible to swap arbitrary peaks and guarantee a
     /// verification failure. However, if the old MMRA is non-empty, the first
     /// peak of the new MMRA is always relevant.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn verification_fails_if_new_mmra_has_first_peak_swapped_out(
         #[filter(#relation.old.num_leafs() > 0)]
@@ -451,6 +464,7 @@ mod test {
         ));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest(cases = 50)]
     fn verification_fails_if_authentication_path_is_corrupt(
         #[filter(!#relation.proof.paths.is_empty())] mut relation: MmrSuccessorRelation,
@@ -466,6 +480,7 @@ mod test {
         ));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn verification_fails_if_authentication_path_has_too_few_elements(
         #[filter(!#relation.proof.paths.is_empty())] mut relation: MmrSuccessorRelation,
@@ -475,6 +490,7 @@ mod test {
         prop_assert_eq!(Err(Error::AuthenticationPathTooShort), relation.verify());
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn verification_fails_if_authentication_path_has_too_many_elements(
         mut relation: MmrSuccessorRelation,

--- a/twenty-first/src/util_types/mmr/shared_advanced.rs
+++ b/twenty-first/src/util_types/mmr/shared_advanced.rs
@@ -282,11 +282,14 @@ mod mmr_test {
     use proptest::prop_assert_eq;
     use rand::RngCore;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::prelude::Digest;
     use crate::prelude::MmrMembershipProof;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn leaf_index_to_node_index_test() {
         assert_eq!(1, leaf_index_to_node_index(0));
@@ -313,6 +316,7 @@ mod mmr_test {
         assert_eq!(40, leaf_index_to_node_index(21));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn node_indices_added_by_append_test() {
         assert_eq!(vec![1], node_indices_added_by_append(0));
@@ -342,6 +346,7 @@ mod mmr_test {
         assert_eq!(vec![64], node_indices_added_by_append(32));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn leaf_index_node_index_pbt() {
         let mut rng = rand::rng();
@@ -353,6 +358,7 @@ mod mmr_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn right_ancestor_count_test() {
         assert_eq!((0, 0), right_lineage_length_and_own_height(1)); // 0b1 => 0
@@ -416,6 +422,7 @@ mod mmr_test {
         assert_eq!((0, 62), right_lineage_length_and_own_height(u64::MAX / 2)); // 0b111...11 => 0
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn right_lineage_length_property(#[strategy(0u64..(1<<63))] leaf_index: u64) {
         let rll = right_lineage_length_from_leaf_index(leaf_index);
@@ -423,6 +430,7 @@ mod mmr_test {
         prop_assert_eq!(rac, rll);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn leftmost_ancestor_test() {
         assert_eq!((1, 0), leftmost_ancestor(1));
@@ -443,6 +451,7 @@ mod mmr_test {
         assert_eq!((31, 4), leftmost_ancestor(16));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn left_sibling_test() {
         assert_eq!(3, left_sibling(6, 1));
@@ -453,6 +462,7 @@ mod mmr_test {
         assert_eq!(7, left_sibling(14, 2));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn node_index_to_leaf_index_test() {
         assert_eq!(Some(0), node_index_to_leaf_index(1));
@@ -479,6 +489,7 @@ mod mmr_test {
         assert_eq!(None, node_index_to_leaf_index(22));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn leaf_count_to_node_count_test() {
         let node_counts: Vec<u64> = vec![
@@ -490,6 +501,7 @@ mod mmr_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn get_peak_heights_and_peak_node_indices_test() {
         type TestCase = (u64, (Vec<u32>, Vec<u64>));
@@ -525,6 +537,7 @@ mod mmr_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn get_authentication_path_node_indices_test() {
         type Interval = (u64, u64, u64);
@@ -547,12 +560,14 @@ mod mmr_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     #[should_panic(expected = "Leaf index out-of-bounds: 5/5")]
     fn auth_path_indices_out_of_bounds_unit_test() {
         auth_path_node_indices(5, 5);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn auth_path_indices_prop(
         #[strategy(0u64..(u64::MAX>>1))] _num_leafs: u64,
@@ -565,6 +580,7 @@ mod mmr_test {
         prop_assert_eq!(mp.get_node_indices(leaf_index), node_indices);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn auth_path_indices_unit_test() {
         assert_eq!(vec![2, 6, 14, 30], auth_path_node_indices(16, 0));
@@ -599,16 +615,19 @@ mod mmr_test {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn right_lineage_length_from_node_index_does_not_crash(node_index: u64) {
         right_lineage_length_from_node_index(node_index);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn leftmost_ancestor_does_not_crash(node_index: u64) {
         leftmost_ancestor(node_index);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn right_lineage_length_and_own_height_does_not_crash(node_index: u64) {
         right_lineage_length_and_own_height(node_index);

--- a/twenty-first/src/util_types/mmr/shared_basic.rs
+++ b/twenty-first/src/util_types/mmr/shared_basic.rs
@@ -142,9 +142,12 @@ mod tests {
     use proptest::collection::vec;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn right_lineage_length_from_leaf_index_test() {
         assert_eq!(0, right_lineage_length_from_leaf_index(0));
@@ -162,6 +165,7 @@ mod tests {
         assert_eq!(63, right_lineage_length_from_leaf_index((1 << 63) - 1));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn leaf_index_to_mt_index_test() {
         // 1 leaf
@@ -267,6 +271,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn peak_index_test() {
         let peak_index = |leaf_index, num_leafs| {
@@ -315,12 +320,14 @@ mod tests {
         assert_eq!(2, peak_index((0b0111 << 29) - 1, (0b1000 << 29) - 1));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn merkle_tree_and_peak_indices_can_be_computed_for_large_mmrs() {
         leaf_index_to_mt_index_and_peak_index(0, u64::MAX);
         leaf_index_to_mt_index_and_peak_index(u64::MAX - 1, u64::MAX);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn right_lineage_length_from_leaf_index_does_not_crash(
         #[strategy(0..=u64::MAX >> 1)] leaf_index: u64,
@@ -328,6 +335,7 @@ mod tests {
         right_lineage_length_from_leaf_index(leaf_index);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[proptest]
     fn calculate_new_peaks_from_append_does_not_crash(
         #[strategy(0..u64::MAX >> 1)] old_num_leafs: u64,
@@ -337,6 +345,7 @@ mod tests {
         calculate_new_peaks_from_append(old_num_leafs, old_peaks, new_leaf);
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn calculate_new_peaks_from_append_to_empty_mmra_does_not_crash() {
         calculate_new_peaks_from_append(0, vec![], rand::random());

--- a/twenty-first/src/util_types/sponge.rs
+++ b/twenty-first/src/util_types/sponge.rs
@@ -61,6 +61,8 @@ mod tests {
     use rand::Rng;
     use rand::distr::Distribution;
     use rand::distr::StandardUniform;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
 
     use super::*;
     use crate::math::digest::Digest;
@@ -90,6 +92,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn to_sequence_test() {
         // bool
@@ -124,6 +127,7 @@ mod tests {
         assert!(indices.into_iter().all(|index| index < max));
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn sample_indices_test() {
         let cases = [
@@ -143,6 +147,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     #[test]
     fn sample_scalars_test() {
         let amounts = [0, 1, 2, 3, 4];

--- a/twenty-first/tests/bfield_codec_derive.rs
+++ b/twenty-first/tests/bfield_codec_derive.rs
@@ -10,6 +10,8 @@ use twenty_first::math::b_field_element::BFieldElement;
 use twenty_first::math::bfield_codec::BFieldCodec;
 use twenty_first::math::digest::Digest;
 use twenty_first::math::x_field_element::XFieldElement;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec, Arbitrary)]
 struct BFieldCodecTestStructA {
@@ -17,6 +19,7 @@ struct BFieldCodecTestStructA {
     b: BFieldElement,
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[proptest]
 fn integration_test_struct_a(#[strategy(arb())] test_struct: BFieldCodecTestStructA) {
     let encoding = test_struct.encode();
@@ -30,6 +33,7 @@ struct BFieldCodecTestStructB {
     b: Vec<(u64, Digest)>,
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[proptest]
 fn integration_test_struct_b(#[strategy(arb())] test_struct: BFieldCodecTestStructB) {
     let encoding = test_struct.encode();
@@ -44,6 +48,7 @@ enum BFieldCodecTestEnumA {
     C,
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[proptest]
 fn integration_test_enum_a(#[strategy(arb())] test_enum: BFieldCodecTestEnumA) {
     let encoding = test_enum.encode();
@@ -58,6 +63,7 @@ enum BFieldCodecTestEnumB {
     C(Vec<(u64, Digest)>),
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[proptest]
 fn integration_test_enum_b(#[strategy(arb())] test_enum: BFieldCodecTestEnumB) {
     let encoding = test_enum.encode();
@@ -65,6 +71,7 @@ fn integration_test_enum_b(#[strategy(arb())] test_enum: BFieldCodecTestEnumB) {
     prop_assert_eq!(test_enum, decoding);
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[test]
 fn try_build_various_failure_cases() {
     let trybuild = trybuild::TestCases::new();


### PR DESCRIPTION
Adds wasm32 support.   See included README files:
* README-wasm32.md --> usage instructions, aimed at users of twenty-first.
* README-wasm32-dev.md --> details of the changes to enable wasm32 support, aimed at twenty-first devs/contributors.

This PR is a series of commits.   The very first commit only changes Cargo.toml and is sufficient to enable wasm32 support for `cargo build` meaning that crates that depend on twenty-first can use it in their wasm32 builds.  So it can be considered the "bare minimum" for wasm32 support.

The remainder of the commits mainly tackle the challenge of getting our unit tests and especially proptests working in the wasm32 environment, which is substantially more complicated. 

There are also a couple of commits that address failing test cases.  One of these failing tests found a problem with twenty-first when executing in a 32-bit environment.  This is addressed in 19a11a41a63478584393cd2b62ee07ad1637fc46, and should be carefully reviewed for correctness.  This is the only change that was made to non-test library code in any of the commits, afaik.

This PR may be easiest to grok by:
1. reading the two README files.
2. reviewing each commit, in sequence from oldest to newest.

note: the README files were generated by Gemini LLM, with coaching and minor edits.  Also the LLM was very helpful for navigating through the complex issues getting the tests to build and execute.