### PR TITLE
Deprecate `XFieldElement::{in, de}crement`

### DIFF
--- a/twenty-first/src/math/b_field_element.rs
+++ b/twenty-first/src/math/b_field_element.rs
@@ -315,14 +315,14 @@ impl BFieldElement {
         XFieldElement::new_const(*self)
     }
 
-    // You should probably only use `increment` and `decrement` for testing purposes
+    /// Add [`BFieldElement::ONE`] to `self`.
     pub fn increment(&mut self) {
-        *self += Self::one();
+        *self += Self::ONE;
     }
 
-    // You should probably only use `increment` and `decrement` for testing purposes
+    /// Subtract [`BFieldElement::ONE`] from `self`.
     pub fn decrement(&mut self) {
-        *self -= Self::one();
+        *self -= Self::ONE;
     }
 
     #[inline]

--- a/twenty-first/src/math/x_field_element.rs
+++ b/twenty-first/src/math/x_field_element.rs
@@ -372,11 +372,14 @@ impl XFieldElement {
         Some(*bfe)
     }
 
-    // `increment` and `decrement` are mainly used for testing purposes
+    #[deprecated(since = "2.0.0")]
+    #[doc(hidden)]
     pub fn increment(&mut self, index: usize) {
         self.coefficients[index].increment();
     }
 
+    #[deprecated(since = "2.0.0")]
+    #[doc(hidden)]
     pub fn decrement(&mut self, index: usize) {
         self.coefficients[index].decrement();
     }
@@ -771,7 +774,10 @@ mod tests {
         prop_assert!(XFieldElement::try_from(bfes).is_err());
     }
 
+    /// To be removed once [XFieldElement::increment] and
+    /// [XFieldElement::decrement] are gone.
     #[test]
+    #[expect(deprecated)]
     fn incr_decr_test() {
         let one_const = XFieldElement::new([1, 0, 0].map(BFieldElement::new));
         let two_const = XFieldElement::new([2, 0, 0].map(BFieldElement::new));


### PR DESCRIPTION
While `BFieldElement::{in, de}crement` are used in downstream crates, the corresponding `XFieldElement` methods are not. With the additional argument, they are even prone to panics.